### PR TITLE
Scrum 1357 added facets for "in corpus" and "needs review"

### DIFF
--- a/src/components/search/BreadCrumbs.js
+++ b/src/components/search/BreadCrumbs.js
@@ -6,6 +6,7 @@ import {useDispatch, useSelector} from "react-redux";
 import Button from "react-bootstrap/Button";
 import {RiCloseFill} from "react-icons/ri";
 import {removeFacetValue} from "../../actions/searchActions";
+import {RENAME_FACETS} from "./Facets";
 
 
 const BreadCrumbs = () => {
@@ -21,7 +22,7 @@ const BreadCrumbs = () => {
                         <span key={facet + "_group"}>
                             {values.map(value =>
                                 <span key={value + "_breadcrumb"}>
-                                    <Button variant="outline-secondary">{value} &nbsp;
+                                    <Button variant="outline-secondary">{(RENAME_FACETS.hasOwnProperty(facet) ? RENAME_FACETS[facet] : facet.replace('.keyword', '').replaceAll('_', ' ')) + ": " + value} &nbsp;
                                         <RiCloseFill onClick={() => dispatch(removeFacetValue(facet, value))}/>
                                     </Button>&nbsp;&nbsp;
                                 </span>)}

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -24,10 +24,12 @@ const Facet = ({facetsToInclude, renameFacets}) => {
 
     return (
         <div>
-            {Object.entries(searchFacets).filter(([key, value]) =>
-                facetsToInclude.includes(key.replace('.keyword', '').replaceAll('_', ' ')))
-                .map(([key, value]) =>
-                    <div key={key} style={{textAlign: "left", paddingLeft: "2em"}}>
+            {Object.entries(searchFacets).length > 0 && facetsToInclude.map(facetToInclude => {
+                let key = facetToInclude + '.keyword'
+                key = key.replaceAll(' ', '_');
+                let value = searchFacets[key];
+                return (
+                    <div key={facetToInclude} style={{textAlign: "left", paddingLeft: "2em"}}>
                         <div>
                             <h5>{renameFacets.hasOwnProperty(key) ? renameFacets[key] : key.replace('.keyword', '').replaceAll('_', ' ')}</h5>
                             {value.buckets.map(bucket =>
@@ -57,6 +59,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                         </div>
                     </div>
                 )}
+            )}
         </div>
     )
 }
@@ -135,6 +138,7 @@ const Facets = () => {
     }, [searchFacetsValues]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
+        <div>
         <Accordion style={{textAlign: "left"}}>
             <div>
                 <Accordion.Toggle as={Button} variant="light" size="lg" eventKey="0"
@@ -150,12 +154,14 @@ const Facets = () => {
                     </div>
                 </Accordion.Collapse>
             </div>
+        </Accordion>
+        <Accordion style={{textAlign: "left"}}>
             <div>
-                <Accordion.Toggle as={Button} variant="light" size="lg" eventKey="1"
+                <Accordion.Toggle as={Button} variant="light" size="lg" eventKey="0"
                                   onClick={() => toggleFacetGroup('Bibliographic Data')}>
                     {openFacets.has('Bibliographic Data') ? <IoIosArrowDropdownCircle/> : <IoIosArrowDroprightCircle/>} Bibliographic Data
                 </Accordion.Toggle>
-                <Accordion.Collapse eventKey="1">
+                <Accordion.Collapse eventKey="0">
                     <div>
                         <Facet facetsToInclude={["pubmed types", "category", "pubmed publication status"]}
                                renameFacets={{"category.keyword": "alliance category"}}/>
@@ -163,6 +169,7 @@ const Facets = () => {
                 </Accordion.Collapse>
             </div>
         </Accordion>
+        </div>
     )
 }
 

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -118,6 +118,7 @@ const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
 const Facets = () => {
 
     const [openFacets, setOpenFacets] = useState(new Set());
+    const searchResults = useSelector(state => state.search.searchResults);
     const searchFacets = useSelector(state => state.search.searchFacets);
     const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
     const searchFacetsLimits = useSelector(state => state.search.searchFacetsLimits);
@@ -136,9 +137,9 @@ const Facets = () => {
     }
 
     useEffect(() => {
-        if (Object.keys(searchFacets).length === 0) {
+        if (Object.keys(searchFacets).length === 0 && searchResults.length === 0) {
             dispatch(fetchInitialFacets(searchFacetsLimits));
-        } else if (searchQuery !== undefined || Object.keys(searchFacetsValues).length > 0) {
+        } else {
             dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
         }
     }, [searchFacetsValues]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -143,7 +143,7 @@ const Facets = () => {
                 </Accordion.Toggle>
                 <Accordion.Collapse eventKey="0">
                     <div>
-                        <Facet facetsToInclude={["pubmed types", "category", "pubmed publication status"]}
+                        <Facet facetsToInclude={["pubmed types", "category", "pubmed publication status", "mods in corpus"]}
                                renameFacets={{"category.keyword": "alliance category"}}/>
                     </div>
                 </Accordion.Collapse>

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -16,6 +16,12 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import _ from "lodash";
 
+export const RENAME_FACETS = {
+    "category.keyword": "alliance category",
+    "mods_in_corpus.keyword": "corpus - in corpus",
+    "mods_needs_review.keyword": "corpus - needs review"
+}
+
 const Facet = ({facetsToInclude, renameFacets}) => {
 
     const searchFacets = useSelector(state => state.search.searchFacets);
@@ -148,9 +154,7 @@ const Facets = () => {
                 <Accordion.Collapse eventKey="0">
                     <div>
                         <Facet facetsToInclude={["mods in corpus", "mods needs review"]}
-                               renameFacets={{
-                                   "mods_in_corpus.keyword": "corpus - in corpus",
-                                   "mods_needs_review.keyword": "corpus - needs review"}}/>
+                               renameFacets={RENAME_FACETS}/>
                     </div>
                 </Accordion.Collapse>
             </div>
@@ -164,7 +168,7 @@ const Facets = () => {
                 <Accordion.Collapse eventKey="0">
                     <div>
                         <Facet facetsToInclude={["pubmed types", "category", "pubmed publication status"]}
-                               renameFacets={{"category.keyword": "alliance category"}}/>
+                               renameFacets={RENAME_FACETS}/>
                     </div>
                 </Accordion.Collapse>
             </div>

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -138,12 +138,26 @@ const Facets = () => {
         <Accordion style={{textAlign: "left"}}>
             <div>
                 <Accordion.Toggle as={Button} variant="light" size="lg" eventKey="0"
-                                  onClick={() => toggleFacetGroup('Bibliographic Data')}>
-                    {openFacets.has('Bibliographic Data') ? <IoIosArrowDropdownCircle/> : <IoIosArrowDroprightCircle/>} Bibliographic Data
+                                  onClick={() => toggleFacetGroup('Alliance Metadata')}>
+                    {openFacets.has('Alliance Metadata') ? <IoIosArrowDropdownCircle/> : <IoIosArrowDroprightCircle/>} Alliance Metadata
                 </Accordion.Toggle>
                 <Accordion.Collapse eventKey="0">
                     <div>
-                        <Facet facetsToInclude={["pubmed types", "category", "pubmed publication status", "mods in corpus"]}
+                        <Facet facetsToInclude={["mods in corpus", "mods needs review"]}
+                               renameFacets={{
+                                   "mods_in_corpus.keyword": "corpus - in corpus",
+                                   "mods_needs_review.keyword": "corpus - needs review"}}/>
+                    </div>
+                </Accordion.Collapse>
+            </div>
+            <div>
+                <Accordion.Toggle as={Button} variant="light" size="lg" eventKey="1"
+                                  onClick={() => toggleFacetGroup('Bibliographic Data')}>
+                    {openFacets.has('Bibliographic Data') ? <IoIosArrowDropdownCircle/> : <IoIosArrowDroprightCircle/>} Bibliographic Data
+                </Accordion.Toggle>
+                <Accordion.Collapse eventKey="1">
+                    <div>
+                        <Facet facetsToInclude={["pubmed types", "category", "pubmed publication status"]}
                                renameFacets={{"category.keyword": "alliance category"}}/>
                     </div>
                 </Accordion.Collapse>


### PR DESCRIPTION
- Added facets to new facet group "Alliance Metadata"
- fixed several UI issues, including re-running search after all facets are removed from the search criteria, sorting facets to display by the array defined in the UI and not by the list returned by ES (which could be arbitrary), added facet types to breadcrumbs to differentiate between criteria when the facet value is the same (e.g., for mod in corpus and mod needs review), and using separate accordions to avoid closing one facet group when another one is opened