### PR TITLE
Fixing Null Error

### DIFF
--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -38,9 +38,9 @@ const SearchResults = () => {
                               <div className="searchRow-title"><Link to={{pathname: "/Biblio", search: "?action=display&referenceCurie=" + reference.curie}} onClick={() => { dispatch(setReferenceCurie(reference.curie)); dispatch(setGetReferenceCurieFlag(true)); }}><span dangerouslySetInnerHTML={{__html: reference.title}} /></Link></div>
                               <div className="searchRow-xref">
                                 <ul><li><Link to={{pathname: "/Biblio", search: "?action=display&referenceCurie=" + reference.curie}} onClick={() => { dispatch(setReferenceCurie(reference.curie)); dispatch(setGetReferenceCurieFlag(true)); }}>{reference.curie}</Link></li>
-                                {reference.cross_references.map((xref, i) => (
+                                {reference.cross_references ? reference.cross_references.map((xref, i) => (
                                   <XrefElement xref={xref}/>
-                                ))}
+                                )) : null}
                                 </ul>
                               </div>
                               <div className="searchRow-other">Authors : {reference.authors ? reference.authors.map((author, i) => ((i ? ', ' : '') + author.name)) : ''}</div>


### PR DESCRIPTION
Search results throw an error if there are no xrefs.  I'm not 100% sure if this needs to be fixed here or on the API level but currently if an entry has no xrefs it will fail to load.  This seemed to happen with an entry that is fake (Testing the Test AGRKB:101000001825278) but if this is possible we need some code to make sure this wont happen to other entries.