### PR TITLE
Xref URL

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -64,6 +64,14 @@ export const searchReferences = (query, facetsValues, facetsLimits, sizeResultsC
   }
 }
 
+export const searchXref = (xref, setUrl) => {
+  axios.get(restUrl + '/cross_reference/'+xref)
+  .then(res => {
+    setUrl(res.data.url);
+  })
+  .catch();
+}
+
 export const setSearchSizeResultsCount = (sizeResultsCount) => ({
   type: SEARCH_SET_SEARCH_SIZE_RESULTS_COUNT,
   payload: {

--- a/src/components/search/SearchBar.js
+++ b/src/components/search/SearchBar.js
@@ -13,7 +13,6 @@ const SearchBar = () => {
     const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
     const searchFacetsLimits = useSelector(state => state.search.searchFacetsLimits);
     const searchSizeResultsCount = useSelector(state => state.search.searchSizeResultsCount);
-    const searchResultsPage = useSelector(state => state.search.searchResultsPage);
     const searchQuery = useSelector(state => state.search.searchQuery);
 
     const dispatch = useDispatch();

--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -13,9 +13,9 @@ const XrefElement = (xref) => {
     const [url, setUrl] = useState(null);
     useEffect(() => {
       searchXref(xref.xref.curie, setUrl);
-    }, [url]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
     return (
-      <li><span className="obsolete">{xref.xref.is_obsolete === 'false' ?  '' : 'obsolete '}</span><a href={url}>{xref.xref.curie}</a></li>
+      <li><span className="obsolete">{xref.xref.is_obsolete === 'false' ?  '' : 'obsolete '}</span><a href={url} rel="noreferrer noopener" target="_blank">{xref.xref.curie}</a></li>
     )
 }
 

--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
@@ -6,9 +6,18 @@ import Col from 'react-bootstrap/Col';
 import {Link} from 'react-router-dom';
 import {setGetReferenceCurieFlag, setReferenceCurie} from '../../actions/biblioActions';
 import {Modal} from 'react-bootstrap';
-import {setSearchError} from '../../actions/searchActions';
+import {setSearchError, searchXref} from '../../actions/searchActions';
 import Button from 'react-bootstrap/Button';
 
+const XrefElement = (xref) => {
+    const [url, setUrl] = useState(null);
+    useEffect(() => {
+      searchXref(xref.xref.curie, setUrl);
+    }, [url]); // eslint-disable-line react-hooks/exhaustive-deps
+    return (
+      <li><span className="obsolete">{xref.xref.is_obsolete === 'false' ?  '' : 'obsolete '}</span><a href={url}>{xref.xref.curie}</a></li>
+    )
+}
 
 const SearchResults = () => {
 
@@ -29,8 +38,8 @@ const SearchResults = () => {
                               <div className="searchRow-title"><Link to={{pathname: "/Biblio", search: "?action=display&referenceCurie=" + reference.curie}} onClick={() => { dispatch(setReferenceCurie(reference.curie)); dispatch(setGetReferenceCurieFlag(true)); }}><span dangerouslySetInnerHTML={{__html: reference.title}} /></Link></div>
                               <div className="searchRow-xref">
                                 <ul><li><Link to={{pathname: "/Biblio", search: "?action=display&referenceCurie=" + reference.curie}} onClick={() => { dispatch(setReferenceCurie(reference.curie)); dispatch(setGetReferenceCurieFlag(true)); }}>{reference.curie}</Link></li>
-                                  {reference.cross_references.map((xref, i) => (
-                                  <li><span className="obsolete">{xref.is_obsolete === 'false' ?  '' : 'obsolete '}</span>{xref.curie}</li>
+                                {reference.cross_references.map((xref, i) => (
+                                  <XrefElement xref={xref}/>
                                 ))}
                                 </ul>
                               </div>


### PR DESCRIPTION
Adding the ability to click on an Xref direct from the search results  page.  Uses the searchXref method to call the cross_references endpoint. This will call every xref in a different api call but it doesn't seem to cause any problems.  Tested with a search artificially expanded to 500 records with no errors.

Of note... MGI urls seem to be a blank informatics.jax.org.  I think this is a known issue but noting it here all the same.