### PR TITLE
Search fixes

### DIFF
--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -129,7 +129,7 @@ const Facets = () => {
     useEffect(() => {
         if (Object.keys(searchFacets).length === 0) {
             dispatch(fetchInitialFacets(searchFacetsLimits));
-        } else {
+        } else if (searchQuery !== undefined || Object.keys(searchFacetsValues).length > 0) {
             dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
         }
     }, [searchFacetsValues]);

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -132,7 +132,7 @@ const Facets = () => {
         } else if (searchQuery !== undefined || Object.keys(searchFacetsValues).length > 0) {
             dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
         }
-    }, [searchFacetsValues]);
+    }, [searchFacetsValues]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <Accordion style={{textAlign: "left"}}>

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -27,7 +27,7 @@ const initialState = {
     'pubmed_publication_status.keyword': INITIAL_FACETS_LIMIT
   },
   searchFacetsShowMore: {},
-  searchQuery: null,
+  searchQuery: undefined,
   xrefcurieField: '',
   querySuccess: false,
   responseColor: 'black',


### PR DESCRIPTION
This PR fixes the following issues:

- warning about undefined value for searchQuery text
- if you go to the search page, query for a PMID and come back, the search results load as if someone had searched for an empy string
- excluded warnings on useEffect in Facets.js