### PR TITLE
Scrum 1462 - Added more facets

### DIFF
--- a/src/actions/queryActions.js
+++ b/src/actions/queryActions.js
@@ -34,6 +34,7 @@ export const resetQueryRedirect = () => {
 
 export const fetchInitialFacets = (facetsLimits) => {
   return dispatch => {
+    dispatch(setSearchFacetsLimits(facetsLimits));
     axios.post(restUrl + '/search/references', {
       query: null,
       facets_values: null,

--- a/src/components/query/BreadCrumbs.js
+++ b/src/components/query/BreadCrumbs.js
@@ -18,14 +18,14 @@ const BreadCrumbs = () => {
             <Row>
                 <Col style={{textAlign: "left"}}>
                     {Object.entries(searchFacetsValues).map(([facet, values]) =>
-                        <div key={facet + "_group"}>
+                        <span key={facet + "_group"}>
                             {values.map(value =>
                                 <span key={value + "_breadcrumb"}>
                                     <Button variant="outline-secondary">{value} &nbsp;
                                         <RiCloseFill onClick={() => dispatch(removeFacetValue(facet, value))}/>
                                     </Button>&nbsp;&nbsp;
                                 </span>)}
-                        </div>
+                        </span>
                     )}
                 </Col>
             </Row>

--- a/src/components/query/Facets.js
+++ b/src/components/query/Facets.js
@@ -13,19 +13,8 @@ import _ from "lodash";
 const Facet = ({facetsToInclude}) => {
 
     const searchFacets = useSelector(state => state.query.searchFacets);
-    const searchQuery = useSelector(state => state.query.searchQuery);
     const searchFacetsValues = useSelector(state => state.query.searchFacetsValues);
-    const searchFacetsLimits = useSelector(state => state.query.searchFacetsLimits);
-    const searchSizeResultsCount = useSelector(state => state.query.searchSizeResultsCount);
     const dispatch = useDispatch();
-
-    const searchWithUpdatedFacetsLimits = (newSearchFacetsLimits) => {
-        if (searchQuery !== null || Object.keys(searchFacetsValues).length !== 0) {
-            dispatch(searchReferences(searchQuery, searchFacetsValues, newSearchFacetsLimits, searchSizeResultsCount))
-        } else {
-            dispatch(fetchInitialFacets(newSearchFacetsLimits));
-        }
-    }
 
     return (
         <div>
@@ -57,31 +46,53 @@ const Facet = ({facetsToInclude}) => {
                                         </Col>
                                     </Row>
                                 </Container>)}
-                            <div style={{paddingLeft: "1em"}}>
-                                {value.buckets.length >= searchFacetsLimits[key] ?
-                                    <button className="button-to-link" onClick={()=> {
-                                        let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
-                                        newSearchFacetsLimits[key] = searchFacetsLimits[key] * 2;
-                                        searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
-                                    }}>+Show More</button> : null
-                                }
-                                {searchFacetsLimits[key] > INITIAL_FACETS_LIMIT ?
-                                    <span>&nbsp;&nbsp;&nbsp;&nbsp;<button className="button-to-link" onClick={() => {
-                                        let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
-                                        newSearchFacetsLimits[key] = searchFacetsLimits[key] = INITIAL_FACETS_LIMIT;
-                                        searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
-                                    }}>-Show Less</button></span> : null
-                                }
-                                {value.buckets.length >= searchFacetsLimits[key] ? <span>&nbsp;&nbsp;&nbsp;&nbsp;
-                                <button className="button-to-link" onClick={() =>{
-                                    let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
-                                        newSearchFacetsLimits[key] = searchFacetsLimits[key] = 1000;
-                                        searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
-                                }}>+Show All</button></span> : null } </div>
+                            <ShowMoreLessAllButtons facetLabel={key} facetValue={value} />
+                            <br/>
                         </div>
                     </div>
                 )}
         </div>
+    )
+}
+
+const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
+
+    const searchQuery = useSelector(state => state.query.searchQuery);
+    const searchFacetsLimits = useSelector(state => state.query.searchFacetsLimits);
+    const searchSizeResultsCount = useSelector(state => state.query.searchSizeResultsCount);
+    const searchFacetsValues = useSelector(state => state.query.searchFacetsValues);
+    const dispatch = useDispatch();
+
+    const searchWithUpdatedFacetsLimits = (newSearchFacetsLimits) => {
+        if (searchQuery !== null || Object.keys(searchFacetsValues).length !== 0) {
+            dispatch(searchReferences(searchQuery, searchFacetsValues, newSearchFacetsLimits, searchSizeResultsCount))
+        } else {
+            dispatch(fetchInitialFacets(newSearchFacetsLimits));
+        }
+    }
+
+    return (
+        <div style={{paddingLeft: "1em"}}>
+            {facetValue.buckets.length >= searchFacetsLimits[facetLabel] ?
+                <button className="button-to-link" onClick={()=> {
+                    let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
+                    newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] * 2;
+                    searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
+                }}>+Show More</button> : null
+            }
+            {searchFacetsLimits[facetLabel] > INITIAL_FACETS_LIMIT ?
+                <span>&nbsp;&nbsp;&nbsp;&nbsp;<button className="button-to-link" onClick={() => {
+                    let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
+                    newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] = INITIAL_FACETS_LIMIT;
+                    searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
+                }}>-Show Less</button></span> : null
+            }
+            {facetValue.buckets.length >= searchFacetsLimits[facetLabel] ? <span>&nbsp;&nbsp;&nbsp;&nbsp;
+                <button className="button-to-link" onClick={() =>{
+                    let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
+                    newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] = 1000;
+                    searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
+                }}>+Show All</button></span> : null } </div>
     )
 }
 

--- a/src/components/query/Facets.js
+++ b/src/components/query/Facets.js
@@ -1,6 +1,12 @@
 import React, {useEffect, useState} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
-import {addFacetValue, fetchInitialFacets, removeFacetValue, searchReferences} from '../../actions/queryActions';
+import {
+    addFacetValue,
+    fetchInitialFacets,
+    removeFacetValue,
+    searchReferences,
+    setSearchFacetsLimits
+} from '../../actions/queryActions';
 import Form from 'react-bootstrap/Form';
 import {Accordion, Badge, Button} from 'react-bootstrap';
 import {IoIosArrowDroprightCircle, IoIosArrowDropdownCircle} from 'react-icons/io';
@@ -63,7 +69,7 @@ const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
     const searchFacetsValues = useSelector(state => state.query.searchFacetsValues);
     const dispatch = useDispatch();
 
-    const searchWithUpdatedFacetsLimits = (newSearchFacetsLimits) => {
+    const searchOrSetInitialFacets = (newSearchFacetsLimits) => {
         if (searchQuery !== null || Object.keys(searchFacetsValues).length !== 0) {
             dispatch(searchReferences(searchQuery, searchFacetsValues, newSearchFacetsLimits, searchSizeResultsCount))
         } else {
@@ -77,21 +83,24 @@ const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
                 <button className="button-to-link" onClick={()=> {
                     let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
                     newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] * 2;
-                    searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
+                    dispatch(setSearchFacetsLimits(newSearchFacetsLimits));
+                    searchOrSetInitialFacets(newSearchFacetsLimits);
                 }}>+Show More</button> : null
             }
             {searchFacetsLimits[facetLabel] > INITIAL_FACETS_LIMIT ?
                 <span>&nbsp;&nbsp;&nbsp;&nbsp;<button className="button-to-link" onClick={() => {
                     let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
                     newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] = INITIAL_FACETS_LIMIT;
-                    searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
+                    dispatch(setSearchFacetsLimits(newSearchFacetsLimits));
+                    searchOrSetInitialFacets(newSearchFacetsLimits);
                 }}>-Show Less</button></span> : null
             }
             {facetValue.buckets.length >= searchFacetsLimits[facetLabel] ? <span>&nbsp;&nbsp;&nbsp;&nbsp;
                 <button className="button-to-link" onClick={() =>{
                     let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
                     newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] = 1000;
-                    searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
+                    dispatch(setSearchFacetsLimits(newSearchFacetsLimits));
+                    searchOrSetInitialFacets(newSearchFacetsLimits);
                 }}>+Show All</button></span> : null } </div>
     )
 }

--- a/src/components/query/Facets.js
+++ b/src/components/query/Facets.js
@@ -30,11 +30,11 @@ const Facet = ({facetsToInclude}) => {
     return (
         <div>
             {Object.entries(searchFacets).filter(([key, value]) =>
-                facetsToInclude.includes(key.replace('.keyword', '').replace('_', ' ')))
+                facetsToInclude.includes(key.replace('.keyword', '').replaceAll('_', ' ')))
                 .map(([key, value]) =>
                     <div key={key} style={{textAlign: "left", paddingLeft: "2em"}}>
                         <div>
-                            <h5>{key.replace('.keyword', '').replace('_', ' ')}</h5>
+                            <h5>{key.replace('.keyword', '').replaceAll('_', ' ')}</h5>
                             {value.buckets.map(bucket =>
                                 <Container key={bucket.key}>
                                     <Row>
@@ -58,11 +58,13 @@ const Facet = ({facetsToInclude}) => {
                                     </Row>
                                 </Container>)}
                             <div style={{paddingLeft: "1em"}}>
-                                <button className="button-to-link" onClick={()=> {
-                                    let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
-                                    newSearchFacetsLimits[key] = searchFacetsLimits[key] * 2;
-                                    searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
-                                }}>+Show More</button>
+                                {value.buckets.length >= searchFacetsLimits[key] ?
+                                    <button className="button-to-link" onClick={()=> {
+                                        let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
+                                        newSearchFacetsLimits[key] = searchFacetsLimits[key] * 2;
+                                        searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
+                                    }}>+Show More</button> : null
+                                }
                                 {searchFacetsLimits[key] > INITIAL_FACETS_LIMIT ?
                                     <span>&nbsp;&nbsp;&nbsp;&nbsp;<button className="button-to-link" onClick={() => {
                                         let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
@@ -70,11 +72,12 @@ const Facet = ({facetsToInclude}) => {
                                         searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
                                     }}>-Show Less</button></span> : null
                                 }
-                                &nbsp;&nbsp;&nbsp;&nbsp; <button className="button-to-link" onClick={() =>{
+                                {value.buckets.length >= searchFacetsLimits[key] ? <span>&nbsp;&nbsp;&nbsp;&nbsp;
+                                <button className="button-to-link" onClick={() =>{
                                     let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
                                         newSearchFacetsLimits[key] = searchFacetsLimits[key] = 1000;
                                         searchWithUpdatedFacetsLimits(newSearchFacetsLimits);
-                            }}>+Show All</button></div>
+                                }}>+Show All</button></span> : null } </div>
                         </div>
                     </div>
                 )}
@@ -120,7 +123,7 @@ const Facets = () => {
                 </Accordion.Toggle>
                 <Accordion.Collapse eventKey="0">
                     <div>
-                        <Facet facetsToInclude={["pubmed types"]}/>
+                        <Facet facetsToInclude={["pubmed types", "category", "pubmed publication status"]}/>
                     </div>
                 </Accordion.Collapse>
             </div>

--- a/src/reducers/queryReducer.js
+++ b/src/reducers/queryReducer.js
@@ -22,8 +22,11 @@ const initialState = {
   searchFacets: {},
   searchFacetsValues: {},
   searchFacetsLimits: {
-    'pubmed_types.keyword': INITIAL_FACETS_LIMIT
+    'pubmed_types.keyword': INITIAL_FACETS_LIMIT,
+    'category.keyword': INITIAL_FACETS_LIMIT,
+    'pubmed_publication_status.keyword': INITIAL_FACETS_LIMIT
   },
+  searchFacetsShowMore: {},
   searchQuery: null,
   xrefcurieField: '',
   querySuccess: false,
@@ -93,14 +96,9 @@ export default function(state = initialState, action) {
       }
 
     case QUERY_SET_SEARCH_FACETS:
-      let newSearchFacetsLimits = _.cloneDeep(state.searchFacetsLimits);
-      Object.entries(action.payload.facets).forEach(([key, values]) => {
-        newSearchFacetsLimits[key] = Math.max(values.buckets.length, INITIAL_FACETS_LIMIT);
-      });
       return {
         ...state,
-        searchFacets: action.payload.facets,
-        searchFacetsLimits: newSearchFacetsLimits
+        searchFacets: action.payload.facets
       }
 
     case QUERY_SET_SEARCH_FACETS_VALUES:


### PR DESCRIPTION
- Added two more facets to the "bibliographic data" category
- Created separate component for show more/less/all buttons
- Changed logic to manage show more/less/all buttons: hide them when no all entries already displayed
- Fixed breadcrumbs: they were displayed on separate lines for each facet, now on the same line