### PR TITLE
feat(search): added new 'ID' search field

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -48,23 +48,36 @@ export const fetchInitialFacets = (facetsLimits) => {
   }
 }
 
-export const searchReferences = (query, facetsValues, facetsLimits, sizeResultsCount) => {
+export const searchReferences = (query, fieldToSearch, facetsValues, facetsLimits, sizeResultsCount) => {
   return dispatch => {
-    dispatch(setSearchLoading());
-    dispatch(setSearchQuery(query));
-    dispatch(setSearchFacetsValues(facetsValues));
-    dispatch(setSearchFacetsLimits(facetsLimits));
-    axios.post(restUrl + '/search/references', {
-      query: query,
-      size_result_count: sizeResultsCount,
-      facets_values: facetsValues,
-      facets_limits: facetsLimits
-    })
-        .then(res => {
-          dispatch(setSearchResults(res.data.hits, res.data.return_count));
-          dispatch(setSearchFacets(res.data.aggregations));
+    if (fieldToSearch === 'ID') {
+      if (query.startsWith('AGR:') || query.startsWith('AGRKB:')) {
+        dispatch({
+          type: 'SEARCH_BUTTON_XREF_CURIE',
+          payload: query,
+          responseFound: 'found'
         })
-        .catch(err => dispatch(setSearchError(true)));
+      } else {
+        dispatch(searchButtonCrossRefCurie(query));
+      }
+      dispatch(setSearchQuery(""));
+    } else {
+      dispatch(setSearchLoading());
+      dispatch(setSearchQuery(query));
+      dispatch(setSearchFacetsValues(facetsValues));
+      dispatch(setSearchFacetsLimits(facetsLimits));
+      axios.post(restUrl + '/search/references', {
+        query: query,
+        size_result_count: sizeResultsCount,
+        facets_values: facetsValues,
+        facets_limits: facetsLimits
+      })
+          .then(res => {
+            dispatch(setSearchResults(res.data.hits, res.data.return_count));
+            dispatch(setSearchFacets(res.data.aggregations));
+          })
+          .catch(err => dispatch(setSearchError(true)));
+    }
   }
 }
 

--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -60,7 +60,6 @@ export const searchReferences = (query, fieldToSearch, facetsValues, facetsLimit
       } else {
         dispatch(searchButtonCrossRefCurie(query));
       }
-      dispatch(setSearchQuery(""));
     } else {
       dispatch(setSearchLoading());
       dispatch(setSearchQuery(query));

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -20,7 +20,6 @@ const Search = () => {
   const searchResponseField = useSelector(state => state.search.responseField);
   const searchResponseColor = useSelector(state => state.search.responseColor);
   const searchRedirectToBiblio = useSelector(state => state.search.redirectToBiblio);
-  const searchQuerySuccess = useSelector(state => state.search.querySuccess);
   const dispatch = useDispatch();
   const history = useHistory();
 
@@ -37,16 +36,7 @@ const Search = () => {
 
   return (
     <div>
-      <h4>Look up Reference by exact cross reference curie.<br/>e.g. PMID:24895670 or RGD:13542090 or WB:WBPaper00010006</h4>
-      <div style={{width: "28em", margin: "auto"}}>
-        <InputGroup className="mb-2">
-          <Form.Control type="text" id="xrefcurieField" name="xrefcurieField" value={xrefcurieField} onChange={(e) => dispatch(changeQueryField(e))} />
-          {searchRedirectToBiblio && pushHistory(searchResponseField)}
-          <Button type="submit" size="sm" onClick={() => dispatch(searchButtonCrossRefCurie(xrefcurieField))}>Query External Identifier Curie</Button>
-        </InputGroup>
-      </div>
-      <div>{searchQuerySuccess ? <Link to={{pathname: "/Biblio", search: "?action=display&referenceCurie=" + searchResponseField}}><span style={{color: searchResponseColor}}>{searchResponseField}</span></Link> : <span style={{color: searchResponseColor}}>{searchResponseField}</span>}</div>
-      <hr/>
+      {searchRedirectToBiblio && pushHistory(searchResponseField)}
       <h4>Search References<br/></h4>
         <SearchLayout/>
       <hr/>

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -91,7 +91,8 @@ const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
 
     const searchOrSetInitialFacets = (newSearchFacetsLimits) => {
         if (searchQuery !== null || Object.keys(searchFacetsValues).length !== 0) {
-            dispatch(searchReferences(searchQuery, searchFacetsValues, newSearchFacetsLimits, searchSizeResultsCount))
+            dispatch(searchReferences(searchQuery, '', searchFacetsValues, newSearchFacetsLimits,
+                searchSizeResultsCount))
         } else {
             dispatch(fetchInitialFacets(newSearchFacetsLimits));
         }
@@ -151,7 +152,9 @@ const Facets = () => {
         if (Object.keys(searchFacets).length === 0 && searchResults.length === 0) {
             dispatch(fetchInitialFacets(searchFacetsLimits));
         } else {
-            dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
+            if (searchQuery !== "" && Object.keys(searchFacetsValues).length > 0)
+            dispatch(searchReferences(searchQuery, '', searchFacetsValues, searchFacetsLimits,
+                searchSizeResultsCount));
         }
     }, [searchFacetsValues]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -152,7 +152,7 @@ const Facets = () => {
         if (Object.keys(searchFacets).length === 0 && searchResults.length === 0) {
             dispatch(fetchInitialFacets(searchFacetsLimits));
         } else {
-            if (searchQuery !== "" && Object.keys(searchFacetsValues).length > 0) {
+            if (searchQuery !== "" || searchResults.length > 0) {
                 dispatch(searchReferences(searchQuery, '', searchFacetsValues, searchFacetsLimits,
                     searchSizeResultsCount));
             }

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -152,9 +152,10 @@ const Facets = () => {
         if (Object.keys(searchFacets).length === 0 && searchResults.length === 0) {
             dispatch(fetchInitialFacets(searchFacetsLimits));
         } else {
-            if (searchQuery !== "" && Object.keys(searchFacetsValues).length > 0)
-            dispatch(searchReferences(searchQuery, '', searchFacetsValues, searchFacetsLimits,
-                searchSizeResultsCount));
+            if (searchQuery !== "" && Object.keys(searchFacetsValues).length > 0) {
+                dispatch(searchReferences(searchQuery, '', searchFacetsValues, searchFacetsLimits,
+                    searchSizeResultsCount));
+            }
         }
     }, [searchFacetsValues]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/search/SearchBar.js
+++ b/src/components/search/SearchBar.js
@@ -9,6 +9,7 @@ import {useDispatch, useSelector} from 'react-redux';
 const SearchBar = () => {
 
     const [fieldToSearch, setFieldToSearch] = useState('Title');
+    const [xrefQuery, setXrefQuery] = useState('');
     const searchLoading = useSelector(state => state.search.searchLoading);
     const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
     const searchFacetsLimits = useSelector(state => state.search.searchFacetsLimits);
@@ -16,6 +17,16 @@ const SearchBar = () => {
     const searchQuery = useSelector(state => state.search.searchQuery);
 
     const dispatch = useDispatch();
+
+    const searchRefOrXref = () => {
+        let query = "";
+        if (fieldToSearch === "ID") {
+            query = xrefQuery;
+        } else {
+            query = searchQuery;
+        }
+        dispatch(searchReferences(query, fieldToSearch, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount))
+    }
 
     return (
         <>
@@ -26,20 +37,30 @@ const SearchBar = () => {
                             {fieldToSearch}
                         </Dropdown.Toggle>
                         <Dropdown.Menu>
-                            <Dropdown.Item onClick={() => setFieldToSearch('Title')}>Title</Dropdown.Item>
-                            <Dropdown.Item onClick={() => setFieldToSearch('ID')}>ID</Dropdown.Item>
+                            <Dropdown.Item onClick={() => {
+                                setFieldToSearch('Title');
+                            }}>Title</Dropdown.Item>
+                            <Dropdown.Item onClick={() => {
+                                setFieldToSearch('ID');
+                            }}>ID</Dropdown.Item>
                         </Dropdown.Menu>
                     </Dropdown>
-                    <Form.Control inline="true" type="text" id="titleField" name="titleField" value={searchQuery}
-                                  onChange={(e) => dispatch(setSearchQuery(e.target.value))}
+                    <Form.Control inline="true" type="text" id="titleField" name="titleField"
+                                  value={fieldToSearch === "ID" ? xrefQuery : searchQuery}
+                                  onChange={(e) => {
+                                      if (fieldToSearch === "ID") {
+                                          setXrefQuery(e.target.value);
+                                      } else {
+                                          dispatch(setSearchQuery(e.target.value));
+                                      }
+                                  }}
                                   onKeyPress={(event) => {
                                       if (event.charCode === 13) {
-                                          dispatch(searchReferences(searchQuery, fieldToSearch, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
+                                          searchRefOrXref();
                                       }
                                   }}
                     />
-                    <Button inline="true" style={{width: "5em"}}
-                            onClick={() => dispatch(searchReferences(searchQuery, fieldToSearch, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount))}>
+                    <Button inline="true" style={{width: "5em"}} onClick={searchRefOrXref}>
                         {searchLoading ? <Spinner animation="border" size="sm"/> : <span>Search</span>  }
                     </Button>
                 </InputGroup>

--- a/src/components/search/SearchBar.js
+++ b/src/components/search/SearchBar.js
@@ -26,20 +26,20 @@ const SearchBar = () => {
                             {fieldToSearch}
                         </Dropdown.Toggle>
                         <Dropdown.Menu>
-                            <Dropdown.Item onClick={() => setFieldToSearch('All text fields')}>All text fields</Dropdown.Item>
                             <Dropdown.Item onClick={() => setFieldToSearch('Title')}>Title</Dropdown.Item>
+                            <Dropdown.Item onClick={() => setFieldToSearch('ID')}>ID</Dropdown.Item>
                         </Dropdown.Menu>
                     </Dropdown>
                     <Form.Control inline="true" type="text" id="titleField" name="titleField" value={searchQuery}
                                   onChange={(e) => dispatch(setSearchQuery(e.target.value))}
                                   onKeyPress={(event) => {
                                       if (event.charCode === 13) {
-                                          dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
+                                          dispatch(searchReferences(searchQuery, fieldToSearch, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
                                       }
                                   }}
                     />
                     <Button inline="true" style={{width: "5em"}}
-                            onClick={() => dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount))}>
+                            onClick={() => dispatch(searchReferences(searchQuery, fieldToSearch, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount))}>
                         {searchLoading ? <Spinner animation="border" size="sm"/> : <span>Search</span>  }
                     </Button>
                 </InputGroup>

--- a/src/components/search/SearchOptions.js
+++ b/src/components/search/SearchOptions.js
@@ -29,7 +29,7 @@ const SearchOptions = () => {
                                   onChange={(e) => {
                                       const intSizeResultsCount = parseInt(e.target.value.replace('Results per page ', ''));
                                       dispatch(setSearchSizeResultsCount(intSizeResultsCount));
-                                      dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, intSizeResultsCount));
+                                      dispatch(searchReferences(searchQuery, '', searchFacetsValues, searchFacetsLimits, intSizeResultsCount));
                                   } }>
                         <option>Results per page 10</option>
                         <option>Results per page 25</option>

--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -15,6 +15,8 @@ const SearchResults = () => {
     const searchResults = useSelector(state => state.search.searchResults);
     const searchSuccess = useSelector(state => state.search.searchSuccess);
     const searchError = useSelector(state => state.search.searchError);
+    const searchResponseField = useSelector(state => state.search.responseField);
+    const searchQuerySuccess = useSelector(state => state.search.querySuccess);
 
     const dispatch = useDispatch();
 
@@ -52,7 +54,7 @@ const SearchResults = () => {
                 <Modal.Header closeButton>
                     <Modal.Title>Error</Modal.Title>
                 </Modal.Header>
-                <Modal.Body>Couldn't search references</Modal.Body>
+                <Modal.Body>{!searchQuerySuccess && (searchResponseField.endsWith('not found')) ? "Reference not found" : "Couldn't search references"}</Modal.Body>
                 <Modal.Footer>
                     <Button variant="secondary" onClick={() => dispatch(setSearchError(false))}>
                         Close

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -27,7 +27,7 @@ const initialState = {
     'pubmed_publication_status.keyword': INITIAL_FACETS_LIMIT
   },
   searchFacetsShowMore: {},
-  searchQuery: undefined,
+  searchQuery: "",
   xrefcurieField: '',
   querySuccess: false,
   responseColor: 'black',
@@ -79,9 +79,7 @@ export default function(state = initialState, action) {
       return {
         ...state,
         searchLoading: false,
-        searchError: action.payload.value,
-        searchSuccess: false,
-        searchResults: []
+        searchError: action.payload.value
       }
 
     case SEARCH_SET_SEARCH_SIZE_RESULTS_COUNT:

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -32,7 +32,8 @@ const initialState = {
   querySuccess: false,
   responseColor: 'black',
   responseField: 'unknown reference',
-  redirectToBiblio: false
+  redirectToBiblio: false,
+  searchError: false
 };
 
 // to ignore a warning about Unexpected default export of anonymous function
@@ -145,14 +146,18 @@ export default function(state = initialState, action) {
       let responseColor = 'blue';
       let redirectToBiblio = false;
       let querySuccess = false;
-      if (responseFound === 'not found') { responseColor = 'red'; }
-        else { redirectToBiblio = true; querySuccess = true; }
+      let searchError = false;
+      if (responseFound === 'not found') {
+        responseColor = 'red';
+        searchError = true;
+      } else { redirectToBiblio = true; querySuccess = true; }
       return {
         ...state,
         responseColor: responseColor,
         responseField: responseField,
         redirectToBiblio: redirectToBiblio,
-        querySuccess: querySuccess
+        querySuccess: querySuccess,
+        searchError: searchError
       }
 //     case 'FETCH_POSTS':
 //       console.log('in postReducer case FETCH_POSTS');


### PR DESCRIPTION
- unified search interface for xrefs and title searches with new search field 'ID'
- when searching for an AGR curie (starting with AGR: or AGRKB:) clicking the search button automatically redirects to the biblio edit page for the inserted curie
- other IDs are managed using functions from the old xref query form and if the xref is found the page redirects to the biblio edit with the respective agr curie