### PR TITLE
fix(search): allow search by facets only

### DIFF
--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -151,8 +151,9 @@ const Facets = () => {
         if (Object.keys(searchFacets).length === 0 && searchResults.length === 0) {
             dispatch(fetchInitialFacets(searchFacetsLimits));
         } else {
-            if (searchQuery !== "" || searchResults.length > 0)
-            dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
+            if (searchQuery !== "" || searchResults.length > 0 || Object.keys(searchFacetsValues).length > 0) {
+                dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
+            }
         }
     }, [searchFacetsValues]); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
Selecting a facet without any text in the search bar now triggers a search