### PR TITLE
Adding in author Facet

### DIFF
--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -20,12 +20,13 @@ import _ from "lodash";
 export const RENAME_FACETS = {
     "category.keyword": "alliance category",
     "mods_in_corpus.keyword": "corpus - in corpus",
-    "mods_needs_review.keyword": "corpus - needs review"
+    "mods_needs_review.keyword": "corpus - needs review",
+    "authors.name.keyword": "Authors"
 }
 
 export const FACETS_CATEGORIES_WITH_FACETS = {
     "Alliance Metadata": ["mods in corpus", "mods needs review"],
-    "Bibliographic Data": ["pubmed types", "category", "pubmed publication status"]
+    "Bibliographic Data": ["pubmed types", "category", "pubmed publication status", "authors.name"]
 }
 
 const Facet = ({facetsToInclude, renameFacets}) => {

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -25,7 +25,8 @@ const initialState = {
   searchFacetsLimits: {
     'pubmed_types.keyword': INITIAL_FACETS_LIMIT,
     'category.keyword': INITIAL_FACETS_LIMIT,
-    'pubmed_publication_status.keyword': INITIAL_FACETS_LIMIT
+    'pubmed_publication_status.keyword': INITIAL_FACETS_LIMIT,
+    'authors.name.keyword': INITIAL_FACETS_LIMIT
   },
   searchFacetsShowMore: {},
   searchQuery: ""


### PR DESCRIPTION
Removed problematic code for filter and just adding Author as another  basic facet.

Note: Show All doesn't actually show all authors... it only shows 1000.  This request seems fine and returns a lot of results but doesn't cause any errors.  We could consider adding in an overflow for these but we'd have to change the div grouping since certain labels are on the same level as the facet data.

Needs SCRUM-2148 in the agr_literature_service to work properly.