### PR TITLE
SCRUM-1356 Adding Pagination

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 
 export const SEARCH_SET_SEARCH_RESULTS_COUNT = 'SEARCH_SET_SEARCH_RESULTS_COUNT';
+export const SEARCH_SET_SEARCH_RESULTS_PAGE = 'SEARCH_SET_SEARCH_RESULTS_PAGE';
 export const SEARCH_SET_SEARCH_RESULTS = 'SEARCH_SET_SEARCH_RESULTS';
 export const SEARCH_SET_SEARCH_LOADING = 'SEARCH_SET_SEARCH_LOADING';
 export const SEARCH_SET_SEARCH_ERROR = 'SEARCH_SET_SEARCH_ERROR';
@@ -48,7 +49,7 @@ export const fetchInitialFacets = (facetsLimits) => {
   }
 }
 
-export const searchReferences = (query, facetsValues, facetsLimits, sizeResultsCount) => {
+export const searchReferences = (query, facetsValues, facetsLimits, sizeResultsCount,searchResultsPage) => {
   return dispatch => {
     dispatch(setSearchLoading());
     dispatch(setSearchQuery(query));
@@ -57,6 +58,7 @@ export const searchReferences = (query, facetsValues, facetsLimits, sizeResultsC
     axios.post(restUrl + '/search/references', {
       query: query,
       size_result_count: sizeResultsCount,
+      page: searchResultsPage,
       facets_values: facetsValues,
       facets_limits: facetsLimits
     })
@@ -72,6 +74,13 @@ export const setSearchSizeResultsCount = (sizeResultsCount) => ({
   type: SEARCH_SET_SEARCH_SIZE_RESULTS_COUNT,
   payload: {
     sizeResultsCount
+  }
+});
+
+export const setSearchResultsPage = (searchResultsPage) => ({
+  type: SEARCH_SET_SEARCH_RESULTS_PAGE,
+  payload: {
+    searchResultsPage
   }
 });
 

--- a/src/components/search/SearchBar.js
+++ b/src/components/search/SearchBar.js
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import {Dropdown, InputGroup, Spinner} from 'react-bootstrap';
-import {searchReferences, setSearchQuery} from '../../actions/searchActions';
+import {searchReferences, setSearchQuery, setSearchResultsPage} from '../../actions/searchActions';
 import {useDispatch, useSelector} from 'react-redux';
 
 
@@ -13,6 +13,7 @@ const SearchBar = () => {
     const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
     const searchFacetsLimits = useSelector(state => state.search.searchFacetsLimits);
     const searchSizeResultsCount = useSelector(state => state.search.searchSizeResultsCount);
+    const searchResultsPage = useSelector(state => state.search.searchResultsPage);
     const searchQuery = useSelector(state => state.search.searchQuery);
 
     const dispatch = useDispatch();
@@ -34,12 +35,16 @@ const SearchBar = () => {
                                   onChange={(e) => dispatch(setSearchQuery(e.target.value))}
                                   onKeyPress={(event) => {
                                       if (event.charCode === 13) {
-                                          dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
+                                        dispatch(setSearchResultsPage(0));
+                                        dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount,0));
                                       }
                                   }}
                     />
                     <Button inline="true" style={{width: "5em"}}
-                            onClick={() => dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount))}>
+                            onClick={() => {
+                              dispatch(setSearchResultsPage(0));
+                              dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount,0))
+                            }}>
                         {searchLoading ? <Spinner animation="border" size="sm"/> : <span>Search</span>  }
                     </Button>
                 </InputGroup>

--- a/src/components/search/SearchOptions.js
+++ b/src/components/search/SearchOptions.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import Form from 'react-bootstrap/Form';
-import {searchReferences, setSearchSizeResultsCount} from '../../actions/searchActions';
+import {searchReferences, setSearchSizeResultsCount, setSearchResultsPage} from '../../actions/searchActions';
 import {useDispatch, useSelector} from 'react-redux';
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
+import Pagination from 'react-bootstrap/Pagination';
+
 
 
 const SearchOptions = () => {
@@ -13,8 +15,36 @@ const SearchOptions = () => {
     const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
     const searchFacetsLimits = useSelector(state => state.search.searchFacetsLimits);
     const searchResultsCount = useSelector(state => state.search.searchResultsCount);
+    const searchSizeResultsCount = useSelector(state => state.search.searchSizeResultsCount);
+    const searchResultsPage  = useSelector(state => state.search.searchResultsPage);
 
     const dispatch = useDispatch();
+
+    function changePage(action){
+      let page = searchResultsPage;
+      let lastPage= parseInt(searchResultsCount/searchSizeResultsCount);
+      switch (action){
+        case 'Next':
+          page=Math.min(lastPage,page+1);
+          break;
+        case 'Prev':
+          page=Math.max(0,page-1);
+          break;
+        case 'First':
+          page=0;
+          break;
+        case 'Last':
+          page=lastPage;
+          break;
+        default:
+          page=0;
+          break;
+
+      }
+      dispatch(setSearchResultsPage(page));
+      dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount,page));
+    }
+
 
     return (
         <Container fluid>
@@ -29,14 +59,24 @@ const SearchOptions = () => {
                                   onChange={(e) => {
                                       const intSizeResultsCount = parseInt(e.target.value.replace('Results per page ', ''));
                                       dispatch(setSearchSizeResultsCount(intSizeResultsCount));
-                                      dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, intSizeResultsCount));
+                                      dispatch(setSearchResultsPage(0));
+                                      dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, intSizeResultsCount,0));
                                   } }>
                         <option>Results per page 10</option>
                         <option>Results per page 25</option>
                         <option>Results per page 50</option>
                     </Form.Control>
                 </Col>
-                <Col sm={8}>
+                <Col sm={6}>
+                  <Pagination>
+                    <Pagination.First  onClick={() => changePage('First')} />
+                    <Pagination.Prev   onClick={() => changePage('Prev')} />
+                    <Pagination.Item   active>{searchResultsPage+1}</Pagination.Item>
+                    <Pagination.Next   onClick={() => changePage('Next')} />
+                    <Pagination.Last   onClick={() => changePage('Last')} />
+                  </Pagination>
+                </Col>
+                <Col sm={2}>
                 </Col>
             </Row>
         </Container>

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -4,7 +4,7 @@ import {
   SEARCH_SET_SEARCH_FACETS, SEARCH_SET_SEARCH_FACETS_LIMITS,
   SEARCH_SET_SEARCH_FACETS_VALUES,
   SEARCH_SET_SEARCH_LOADING, SEARCH_SET_SEARCH_SEARCH,
-  SEARCH_SET_SEARCH_RESULTS,
+  SEARCH_SET_SEARCH_RESULTS, SEARCH_SET_SEARCH_RESULTS_PAGE,
   SEARCH_SET_SEARCH_SIZE_RESULTS_COUNT,
 } from '../actions/searchActions';
 
@@ -17,6 +17,7 @@ const initialState = {
   searchResults: [],
   searchResultsCount: 0,
   searchSizeResultsCount: 10,
+  searchResultsPage: 0,
   searchLoading: false,
   searchSuccess: false,
   searchFacets: {},
@@ -87,6 +88,12 @@ export default function(state = initialState, action) {
       return {
         ...state,
         searchSizeResultsCount: action.payload.sizeResultsCount
+      }
+
+    case SEARCH_SET_SEARCH_RESULTS_PAGE:
+      return {
+        ...state,
+        searchResultsPage: action.payload.searchResultsPage
       }
 
     case SEARCH_SET_SEARCH_SEARCH:


### PR DESCRIPTION
Adding code to delivery pagination.  Functions are limited to First,  Last, Next, and Previous.  The first page is defined as page zero (to  make the maths easier) but displayed as page one.  Page is reset to zero  upon changing the size of pages or running another query.  Its possible that all the pagination could be moved into its own component as it get more complex... or now if we think thats necessary.

Needs the corresponding SCRUM-1356 pull from the agr_literature_service repo to function properly. 