### PR TITLE
Various Fixes

### DIFF
--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -5,7 +5,8 @@ import {
     fetchInitialFacets,
     removeFacetValue,
     searchReferences,
-    setSearchFacetsLimits
+    setSearchFacetsLimits,
+    setSearchResultsPage
 } from '../../actions/searchActions';
 import Form from 'react-bootstrap/Form';
 import {Badge, Button, Collapse} from 'react-bootstrap';
@@ -91,7 +92,8 @@ const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
 
     const searchOrSetInitialFacets = (newSearchFacetsLimits) => {
         if (searchQuery !== null || Object.keys(searchFacetsValues).length !== 0) {
-            dispatch(searchReferences(searchQuery, searchFacetsValues, newSearchFacetsLimits, searchSizeResultsCount))
+            dispatch(setSearchResultsPage(0));
+            dispatch(searchReferences(searchQuery, searchFacetsValues, newSearchFacetsLimits, searchSizeResultsCount,0))
         } else {
             dispatch(fetchInitialFacets(newSearchFacetsLimits));
         }
@@ -152,7 +154,8 @@ const Facets = () => {
             dispatch(fetchInitialFacets(searchFacetsLimits));
         } else {
             if (searchQuery !== "" || searchResults.length > 0)
-            dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount));
+            dispatch(setSearchResultsPage(0));
+            dispatch(searchReferences(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount,0));
         }
     }, [searchFacetsValues]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/search/SearchOptions.js
+++ b/src/components/search/SearchOptions.js
@@ -24,23 +24,11 @@ const SearchOptions = () => {
       <Pagination>
         <Pagination.First  onClick={() => changePage('First')} />
         <Pagination.Prev   onClick={() => changePage('Prev')} />
-        <Pagination.Item  disabled>{searchResultsPage+1}</Pagination.Item>
-        <Pagination.Ellipsis disabled/>
-        <Pagination.Item  disabled>{Math.ceil(searchResultsCount/searchSizeResultsCount)}</Pagination.Item>
+        <Pagination.Item  disabled>{"Page " + (searchResultsPage+1) + " of " + Math.ceil(searchResultsCount/searchSizeResultsCount)}</Pagination.Item>
         <Pagination.Next   onClick={() => changePage('Next')} />
         <Pagination.Last   onClick={() => changePage('Last')} />
       </Pagination>
-    ) : (
-      <Pagination>
-        <Pagination.First  disabled />
-        <Pagination.Prev   disabled />
-        <Pagination.Item  disabled> . </Pagination.Item>
-        <Pagination.Ellipsis disabled/>
-        <Pagination.Item  disabled> . </Pagination.Item>
-        <Pagination.Next   disabled/>
-        <Pagination.Last   disabled />
-      </Pagination>
-    )
+    ) : null
 
     function changePage(action){
       let page = searchResultsPage;

--- a/src/components/search/SearchOptions.js
+++ b/src/components/search/SearchOptions.js
@@ -20,9 +20,31 @@ const SearchOptions = () => {
 
     const dispatch = useDispatch();
 
+    const pagination_elements = searchResultsCount ? (
+      <Pagination>
+        <Pagination.First  onClick={() => changePage('First')} />
+        <Pagination.Prev   onClick={() => changePage('Prev')} />
+        <Pagination.Item  disabled>{searchResultsPage+1}</Pagination.Item>
+        <Pagination.Ellipsis disabled/>
+        <Pagination.Item  disabled>{Math.ceil(searchResultsCount/searchSizeResultsCount)}</Pagination.Item>
+        <Pagination.Next   onClick={() => changePage('Next')} />
+        <Pagination.Last   onClick={() => changePage('Last')} />
+      </Pagination>
+    ) : (
+      <Pagination>
+        <Pagination.First  disabled />
+        <Pagination.Prev   disabled />
+        <Pagination.Item  disabled> . </Pagination.Item>
+        <Pagination.Ellipsis disabled/>
+        <Pagination.Item  disabled> . </Pagination.Item>
+        <Pagination.Next   disabled/>
+        <Pagination.Last   disabled />
+      </Pagination>
+    )
+
     function changePage(action){
       let page = searchResultsPage;
-      let lastPage= parseInt(searchResultsCount/searchSizeResultsCount);
+      let lastPage= Math.ceil(searchResultsCount/searchSizeResultsCount)-1;
       switch (action){
         case 'Next':
           page=Math.min(lastPage,page+1);
@@ -68,13 +90,7 @@ const SearchOptions = () => {
                     </Form.Control>
                 </Col>
                 <Col sm={6}>
-                  <Pagination>
-                    <Pagination.First  onClick={() => changePage('First')} />
-                    <Pagination.Prev   onClick={() => changePage('Prev')} />
-                    <Pagination.Item   active>{searchResultsPage+1}</Pagination.Item>
-                    <Pagination.Next   onClick={() => changePage('Next')} />
-                    <Pagination.Last   onClick={() => changePage('Last')} />
-                  </Pagination>
+                  {pagination_elements}
                 </Col>
                 <Col sm={2}>
                 </Col>


### PR DESCRIPTION
Fixing last page bug with perfectly divisible numbers of results, page  is reset to zero when changing facet values, added total number of pages  in pagination widget, fixed bug with empty search by disabling all  pagination on initial page load.

There is a decent amount of code in the pagination functionality that when we go to work on this again I'd probably want to move it into its own component/container.