### PR TITLE
Correcting URL's

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -67,7 +67,11 @@ export const searchReferences = (query, facetsValues, facetsLimits, sizeResultsC
 export const searchXref = (xref, setUrl) => {
   axios.get(restUrl + '/cross_reference/'+xref)
   .then(res => {
-    setUrl(res.data.url);
+    if(res.data.pages){
+      setUrl(res.data.pages[0].url)
+    }else{
+        setUrl(res.data.url);
+    }
   })
   .catch();
 }

--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -70,7 +70,7 @@ export const searchXref = (xref, setUrl) => {
     if(res.data.pages){
       setUrl(res.data.pages[0].url)
     }else{
-        setUrl(res.data.url);
+      setUrl(res.data.url);
     }
   })
   .catch();
@@ -152,4 +152,3 @@ export const removeFacetValue = (facet, value) => ({
     value: value
   }
 });
-


### PR DESCRIPTION
It seems that this endpoint returns URL in two different fields.  The  pages field that is an array and the url field on the top level.  This  change means if the pages field exists we use the first url from that  array and if not we use the top level url.  I dont know if its possible  to have more than one entry in this array but the returns I looked at  did not seem to.  Checked the examples that Ceri provided (MGI, SGD, etc) and all appear to be going to the correct url now.