### PR TITLE
Scrum 1980 - file management interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1325,6 +1325,21 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
+    "@emotion/is-prop-valid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "requires": {
+        "@emotion/memoize": "^0.8.0"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+          "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+        }
+      }
+    },
     "@emotion/memoize": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
@@ -3748,6 +3763,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
+    },
     "autoprefixer": {
       "version": "9.8.8",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
@@ -3993,6 +4013,18 @@
       "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.3"
+      }
+    },
+    "babel-plugin-styled-components": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
       }
     },
     "babel-plugin-syntax-jsx": {
@@ -4669,6 +4701,11 @@
         }
       }
     },
+    "camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
+    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -5321,6 +5358,11 @@
         "postcss": "^7.0.5"
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -5403,6 +5445,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "css-to-react-native": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.1.0.tgz",
+      "integrity": "sha512-AryfkFA29b4I3vG7N4kxFboq15DxwSXzhXM37XNEjwJMgjYIc8BcqfiprpAqX0zadI5PMByEIwAMzXxk5Vcc4g==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
@@ -7335,6 +7387,14 @@
             "ajv-keywords": "^3.5.2"
           }
         }
+      }
+    },
+    "file-selector": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "filesize": {
@@ -13948,6 +14008,16 @@
         "scheduler": "^0.20.2"
       }
     },
+    "react-dropzone": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
+      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "requires": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
+      }
+    },
     "react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -15275,6 +15345,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -15868,6 +15943,38 @@
       "requires": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^2.7.0"
+      }
+    },
+    "styled-components": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
+      "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "stylehacks": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^17.0.2",
     "react-bootstrap": "^1.6.0",
     "react-dom": "^17.0.2",
+    "react-dropzone": "^14.2.3",
     "react-icons": "^4.3.1",
     "react-loading-overlay": "^1.0.1",
     "react-popup": "^0.10.0",
@@ -32,6 +33,7 @@
     "reactjs-popup": "^2.0.4",
     "redux": "^4.1.0",
     "redux-thunk": "^2.3.0",
+    "styled-components": "^5.3.6",
     "web-vitals": "^1.1.2"
   },
   "scripts": {

--- a/src/App.css
+++ b/src/App.css
@@ -344,6 +344,21 @@ em {
   background-color: #bbeffd;
 */
 
+.dropzone {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  margin: -2px, 2px;
+  border-width: 2px;
+  border-radius: 2px;
+  border-style: dashed;
+  background-color: var(--light-blue);
+  color: #bdbdbd;
+  outline: none;
+  transition: border .24s ease-in-out;
+}
 
 /*
 .App-header {

--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -836,3 +836,8 @@ export const setFileUploadingShowModal = (payload) => {
     payload: payload
   };
 };
+
+export const setFileUploadingModalText = (modalText) => ({
+  type: 'SET_FILE_UPLOADING_MODAL_TEXT',
+  payload: modalText
+})

--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -818,3 +818,21 @@ export const downloadReferencefile = (referencefileId, filename, accessToken, re
     })
   }
 }
+
+export const setFileUploadingCount = (payload) => { return { type: 'SET_FILE_UPLOADING_COUNT', payload: payload }; };
+
+export const fileUploadResult = (filename, resultMessage) => { 
+  return { 
+    type: 'FILE_UPLOAD_RESULT',
+        payload: {
+          filename: filename,
+          resultMessage: resultMessage
+        }
+}; };
+
+export const setFileUploadingShowModal = (payload) => {
+  return {
+    type: 'SET_FILE_UPLOADING_SHOW_MODAL',
+    payload: payload
+  };
+};

--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -830,6 +830,13 @@ export const fileUploadResult = (filename, resultMessage) => {
         }
 }; };
 
+export const setFileUploadingShowSuccess = (payload) => {
+  return {
+    type: 'SET_FILE_UPLOADING_SHOW_SUCCESS',
+    payload: payload
+  };
+};
+
 export const setFileUploadingShowModal = (payload) => {
   return {
     type: 'SET_FILE_UPLOADING_SHOW_MODAL',

--- a/src/components/Biblio.js
+++ b/src/components/Biblio.js
@@ -10,6 +10,7 @@ import BiblioEditor from './biblio/BiblioEditor';
 import BiblioEntity from './biblio/BiblioEntity';
 import BiblioWorkflow from './biblio/BiblioWorkflow';
 import BiblioFileManagement from './biblio/BiblioFileManagement';
+import NoAccessAlert from './biblio/NoAccessAlert';
 
 import { RowDisplayString } from './biblio/BiblioDisplay';
 import { RowDisplaySimple } from './biblio/BiblioDisplay';
@@ -197,17 +198,18 @@ const BiblioActionToggler = () => {
 
 const BiblioActionRouter = () => {
   const biblioAction = useSelector(state => state.biblio.biblioAction);
+  const accessToken = useSelector(state => state.isLogged.accessToken);
   switch (biblioAction) {
     case 'display':
       return (<Container><BiblioActionToggler /><RowDivider /><BiblioDisplay /></Container>);
     case 'editor':
-      return (<Container><BiblioActionToggler /><RowDivider /><BiblioEditor /></Container>);
+      return (<><Container><BiblioActionToggler /></Container>{ accessToken === null ? <NoAccessAlert /> : <BiblioEditor /> }</>);
     case 'entity':
-      return (<><Container><BiblioActionToggler /></Container><BiblioTagging /></>);
+      return (<><Container><BiblioActionToggler /></Container>{ accessToken === null ? <NoAccessAlert /> : <BiblioTagging /> }</>);
     case 'workflow':
-      return (<><Container><BiblioActionToggler /></Container><BiblioTagging /></>);
+      return (<><Container><BiblioActionToggler /></Container>{ accessToken === null ? <NoAccessAlert /> : <BiblioTagging /> }</>);
     case 'filemanagement':
-      return (<><Container><BiblioActionToggler /></Container><BiblioFileManagement /></>);
+      return (<><Container><BiblioActionToggler /></Container>{ accessToken === null ? <NoAccessAlert /> : <BiblioFileManagement /> }</>);
     default:
       return (<Container><BiblioActionToggler /><RowDivider /><BiblioDisplay /></Container>);
   }

--- a/src/components/Biblio.js
+++ b/src/components/Biblio.js
@@ -9,6 +9,7 @@ import BiblioDisplay from './biblio/BiblioDisplay';
 import BiblioEditor from './biblio/BiblioEditor';
 import BiblioEntity from './biblio/BiblioEntity';
 import BiblioWorkflow from './biblio/BiblioWorkflow';
+import BiblioFileManagement from './biblio/BiblioFileManagement';
 
 import { RowDisplayString } from './biblio/BiblioDisplay';
 import { RowDisplaySimple } from './biblio/BiblioDisplay';
@@ -86,10 +87,12 @@ const BiblioActionToggler = () => {
   let editorChecked = '';
   let entityChecked = '';
   let workflowChecked = '';
+  let filemanagementChecked = '';
   let radioFormDisplayClassname = 'radio-form';
   let radioFormEditorClassname = 'radio-form';
   let radioFormEntityClassname = 'radio-form';
   let radioFormWorkflowClassname = 'radio-form';
+  let radioFormFilemanagementClassname = 'radio-form';
   let biblioActionTogglerSelected = 'display';
   if (biblioAction === 'editor') {
       radioFormEditorClassname += ' underlined';
@@ -103,6 +106,10 @@ const BiblioActionToggler = () => {
       radioFormWorkflowClassname += ' underlined';
       workflowChecked = 'checked';
       biblioActionTogglerSelected = 'workflow'; }
+    else if (biblioAction === 'filemanagement') {
+      radioFormFilemanagementClassname += ' underlined';
+      filemanagementChecked = 'checked';
+      biblioActionTogglerSelected = 'filemanagement'; }
     else {
       radioFormDisplayClassname += ' underlined';
       displayChecked = 'checked'; }
@@ -172,6 +179,17 @@ const BiblioActionToggler = () => {
           onChange={(e) => dispatch(changeBiblioActionToggler(e, 'workflow'))}
         />
       </div>
+      <div className='radio-span'>
+        <Form.Check
+          inline
+          className={radioFormFilemanagementClassname}
+          checked={filemanagementChecked}
+          type='radio'
+          label='file management'
+          id='biblio-toggler-filemanagement'
+          onChange={(e) => dispatch(changeBiblioActionToggler(e, 'filemanagement'))}
+        />
+      </div>
     </div>
     </Form>);
 } // const BiblioActionToggler
@@ -188,6 +206,8 @@ const BiblioActionRouter = () => {
       return (<><Container><BiblioActionToggler /></Container><BiblioTagging /></>);
     case 'workflow':
       return (<><Container><BiblioActionToggler /></Container><BiblioTagging /></>);
+    case 'filemanagement':
+      return (<><Container><BiblioActionToggler /></Container><BiblioFileManagement /></>);
     default:
       return (<Container><BiblioActionToggler /><RowDivider /><BiblioDisplay /></Container>);
   }

--- a/src/components/biblio/BiblioDisplay.js
+++ b/src/components/biblio/BiblioDisplay.js
@@ -356,6 +356,7 @@ const RowDisplayAuthors = ({fieldIndex, fieldName, referenceJsonLive, referenceJ
 
 
 const BiblioDisplay = () => {
+  const accessToken = useSelector(state => state.isLogged.accessToken);
   const referenceJsonLive = useSelector(state => state.biblio.referenceJsonLive);
   const referenceJsonDb = useSelector(state => state.biblio.referenceJsonDb);
   if (!('date_created' in referenceJsonLive)) {
@@ -388,7 +389,7 @@ const BiblioDisplay = () => {
       rowOrderedElements.push(<RowDisplayReflinks key="referencefile" fieldName="referencefiles" referenceJsonLive={referenceJsonLive} displayOrEditor="display" />); }
   } // for (const [fieldIndex, fieldName] of fieldsOrdered.entries())
 
-  return (<Container><BiblioSubmitUpdateRouter />{rowOrderedElements}</Container>);
+  return (<Container>{ accessToken !== null && <BiblioSubmitUpdateRouter /> }{rowOrderedElements}</Container>);
 } // const BiblioDisplay
 
 

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -17,11 +17,7 @@ import ModalGeneric from './ModalGeneric';
 import { fileUploadResult, setFileUploadingModalText } from '../../actions/biblioActions';
 import { setFileUploadingCount } from '../../actions/biblioActions';
 import { setFileUploadingShowModal } from '../../actions/biblioActions';
-import {
-  downloadReferencefile,
-  queryId,
-  setReferenceCurie
-} from '../../actions/biblioActions';
+import { downloadReferencefile } from '../../actions/biblioActions';
 
 import {useDropzone} from 'react-dropzone';
 
@@ -115,7 +111,6 @@ const FileEditor = () => {
   const dispatch = useDispatch();
   const oktaGroups = useSelector(state => state.isLogged.oktaGroups);
   const accessToken = useSelector(state => state.isLogged.accessToken);
-  const supplementExpand = useSelector(state => state.biblio.supplementExpand);
   const loadingFileNames = useSelector(state => state.biblio.loadingFileNames);
   let cssDisplayLeft = 'Col-display Col-display-left';
   let cssDisplay = 'Col-display';
@@ -125,13 +120,9 @@ const FileEditor = () => {
     cssDisplayLeft = ''; cssDisplayRight = 'Col-editor-disabled'; }
   const access = getOktaModAccess(oktaGroups);
   if ('referencefiles' in referenceJsonLive && referenceJsonLive['referencefiles'] !== null) {
-    let tarballChecked = ''; let listChecked = '';
-    if (supplementExpand === 'tarball') { tarballChecked = 'checked'; }
-      else if (supplementExpand === 'list') { listChecked = 'checked'; }
     const rowReferencefileElements = []
 
     // for (const[index, referencefileDict] of referenceJsonLive['referencefiles'].filter(x => x['file_class'] === 'main').entries())
-    let hasAccessToTarball = false;
     for (const[index, referencefileDict] of referenceJsonLive['referencefiles'].entries()) {
       let is_ok = false;
       let allowed_mods = [];
@@ -146,7 +137,6 @@ const FileEditor = () => {
       if (access === 'developer') { is_ok = true; }
         else if (access === 'No') { is_ok = false; referencefileValue = (<div>{filename}</div>); }
       if (is_ok) {
-        hasAccessToTarball = true;
         referencefileValue = (<div><button className='button-to-link' onClick={ () =>
             dispatch(downloadReferencefile(referencefileDict['referencefile_id'], filename, accessToken))
         } >{filename}</button>&nbsp;{loadingFileNames.has(filename) ? <Spinner animation="border" size="sm"/> : null}</div>); }

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -1,5 +1,5 @@
 
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
@@ -33,7 +33,6 @@ const FileUpload = ({main_or_supp}) => {
   const accessToken = useSelector(state => state.isLogged.accessToken);
   const fileUploadingShowModal = useSelector(state => state.biblio.fileUploadingShowModal);
   const fileUploadingModalText = useSelector(state => state.biblio.fileUploadingModalText);
-  const fileUploadResultMap = useSelector(state => state.biblio.fileUploadResultMap);
 
   // https://react-dropzone.js.org/
   const onDrop = useCallback((acceptedFiles) => {

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -1,0 +1,401 @@
+
+import {useEffect, useState} from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { changeFieldEntityEntityList } from '../../actions/biblioActions';
+import { changeFieldEntityAddGeneralField } from '../../actions/biblioActions';
+import { changeFieldEntityAddTaxonSelect } from '../../actions/biblioActions';
+import { updateButtonBiblioEntityAdd } from '../../actions/biblioActions';
+import { setBiblioUpdatingEntityAdd } from '../../actions/biblioActions';
+import { updateButtonBiblioEntityEditEntity } from '../../actions/biblioActions';
+import { setBiblioEntityRemoveEntity } from '../../actions/biblioActions';
+import { setEntityModalText } from '../../actions/biblioActions';
+import { changeFieldEntityEditor } from '../../actions/biblioActions';
+import { setFieldEntityEditor } from '../../actions/biblioActions';
+import { changeFieldEntityEditorPriority } from '../../actions/biblioActions';
+
+import { RowDisplayString } from './BiblioDisplay';
+
+import RowDivider from './RowDivider';
+import ModalGeneric from './ModalGeneric';
+
+import { getOktaModAccess } from '../Biblio';
+
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Button from 'react-bootstrap/Button'
+import Spinner from 'react-bootstrap/Spinner'
+import axios from "axios";
+import Pagination from "react-bootstrap/Pagination";
+
+import {useDropzone} from 'react-dropzone';
+
+export const curieToNameEntityType = { 'ATP:0000005': 'gene', 'ATP:0000006': 'allele' };
+
+const BiblioFileManagement = () => {
+  return (<>
+            <Container>
+              <BiblioCitationDisplay key="filemanagementCitationDisplay" />
+              <FileUpload />
+            </Container>
+            <EntityEditor key="entityEditor" />
+          </>); }
+
+const FileUpload = () => {
+  const {acceptedFiles, getRootProps, getInputProps} = useDropzone();
+  return (
+    <section className="container">
+      <div {...getRootProps({className: 'dropzone'})}>
+        <input {...getInputProps()} />
+        <p>Drag 'n' drop some files here, or click to select files</p>
+      </div>
+      <aside>
+        <h4>Files</h4>
+        <ul></ul>
+      </aside>
+    </section>
+  );
+}
+
+const BiblioCitationDisplay = () => {
+  const referenceJsonLive = useSelector(state => state.biblio.referenceJsonLive);
+  const referenceJsonDb = useSelector(state => state.biblio.referenceJsonDb);
+  const fieldName = 'citation';
+  return (<RowDisplayString key={fieldName} fieldName={fieldName} referenceJsonLive={referenceJsonLive} referenceJsonDb={referenceJsonDb} />);
+}
+
+
+  const curieToNameAtp = { 'ATP:0000005': 'gene', 'ATP:0000006': 'allele', 'ATP:0000122': 'entity type', 'ATP:0000132': 'additional display', 'ATP:0000129': 'headline display', 'ATP:0000131': 'other primary display', 'ATP:0000130': 'review display', 'ATP:0000116': 'high priority', '': '' };
+  const qualifierList = [ '', 'ATP:0000131', 'ATP:0000132', 'ATP:0000130', 'ATP:0000129', 'ATP:0000116' ];
+  const curieToNameTaxon = { 'NCBITaxon:559292': 'Saccharomyces cerevisiae', 'NCBITaxon:6239': 'Caenorhabditis elegans', 'NCBITaxon:7227': 'Drosophila melanogaster', 'NCBITaxon:7955': 'Danio rerio', 'NCBITaxon:10116': 'Rattus norvegicus', 'NCBITaxon:10090': 'Mus musculus', 'NCBITaxon:8355': 'Xenopus laevis', 'NCBITaxon:8364': 'Xenopus tropicalis', 'NCBITaxon:9606': 'Homo sapiens', '': '' };
+
+const EntityEditor = () => {
+  const dispatch = useDispatch();
+//   const curieToNameAtp = { 'ATP:0000005': 'gene', 'ATP:0000122': 'entity type', 'ATP:0000132': 'additional display', 'ATP:0000129': 'headline display', 'ATP:0000131': 'other primary display', 'ATP:0000130': 'review display', 'ATP:0000116': 'high priority', '': '' };
+//   const qualifierList = [ '', 'ATP:0000132', 'ATP:0000129', 'ATP:0000131', 'ATP:0000130', 'ATP:0000116' ];
+//   const curieToNameTaxon = { 'NCBITaxon:559292': 'S. cerevisiae S288C', 'NCBITaxon:6239': 'Caenorhabditis elegans' };
+
+  const biblioAction = useSelector(state => state.biblio.biblioAction);
+  const accessToken = useSelector(state => state.isLogged.accessToken);
+  const [topicEntityTags, setTopicEntityTags] = useState([]);
+  const [entityEntityMappings, setEntityEntityMappings] = useState({});
+  const biblioUpdatingEntityRemoveEntity = useSelector(state => state.biblio.biblioUpdatingEntityRemoveEntity);
+  const biblioUpdatingEntityAdd = useSelector(state => state.biblio.biblioUpdatingEntityAdd);
+  const referenceCurie = useSelector(state => state.biblio.referenceCurie);
+  const [totalTagsCount, setTotalTagsCount] = useState(undefined);
+  const [offset, setOffset] = useState(0);
+  //const [limit, setLimit] = useState(10);
+  const limit = 10; // fixed limit value for now
+
+
+  useEffect(() => {
+    const fetchMappings = async () => {
+      let config = {
+        headers: {
+          'content-type': 'application/json',
+          'authorization': 'Bearer ' + accessToken
+        }
+      };
+      const resultMappings = await axios.get(process.env.REACT_APP_RESTAPI + "/topic_entity_tag/map_entity_curie_to_name/?curie_or_reference_id=" + referenceCurie + "&token=" + accessToken,
+          config);
+      setEntityEntityMappings(resultMappings.data);
+    }
+    fetchMappings().then();
+  }, [accessToken, referenceCurie, biblioUpdatingEntityAdd, biblioUpdatingEntityRemoveEntity]);
+
+  useEffect(() => {
+    const fetchTotalTagsCount = async () => {
+      const resultTags = await axios.get(process.env.REACT_APP_RESTAPI + '/topic_entity_tag/by_reference/' + referenceCurie + "?count_only=true");
+      setTotalTagsCount(resultTags.data);
+    }
+    fetchTotalTagsCount().then();
+  }, [referenceCurie, biblioUpdatingEntityAdd, biblioUpdatingEntityRemoveEntity])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const resultTags = await axios.get(process.env.REACT_APP_RESTAPI + '/topic_entity_tag/by_reference/' + referenceCurie + "?offset=" + offset + "&limit=" + limit);
+      setTopicEntityTags(resultTags.data);
+    }
+    fetchData().then();
+  }, [referenceCurie, biblioUpdatingEntityAdd, biblioUpdatingEntityRemoveEntity, offset, limit]);
+
+  const changePage = (action) => {
+      let maxOffset= Math.max(0, Math.floor(totalTagsCount/limit) * limit);
+      switch (action){
+        case 'Next':
+          setOffset(Math.min(maxOffset, offset + limit));
+          break;
+        case 'Prev':
+          setOffset(Math.max(0, offset - limit));
+          break;
+        case 'First':
+          setOffset(0);
+          break;
+        case 'Last':
+          setOffset(maxOffset);
+          break;
+        default:
+          setOffset(0);
+          break;
+      }
+    }
+
+  return (
+      <div>
+        <Container fluid>
+          <RowDivider />
+          <Row className="form-group row" >
+            <Col className="form-label col-form-label" sm="3"><h3>Entity and Topic Editor</h3></Col></Row>
+          <Row className="form-group row" >
+            <Col className="div-grey-border" sm="1">topic</Col>
+            <Col className="div-grey-border" sm="1">entity type</Col>
+            <Col className="div-grey-border" sm="1">species (taxon)</Col>
+            <Col className="div-grey-border" sm="2">entity name</Col>
+            <Col className="div-grey-border" sm="2">entity curie</Col>
+            <Col className="div-grey-border" sm="1">qualifier</Col>
+            <Col className="div-grey-border" sm="3">internal notes</Col>
+            <Col className="div-grey-border" sm="1">button</Col>
+          </Row>
+          { topicEntityTags.map( (tetDict, index) => {
+            let qualifierValue = ''; let qualifierId = ''; let qualifierIndex = '';
+            // UI only allows display/selection of one priority qualifier, but someone could connect in the database multiple priority qualifier in topic_entity_tag_prop to the same topic_entity_tag, even though that would be wrong.
+            if ('props' in tetDict && tetDict['props'].length > 0) {
+              // for (const tetpDict of tetDict['props'].values())
+              for (const[indexPriority, tetpDict] of tetDict['props'].entries()) {
+                if ('qualifier' in tetpDict && tetpDict['qualifier'] !== '' && qualifierList.includes(tetpDict['qualifier'])) {
+                  qualifierId = tetpDict['topic_entity_tag_prop_id'];
+                  qualifierIndex = indexPriority;
+                  qualifierValue = tetpDict['qualifier']; } } }
+            const entityName = tetDict.alliance_entity in entityEntityMappings ? entityEntityMappings[tetDict.alliance_entity] : 'unknown';
+            if ( (biblioAction === 'entity') && (tetDict.topic !== 'ATP:0000122') ) { return ""; }
+            // else if ( (biblioAction === 'topic') && (tetDict.topic === 'ATP:0000122') ) { return ""; } // topic no longer a separate section
+            else {
+              return (
+                  <Row key={`geneEntityContainerrows ${tetDict.topic_entity_tag_id}`}>
+                    <Col className="div-grey-border" sm="1">{tetDict.topic in curieToNameAtp ? curieToNameAtp[tetDict.topic] : tetDict.topic }</Col>
+                    <Col className="div-grey-border" sm="1">{tetDict.entity_type in curieToNameAtp ? curieToNameAtp[tetDict.entity_type] : tetDict.entity_type }</Col>
+                    <Col className="div-grey-border" sm="1">{tetDict.taxon in curieToNameTaxon ? curieToNameTaxon[tetDict.taxon] : tetDict.taxon }</Col>
+                    <Col className="div-grey-border" sm="2">{entityName}</Col>
+                    <Col className="div-grey-border" sm="2">{tetDict.alliance_entity}</Col>
+
+                    <Col sm="1">
+                      {/* changeFieldEntityEditorPriority changes which value to display, but does not update database. ideally this would update the databasewithout reloading referenceJsonLive, because API would return entities in a different order, so things would jump. but if creating a new qualifier where there wasn't any, there wouldn't be a tetpId until created, and it wouldn't be in the prop when changing again. could get the tetpId from the post and inject it, but it starts to get more complicated.  needs to display to patch existing tetp prop, or post to create a new one */}
+                      <Form.Control as="select" id={`qualifier ${index} ${qualifierIndex} ${qualifierId}`} type="tetqualifierSelect" disabled="disabled" value={qualifierValue} onChange={(e) => dispatch(changeFieldEntityEditorPriority(e))} >
+                        { qualifierList.map((optionValue, index) => (
+                            <option key={`tetqualifierSelect ${optionValue}`} value={optionValue}>{curieToNameAtp[optionValue]}</option>
+                        ))}
+                      </Form.Control>
+                    </Col>
+
+                    <Col className="form-label col-form-label" sm="3" style={{position: 'relative'}}>
+              <span style={{position: 'absolute', top: '0.2em', right: '1.2em'}}>
+                <span style={{color: '#007bff'}}
+                      onClick={() => {
+                        dispatch(updateButtonBiblioEntityEditEntity(accessToken, tetDict.topic_entity_tag_id, {'note': tetDict.note || ''}, 'PATCH', 'UPDATE_BUTTON_BIBLIO_ENTITY_EDIT_NOTE')) } } >&#10003;</span><br/>
+                <span style={{color: '#dc3545'}}
+                      onClick={() => {
+                        dispatch(setFieldEntityEditor('note ' + index, ''));
+                        dispatch(updateButtonBiblioEntityEditEntity(accessToken, tetDict.topic_entity_tag_id, {'note': ''}, 'PATCH', 'UPDATE_BUTTON_BIBLIO_ENTITY_EDIT_NOTE')) } } >X</span>
+              </span>
+                      <Form.Control as="textarea" id={`note ${index}`} type="note" value={tetDict.note || ''} onChange={(e) => dispatch(changeFieldEntityEditor(e))} />
+                      <Button variant="outline-primary"
+                              onClick={() => {
+                                dispatch(updateButtonBiblioEntityEditEntity(accessToken, tetDict.topic_entity_tag_id, {'note': tetDict.note || ''}, 'PATCH', 'UPDATE_BUTTON_BIBLIO_ENTITY_EDIT_NOTE')) } } >
+                        Update note</Button>&nbsp;
+                      <Button variant="outline-danger"
+                              onClick={() => {
+                                dispatch(setFieldEntityEditor('note ' + index, ''));
+                                dispatch(updateButtonBiblioEntityEditEntity(accessToken, tetDict.topic_entity_tag_id, {'note': ''}, 'PATCH', 'UPDATE_BUTTON_BIBLIO_ENTITY_EDIT_NOTE')) } } >
+                        Remove note</Button>
+                    </Col>
+                    <Col className="form-label col-form-label" sm="1">
+                      <Button variant="outline-danger"
+                              disabled={biblioUpdatingEntityRemoveEntity[tetDict.topic_entity_tag_id] === true ? 'disabled' : ''}
+                              onClick={() => {
+                                dispatch(setBiblioEntityRemoveEntity(tetDict.topic_entity_tag_id, true));
+                                dispatch(updateButtonBiblioEntityEditEntity(accessToken, tetDict.topic_entity_tag_id, null, 'DELETE', 'UPDATE_BUTTON_BIBLIO_ENTITY_REMOVE_ENTITY')) } } >
+                        {biblioUpdatingEntityRemoveEntity[tetDict.topic_entity_tag_id] === true ? <Spinner animation="border" size="sm"/> : "Remove Entity"}</Button></Col>
+                  </Row> ) }
+          } ) }
+        </Container>
+        {totalTagsCount > 0 ?
+            <Pagination style={{display: 'flex', justifyContent: 'center', alignItems: 'center', height: '10vh'}}>
+              <Pagination.First  onClick={() => changePage('First')} />
+              <Pagination.Prev   onClick={() => changePage('Prev')} />
+              <Pagination.Item  disabled>{"Page " + (offset / limit + 1) + " of " + Math.ceil(totalTagsCount/limit)}</Pagination.Item>
+              <Pagination.Next   onClick={() => changePage('Next')} />
+              <Pagination.Last   onClick={() => changePage('Last')} />
+            </Pagination>
+            : null}
+      </div>);
+} // const EntityEditor
+
+
+//           <Col className="form-label col-form-label" sm="1"><Button variant="outline-danger" >Remove Entity</Button></Col>
+//           <Col className="form-label col-form-label" sm="1"><Button variant="outline-primary" disabled={disabledAddButton} onClick={() => createEntities(referenceJsonLive.curie)} >{biblioUpdatingEntityAdd > 0 ? <Spinner animation="border" size="sm"/> : "Add"}</Button></Col>
+
+
+// const ModalGeneric = ({showGenericModal, genericModalHeader, genericModalBody, onHideAction}) => {
+//   const dispatch = useDispatch();
+//   if (showGenericModal) {
+//     return (<Modal size="lg" show={showGenericModal} backdrop="static" onHide={() => dispatch(onHideAction)} >
+//              <Modal.Header closeButton><Modal.Title>{genericModalHeader}</Modal.Title></Modal.Header>
+//              <Modal.Body><div dangerouslySetInnerHTML={{__html:`${genericModalBody}`}}/></Modal.Body>
+//             </Modal>); }
+//   return null;
+// }
+
+const EntityCreate = () => {
+  const dispatch = useDispatch();
+  const referenceJsonLive = useSelector(state => state.biblio.referenceJsonLive);
+  const oktaGroups = useSelector(state => state.isLogged.oktaGroups);
+  const accessToken = useSelector(state => state.isLogged.accessToken);
+  const biblioAction = useSelector(state => state.biblio.biblioAction);
+  const biblioUpdatingEntityAdd = useSelector(state => state.biblio.biblioUpdatingEntityAdd);
+  const entityModalText = useSelector(state => state.biblio.entityModalText);
+  const entityText = useSelector(state => state.biblio.entityAdd.entitytextarea);
+  const noteText = useSelector(state => state.biblio.entityAdd.notetextarea);
+  const tetqualifierSelect = useSelector(state => state.biblio.entityAdd.tetqualifierSelect);
+  const taxonSelect = useSelector(state => state.biblio.entityAdd.taxonSelect);
+  const entityTypeSelect = useSelector(state => state.biblio.entityAdd.entityTypeSelect);
+  const entityResultList = useSelector(state => state.biblio.entityAdd.entityResultList);
+  const topicSelect = 'entity type ATP:0000122';
+//   let geneStringListDash = [];
+//   let geneStringListParen = [];
+//   if (geneResultList) {
+//     for (const geneResObject of geneResultList) {
+//       geneStringListParen.push(geneResObject.geneSymbol + " ( " + geneResObject.curie + " ) ");
+//       geneStringListDash.push(geneResObject.geneSymbol + " -- " + geneResObject.curie); } }
+
+  useEffect( () => {
+    if (!(taxonSelect === '' || taxonSelect === undefined)) {
+      dispatch(changeFieldEntityEntityList(entityText, accessToken, taxonSelect, curieToNameEntityType[entityTypeSelect])) }
+  }, [entityText, taxonSelect]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function createEntities(refCurie) {
+    const forApiArray = []
+    if ( entityResultList && entityResultList.length > 0 ) {
+      for (const entityResult of entityResultList.values()) {
+        console.log(entityResult);
+        console.log(entityResult.curie);
+        if (entityResult.curie !== 'no Alliance curie') {
+          let updateJson = {};
+          updateJson['reference_curie'] = refCurie;
+          updateJson['topic'] = biblioAction === 'entity' ? 'ATP:0000122' : 'insert topic here';
+          // updateJson['entity_type'] = 'ATP:0000005';
+          updateJson['entity_type'] = entityTypeSelect;
+          updateJson['alliance_entity'] = entityResult.curie;
+          // updateJson['taxon'] = 'NCBITaxon:559292';	// to hardcode if they don't want a dropdown
+          updateJson['taxon'] = taxonSelect;
+          updateJson['note'] = noteText;
+          if (tetqualifierSelect && tetqualifierSelect !== '') {
+            updateJson['props'] = [ { 'qualifier': tetqualifierSelect } ]; }
+          // console.log(updateJson);
+          let subPath = 'topic_entity_tag/';
+          let method = 'POST';
+          // let array = [ subPath, updateJson, method, 0, null, null]
+          let array = [ subPath, updateJson, method]
+          forApiArray.push( array );
+    } } }
+
+    let dispatchCount = forApiArray.length;
+
+    // console.log('dispatchCount ' + dispatchCount)
+    dispatch(setBiblioUpdatingEntityAdd(dispatchCount))
+
+    for (const arrayData of forApiArray.values()) {
+      arrayData.unshift(accessToken);
+      console.log(arrayData);
+      dispatch(updateButtonBiblioEntityAdd(arrayData))
+    }
+  }
+
+  const modToTaxon = { 'ZFIN': ['NCBITaxon:7955'], 'FB': ['NCBITaxon:7227'], 'WB': ['NCBITaxon:6239'], 'RGD': ['NCBITaxon:10116'], 'MGI': ['NCBITaxon:10090'], 'SGD': ['NCBITaxon:559292'], 'XB': ['NCBITaxon:8355', 'NCBITaxon:8364'] }
+  const unsortedTaxonList = [ '', 'NCBITaxon:559292', 'NCBITaxon:6239', 'NCBITaxon:7227', 'NCBITaxon:7955', 'NCBITaxon:10116', 'NCBITaxon:10090', 'NCBITaxon:8355', 'NCBITaxon:8364', 'NCBITaxon:9606' ];
+  let taxonList = unsortedTaxonList.sort((a, b) => (curieToNameTaxon[a] > curieToNameTaxon[b] ? 1 : -1));
+  const entityTypeList = ['ATP:0000005', 'ATP:0000006'];
+  const access = getOktaModAccess(oktaGroups);
+  // const access = 'WB';	// uncomment if you have developer okta access and need to test a specific mod
+  if (access in modToTaxon) {
+    let filteredTaxonList = taxonList.filter((x) => !modToTaxon[access].includes(x));
+    taxonList = modToTaxon[access].concat(filteredTaxonList); }
+  useEffect( () => {
+    if (access in modToTaxon) {
+      dispatch(changeFieldEntityAddTaxonSelect(modToTaxon[access][0])) }
+  }, [access]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // const taxonSelect = 'NCBITaxon:4932';	// to hardcode if they don't want a dropdown
+  // const taxonSelect = 'NCBITaxon:6239';	// to hardcode if they don't want a dropdown
+  // figure out if they want general disabling to work the same for the whole row, in which case combine the next two variables
+  const disabledEntityList = (taxonSelect === '' || taxonSelect === undefined) ? 'disabled' : '';
+  const disabledAddButton = (taxonSelect === '' || taxonSelect === undefined) ? 'disabled' : '';
+
+  return (
+    <Container fluid>
+    <ModalGeneric showGenericModal={entityModalText !== '' ? true : false} genericModalHeader="Entity Error"
+                  genericModalBody={entityModalText} onHideAction={setEntityModalText('')} />
+    <RowDivider />
+    <Row className="form-group row" >
+      <Col className="form-label col-form-label" sm="3"><h3>Entity and Topic Addition</h3></Col></Row>
+    <Row className="form-group row" >
+      <Col className="div-grey-border" sm="1">topic</Col>
+      <Col className="div-grey-border" sm="1">entity type</Col>
+      <Col className="div-grey-border" sm="1">species</Col>
+      <Col className="div-grey-border" sm="2">entity list (one per line, case insensitive)</Col>
+      <Col className="div-grey-border" sm="2">entity validation</Col>
+      <Col className="div-grey-border" sm="1">qualifier</Col>
+      <Col className="div-grey-border" sm="3">internal notes</Col>
+      <Col className="div-grey-border" sm="1">button</Col>
+    </Row>
+    <Row className="form-group row" >
+      <Col sm="1">
+        <Form.Control as="select" id="topicSelect" type="topicSelect" value={topicSelect} onChange={(e) => {} } >
+          <option key={`topicSelect ${topicSelect}`} value={topicSelect}>{topicSelect}</option>
+        </Form.Control>
+      </Col>
+      <Col sm="1">
+        <Form.Control as="select" id="entityTypeSelect" type="entityTypeSelect" value={entityTypeSelect} onChange={(e) => { dispatch(changeFieldEntityAddGeneralField(e)) } } >
+          { entityTypeList.map((optionValue, index) => (
+            <option key={`entityTypeSelect ${optionValue}`} value={optionValue}>{curieToNameEntityType[optionValue]} {optionValue}</option>
+          ))}
+        </Form.Control>
+      </Col>
+      <Col sm="1">
+        <Form.Control as="select" id="taxonSelect" type="taxonSelect" value={taxonSelect} onChange={(e) => { dispatch(changeFieldEntityAddGeneralField(e)) } } >
+          { taxonList.map((optionValue, index) => (
+            <option key={`taxonSelect ${optionValue}`} value={optionValue}>{curieToNameTaxon[optionValue]}</option>
+          ))}
+        </Form.Control>
+      </Col>
+      <Col className="form-label col-form-label" sm="2" >
+        <Form.Control as="textarea" id="entitytextarea" type="entitytextarea" value={entityText} disabled={disabledEntityList} onChange={(e) => { dispatch(changeFieldEntityAddGeneralField(e)); } } />
+      </Col>
+      <Col className="form-label col-form-label" sm="2" >
+        <Container>
+          { entityResultList && entityResultList.length > 0 && entityResultList.map( (entityResult, index) => {
+            const colDisplayClass = (entityResult.curie === 'no Alliance curie') ? 'Col-display-warn' : 'Col-display';
+            return (
+              <Row key={`entityEntityContainerrows ${index}`}>
+                <Col className={`Col-general ${colDisplayClass} Col-display-left`} sm="5">{entityResult.entityTypeSymbol}</Col>
+                <Col className={`Col-general ${colDisplayClass} Col-display-right`} sm="7">{entityResult.curie}</Col>
+              </Row>)
+          } ) }
+        </Container>
+      </Col>
+      <Col sm="1">
+        <Form.Control as="select" id="tetqualifierSelect" type="tetqualifierSelect" value={tetqualifierSelect} onChange={(e) => dispatch(changeFieldEntityAddGeneralField(e))} >
+          { qualifierList.map((optionValue, index) => (
+            <option key={`tetqualifierSelect ${optionValue}`} value={optionValue}>{curieToNameAtp[optionValue]}</option>
+          ))}
+        </Form.Control>
+      </Col>
+      <Col className="form-label col-form-label" sm="3">
+        <Form.Control as="textarea" id="notetextarea" type="notetextarea" value={noteText} onChange={(e) => dispatch(changeFieldEntityAddGeneralField(e))} />
+      </Col>
+      <Col className="form-label col-form-label" sm="1"><Button variant="outline-primary" disabled={disabledAddButton} onClick={() => createEntities(referenceJsonLive.curie)} >{biblioUpdatingEntityAdd > 0 ? <Spinner animation="border" size="sm"/> : "Add"}</Button></Col>
+    </Row></Container>);
+}
+
+export default BiblioFileManagement;

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -1,39 +1,39 @@
-
-import { useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import {useCallback} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Spinner from "react-bootstrap/Spinner";
 import Button from 'react-bootstrap/Button';
 import axios from "axios";
-
-
-import { getOktaModAccess } from '../Biblio';
 import RowDivider from './RowDivider';
-import { RowDisplayString } from './BiblioDisplay';
+import {RowDisplayString} from './BiblioDisplay';
 import ModalGeneric from './ModalGeneric';
 
-import { fileUploadResult, setFileUploadingModalText } from '../../actions/biblioActions';
-import { setFileUploadingCount } from '../../actions/biblioActions';
-import { setFileUploadingShowModal } from '../../actions/biblioActions';
-import { downloadReferencefile } from '../../actions/biblioActions';
+import {
+  downloadReferencefile,
+  fileUploadResult,
+  setFileUploadingCount,
+  setFileUploadingModalText,
+  setFileUploadingShowModal
+} from '../../actions/biblioActions';
 
 import {useDropzone} from 'react-dropzone';
-
-
-export const curieToNameEntityType = { 'ATP:0000005': 'gene', 'ATP:0000006': 'allele' };
+import {getOktaModAccess} from "../Biblio";
 
 const BiblioFileManagement = () => {
-  return (<>
-            <Container>
-              <FileEditor />
-              <RowDivider />
-              <BiblioCitationDisplay key="filemanagementCitationDisplay" />
-              <FileUpload main_or_supp="main" />
-              <FileUpload main_or_supp="supplement" />
-            </Container>
-          </>); }
+  return (
+      <>
+        <Container>
+          <FileEditor />
+          <RowDivider />
+          <BiblioCitationDisplay key="filemanagementCitationDisplay" />
+          <FileUpload main_or_supp="main" />
+          <FileUpload main_or_supp="supplement" />
+        </Container>
+      </>
+  );
+}
 
 const FileUpload = ({main_or_supp}) => {
   const dispatch = useDispatch();
@@ -56,21 +56,21 @@ const FileUpload = ({main_or_supp}) => {
         reader.onload = () => {}
         reader.readAsBinaryString(file);
         const formData = new FormData();
-          formData.append("file", file);
-          let url = process.env.REACT_APP_RESTAPI + "/reference/referencefile/file_upload/?reference_curie=" + referenceCurie + "&display_name=" + file.name.split(".").slice(0, -1) + "&file_class=" + main_or_supp + "&file_publication_status=final&file_extension=" + file.name.split(".").pop()+ "&pdf_type=null&is_annotation=false&mod_abbreviation=WB";
-          axios.post(url, formData, {
-            headers: {
-              "Authorization": "Bearer " + accessToken,
-              "Content-Type": "multipart/form-data",
-            }
-          })
-          .then((res) => {
-            dispatch(fileUploadResult(file.name, 'success'))
-          })
-          .catch((error) => {
-            dispatch(fileUploadResult(file.name, error.response.data.detail))
-            console.log(error)
-          });
+        formData.append("file", file);
+        let url = process.env.REACT_APP_RESTAPI + "/reference/referencefile/file_upload/?reference_curie=" + referenceCurie + "&display_name=" + file.name.split(".").slice(0, -1) + "&file_class=" + main_or_supp + "&file_publication_status=final&file_extension=" + file.name.split(".").pop()+ "&pdf_type=null&is_annotation=false&mod_abbreviation=WB";
+        axios.post(url, formData, {
+          headers: {
+            "Authorization": "Bearer " + accessToken,
+            "Content-Type": "multipart/form-data",
+          }
+        })
+            .then((res) => {
+              dispatch(fileUploadResult(file.name, 'success'))
+            })
+            .catch((error) => {
+              dispatch(fileUploadResult(file.name, error.response.data.detail))
+              console.log(error)
+            });
         //reader.readAsBinaryString();
       });
     }
@@ -79,20 +79,20 @@ const FileUpload = ({main_or_supp}) => {
   const {getRootProps, getInputProps} = useDropzone({onDrop})
 
   return (
-    <>
-      <ModalGeneric showGenericModal={fileUploadingShowModal}
-                    genericModalHeader="File Upload Result"
-                    genericModalBody={fileUploadingModalText}
-                    onHideAction={setFileUploadingShowModal(false)} />
-      <Row key={main_or_supp} >
-        <Col className="Col-general Col-display Col-display-left" lg={{ span: 2 }}>{main_or_supp} file</Col>
-        <Col lg={{ span: 10 }}>
-          <div className="dropzone" {...getRootProps()} >
-            <input {...getInputProps()} />
-            <p>Drag and drop {main_or_supp} file here, or click to select files</p>
-          </div></Col>
-      </Row>
-    </>
+      <>
+        <ModalGeneric showGenericModal={fileUploadingShowModal}
+                      genericModalHeader="File Upload Result"
+                      genericModalBody={fileUploadingModalText}
+                      onHideAction={setFileUploadingShowModal(false)} />
+        <Row key={main_or_supp} >
+          <Col className="Col-general Col-display Col-display-left" lg={{ span: 2 }}>{main_or_supp} file</Col>
+          <Col lg={{ span: 10 }}>
+            <div className="dropzone" {...getRootProps()} >
+              <input {...getInputProps()} />
+              <p>Drag and drop {main_or_supp} file here, or click to select files</p>
+            </div></Col>
+        </Row>
+      </>
   );
 }
 
@@ -112,60 +112,80 @@ const FileEditor = () => {
   const oktaGroups = useSelector(state => state.isLogged.oktaGroups);
   const accessToken = useSelector(state => state.isLogged.accessToken);
   const loadingFileNames = useSelector(state => state.biblio.loadingFileNames);
+
+  const compareFn = (a, b) => {
+    if (a.file_class + a.display_name + a.file_extension > b.file_class + b.display_name + b.file_extension) {
+      return 1;
+    }
+    if (a.file_class + a.display_name + a.file_extension < b.file_class + b.display_name + b.file_extension) {
+      return -1;
+    }
+    return 0;
+  }
+
+  const getDisplayRowsFromReferenceFiles = (referenceFilesArray, hasAccess) => {
+    return referenceFilesArray.map((referenceFile, index) => {
+      const source = referenceFile.referencefile_mods.map(
+          (mod_abbreviation) => mod_abbreviation === null ? "PMC" : mod_abbreviation).join(", ");
+      let filename = referenceFile.display_name + '.' + referenceFile.file_extension;
+      let referencefileValue = (<div>{filename}</div>);
+      if (hasAccess) {
+        referencefileValue = (<div>
+          <button className='button-to-link' onClick={() =>
+              dispatch(downloadReferencefile(referenceFile.referencefile_id, filename, accessToken))
+          }>{filename}</button>
+          &nbsp;{loadingFileNames.has(filename) ? <Spinner animation="border" size="sm"/> : null}</div>);
+      }
+      return (
+          <Row key={`${fieldName} ${index}`} className="Row-general" xs={2} md={4} lg={6}>
+            <Col className={`Col-general ${cssDisplayLeft} `} lg={{span: 2}}>{referenceFile.file_class}</Col>
+            <Col className={`Col-general ${cssDisplay} `} lg={{span: 3}}>{referencefileValue}</Col>
+            <Col className={`Col-general ${cssDisplay} `} lg={{span: 2}}>{source}</Col>
+            <Col className={`Col-general ${cssDisplay} `}
+                 lg={{span: 1}}>{referenceFile.pdf_type === 'null' ? 'pdf' : referenceFile.pdf_type}</Col>
+            <Col className={`Col-general ${cssDisplay} `}
+                 lg={{span: 2}}>{referenceFile.file_publication_status}</Col>
+            <Col className={`Col-general ${cssDisplayRight} `} lg={{span: 2}}><Button
+                variant="outline-primary">delete</Button></Col>
+          </Row>);
+    });
+  }
   let cssDisplayLeft = 'Col-display Col-display-left';
   let cssDisplay = 'Col-display';
   let cssDisplayRight = 'Col-display Col-display-right';
   if (displayOrEditor === 'editor') {
     cssDisplay = 'Col-editor-disabled';
-    cssDisplayLeft = ''; cssDisplayRight = 'Col-editor-disabled'; }
+    cssDisplayLeft = ''; cssDisplayRight = 'Col-editor-disabled';
+  }
+  let rowReferencefileElements = [];
   const access = getOktaModAccess(oktaGroups);
   if ('referencefiles' in referenceJsonLive && referenceJsonLive['referencefiles'] !== null) {
-    const rowReferencefileElements = []
+    let referenceFilesWithAccess = referenceJsonLive['referencefiles']
+        .filter((referenceFile) => access === 'developer' || referenceFile.referencefile_mods
+            .some((mod) => mod.mod_abbreviation === access || mod.mod_abbreviation === null));
 
-    // for (const[index, referencefileDict] of referenceJsonLive['referencefiles'].filter(x => x['file_class'] === 'main').entries())
-    for (const[index, referencefileDict] of referenceJsonLive['referencefiles'].entries()) {
-      let is_ok = false;
-      let allowed_mods = [];
-      for (const rfm of referencefileDict['referencefile_mods']) {
-        if (rfm['mod_abbreviation'] !== null) { allowed_mods.push(rfm['mod_abbreviation']); }
-          else { allowed_mods.push('PMC'); }
-        if (rfm['mod_abbreviation'] === null || rfm['mod_abbreviation'] === access) { is_ok = true; }
-      }
-      const source = allowed_mods.join(", ");
-      let filename = referencefileDict['display_name'] + '.' + referencefileDict['file_extension'];
-      let referencefileValue = (<div>{filename}</div>);
-      if (access === 'developer') { is_ok = true; }
-        else if (access === 'No') { is_ok = false; referencefileValue = (<div>{filename}</div>); }
-      if (is_ok) {
-        referencefileValue = (<div><button className='button-to-link' onClick={ () =>
-            dispatch(downloadReferencefile(referencefileDict['referencefile_id'], filename, accessToken))
-        } >{filename}</button>&nbsp;{loadingFileNames.has(filename) ? <Spinner animation="border" size="sm"/> : null}</div>); }
-        const referencefileRow = (
-            <Row key={`${fieldName} ${index}`} className="Row-general" xs={2} md={4} lg={6}>
-              <Col className={`Col-general ${cssDisplayLeft} `} lg={{ span: 2 }}>{referencefileDict['file_class']}</Col>
-              <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}>{referencefileValue}</Col>
-              <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}>{source}</Col>
-              <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}>{ referencefileDict['pdf_type'] === 'null' ? 'pdf' : referencefileDict['pdf_type'] }</Col>
-              <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}>{referencefileDict['file_publication_status']}</Col>
-              <Col className={`Col-general ${cssDisplayRight} `} lg={{ span: 2 }}><Button variant="outline-primary">delete</Button></Col>
-            </Row>);
-        rowReferencefileElements.push( referencefileRow );
-      }
+    let referenceFilesNoAccess = referenceJsonLive['referencefiles']
+        .filter((referenceFile) => access !== 'developer' && referenceFile.referencefile_mods
+            .every((mod) => mod.mod_abbreviation !== access && mod.mod_abbreviation !== null));
 
+    referenceFilesWithAccess.sort(compareFn);
+    referenceFilesNoAccess.sort(compareFn);
+    rowReferencefileElements = [...getDisplayRowsFromReferenceFiles(referenceFilesWithAccess, true),
+        ...getDisplayRowsFromReferenceFiles(referenceFilesNoAccess, false)];
+    }
     if (rowReferencefileElements.length > 0) {
       const referencefileHeaderRow = (
-              <Row key={`${fieldName} header`} className="Row-general" xs={2} md={4} lg={6}>
-                <Col className={`Col-general ${cssDisplayLeft} `} lg={{ span: 2 }}><strong>File Class</strong></Col>
-                <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}><strong>File Name</strong></Col>
-                <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}><strong>Source</strong></Col>
-                <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}><strong>Pdf Type</strong></Col>
-                <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}><strong>File Publication Status</strong></Col>
-                <Col className={`Col-general ${cssDisplayRight} `} lg={{ span: 2 }}><strong>Delete placeholder</strong></Col>
-              </Row>);
-      rowReferencefileElements.unshift( referencefileHeaderRow ); }
-
-    return (<>{rowReferencefileElements}</>); }
-  else { return null; } 
+          <Row key={`${fieldName} header`} className="Row-general" xs={2} md={4} lg={6}>
+            <Col className={`Col-general ${cssDisplayLeft} `} lg={{ span: 2 }}><strong>File Class</strong></Col>
+            <Col className={`Col-general ${cssDisplay} `} lg={{ span: 3 }}><strong>File Name</strong></Col>
+            <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}><strong>Source</strong></Col>
+            <Col className={`Col-general ${cssDisplay} `} lg={{ span: 1 }}><strong>Pdf Type</strong></Col>
+            <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}><strong>File Publication Status</strong></Col>
+            <Col className={`Col-general ${cssDisplayRight} `} lg={{ span: 2 }}><strong>Delete placeholder</strong></Col>
+          </Row>);
+      rowReferencefileElements.unshift( referencefileHeaderRow );
+      return (<>{rowReferencefileElements}</>);
+    } else { return null; }
 }
 
 export default BiblioFileManagement;

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -9,7 +9,7 @@ import axios from "axios";
 import { RowDisplayString } from './BiblioDisplay';
 import ModalGeneric from './ModalGeneric';
 
-import { fileUploadResult } from '../../actions/biblioActions';
+import {fileUploadResult, setFileUploadingModalText} from '../../actions/biblioActions';
 import { setFileUploadingCount } from '../../actions/biblioActions';
 import { setFileUploadingShowModal } from '../../actions/biblioActions';
 
@@ -32,20 +32,15 @@ const FileUpload = ({main_or_supp}) => {
   const referenceCurie = useSelector(state => state.biblio.referenceCurie);
   const accessToken = useSelector(state => state.isLogged.accessToken);
   const fileUploadingShowModal = useSelector(state => state.biblio.fileUploadingShowModal);
+  const fileUploadingModalText = useSelector(state => state.biblio.fileUploadingModalText);
   const fileUploadResultMap = useSelector(state => state.biblio.fileUploadResultMap);
-  const [modalText, setModalText] = useState('');
 
   // https://react-dropzone.js.org/
   const onDrop = useCallback((acceptedFiles) => {
-    if (acceptedFiles.filter( (file) => file.name.split('.').length !== 1).length > 0) {
-console.log('IF');
-      setModalText('Upload files need to have exactly one period');
+    if (acceptedFiles.filter( (file) => file.name.split('.').length !== 2).length > 0) {
+      dispatch(setFileUploadingModalText('Upload files need to have exactly one period'));
       dispatch(setFileUploadingShowModal(true));
     } else {
-console.log('ELSE');
-      setModalText(Object.entries(fileUploadResultMap).filter( ([key, value]) => value !== 'success' ).length > 0 ?
-        Object.entries(fileUploadResultMap).map( ([key, value]) => key + ' ' + value ).join("<br/>") :
-        'All files uploaded');
       dispatch(setFileUploadingCount(acceptedFiles.length));
       acceptedFiles.forEach((file) => {
         const reader = new FileReader()
@@ -66,9 +61,9 @@ console.log('ELSE');
             dispatch(fileUploadResult(file.name, 'success'))
           })
           .catch((error) => {
-            dispatch(fileUploadResult(file.name, error))
+            dispatch(fileUploadResult(file.name, error.response.data.detail))
             console.log(error)
-          })
+          });
         //reader.readAsBinaryString();
       });
     }
@@ -77,8 +72,10 @@ console.log('ELSE');
 
   return (
     <>
-      <ModalGeneric showGenericModal={fileUploadingShowModal} genericModalHeader="File Upload Result"
-                    genericModalBody={modalText} onHideAction={setFileUploadingShowModal(false)} />
+      <ModalGeneric showGenericModal={fileUploadingShowModal}
+                    genericModalHeader="File Upload Result"
+                    genericModalBody={fileUploadingModalText}
+                    onHideAction={setFileUploadingShowModal(false)} />
       <Row key={main_or_supp} >
         <Col className="Col-general Col-display Col-display-left" lg={{ span: 2 }}>{main_or_supp} file</Col>
         <Col lg={{ span: 10 }}>

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -52,6 +52,7 @@ const FileUpload = ({main_or_supp}) => {
     if (process.env.REACT_APP_DEV_OR_STAGE_OR_PROD === 'prod') {
       access = 'No';
     } else {
+      // This means that developers upload files with PMC (all) access in dev environment only - no access on prod
       access = null;
     }
   }

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -66,7 +66,8 @@ const FileUpload = ({main_or_supp}) => {
         //reader.readAsBinaryString();
       });
     }
-  }, [])
+  }, [dispatch, accessToken, main_or_supp, referenceCurie]);
+
   const {getRootProps, getInputProps} = useDropzone({onDrop})
 
   return (

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -31,6 +31,7 @@ import axios from "axios";
 import Pagination from "react-bootstrap/Pagination";
 
 import {useDropzone} from 'react-dropzone';
+import styled from 'styled-components';
 
 export const curieToNameEntityType = { 'ATP:0000005': 'gene', 'ATP:0000006': 'allele' };
 
@@ -43,19 +44,32 @@ const BiblioFileManagement = () => {
             <EntityEditor key="entityEditor" />
           </>); }
 
+
+const Container2 = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  border-width: 2px;
+  border-radius: 2px;
+  border-style: dashed;
+  background-color: #fafafa;
+  color: #bdbdbd;
+  outline: none;
+  transition: border .24s ease-in-out;
+`;
+
+
 const FileUpload = () => {
   const {acceptedFiles, getRootProps, getInputProps} = useDropzone();
   return (
-    <section className="container">
-      <div {...getRootProps({className: 'dropzone'})}>
+    <div>
+      <Container2 {...getRootProps({className: 'dropzone'})}>
         <input {...getInputProps()} />
         <p>Drag 'n' drop some files here, or click to select files</p>
-      </div>
-      <aside>
-        <h4>Files</h4>
-        <ul></ul>
-      </aside>
-    </section>
+      </Container2>
+    </div>
   );
 }
 

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -1,5 +1,5 @@
 
-import {useEffect, useState} from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { changeFieldEntityEntityList } from '../../actions/biblioActions';
@@ -31,7 +31,6 @@ import axios from "axios";
 import Pagination from "react-bootstrap/Pagination";
 
 import {useDropzone} from 'react-dropzone';
-import styled from 'styled-components';
 
 export const curieToNameEntityType = { 'ATP:0000005': 'gene', 'ATP:0000006': 'allele' };
 
@@ -39,37 +38,40 @@ const BiblioFileManagement = () => {
   return (<>
             <Container>
               <BiblioCitationDisplay key="filemanagementCitationDisplay" />
-              <FileUpload />
+              <FileUpload main_or_supp="main" />
+              <FileUpload main_or_supp="supplemental" />
             </Container>
             <EntityEditor key="entityEditor" />
           </>); }
 
 
-const Container2 = styled.div`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 20px;
-  border-width: 2px;
-  border-radius: 2px;
-  border-style: dashed;
-  background-color: #fafafa;
-  color: #bdbdbd;
-  outline: none;
-  transition: border .24s ease-in-out;
-`;
+const FileUpload = ({main_or_supp}) => {
+//   const label_type = main_or_supp;
+  const onDrop = useCallback((acceptedFiles) => {
+    acceptedFiles.forEach((file) => {
+      const reader = new FileReader()
 
-
-const FileUpload = () => {
-  const {acceptedFiles, getRootProps, getInputProps} = useDropzone();
+      reader.onabort = () => console.log('file reading was aborted')
+      reader.onerror = () => console.log('file reading has failed')
+      reader.onload = () => {
+      // Do whatever you want with the file contents
+        const binaryStr = reader.result
+        console.log(binaryStr)
+      }
+      reader.readAsArrayBuffer(file)
+    })
+    
+  }, [])
+  const {getRootProps, getInputProps} = useDropzone({onDrop})
   return (
-    <div>
-      <Container2 {...getRootProps({className: 'dropzone'})}>
-        <input {...getInputProps()} />
-        <p>Drag 'n' drop some files here, or click to select files</p>
-      </Container2>
-    </div>
+    <Row key={main_or_supp} >
+      <Col className="Col-general Col-display Col-display-left" lg={{ span: 2 }}>{main_or_supp} file</Col>
+      <Col lg={{ span: 10 }}>
+        <div className="dropzone" {...getRootProps()} >
+          <input {...getInputProps()} />
+          <p>Drag and drop {main_or_supp} files here, or click to select files</p>
+        </div></Col>
+    </Row>
   );
 }
 

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -1,34 +1,11 @@
 
-import { useEffect, useState, useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-
-import { changeFieldEntityEntityList } from '../../actions/biblioActions';
-import { changeFieldEntityAddGeneralField } from '../../actions/biblioActions';
-import { changeFieldEntityAddTaxonSelect } from '../../actions/biblioActions';
-import { updateButtonBiblioEntityAdd } from '../../actions/biblioActions';
-import { setBiblioUpdatingEntityAdd } from '../../actions/biblioActions';
-import { updateButtonBiblioEntityEditEntity } from '../../actions/biblioActions';
-import { setBiblioEntityRemoveEntity } from '../../actions/biblioActions';
-import { setEntityModalText } from '../../actions/biblioActions';
-import { changeFieldEntityEditor } from '../../actions/biblioActions';
-import { setFieldEntityEditor } from '../../actions/biblioActions';
-import { changeFieldEntityEditorPriority } from '../../actions/biblioActions';
-
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import { RowDisplayString } from './BiblioDisplay';
-
-import RowDivider from './RowDivider';
-import ModalGeneric from './ModalGeneric';
-
-import { getOktaModAccess } from '../Biblio';
-
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
-import Form from 'react-bootstrap/Form';
-import Button from 'react-bootstrap/Button'
-import Spinner from 'react-bootstrap/Spinner'
 import axios from "axios";
-import Pagination from "react-bootstrap/Pagination";
 
 import {useDropzone} from 'react-dropzone';
 
@@ -39,27 +16,40 @@ const BiblioFileManagement = () => {
             <Container>
               <BiblioCitationDisplay key="filemanagementCitationDisplay" />
               <FileUpload main_or_supp="main" />
-              <FileUpload main_or_supp="supplemental" />
+              <FileUpload main_or_supp="supplement" />
             </Container>
-            <EntityEditor key="entityEditor" />
           </>); }
 
 
 const FileUpload = ({main_or_supp}) => {
+  const referenceCurie = useSelector(state => state.biblio.referenceCurie);
+  const accessToken = useSelector(state => state.isLogged.accessToken);
+
 //   const label_type = main_or_supp;
   const onDrop = useCallback((acceptedFiles) => {
     acceptedFiles.forEach((file) => {
       const reader = new FileReader()
-
       reader.onabort = () => console.log('file reading was aborted')
       reader.onerror = () => console.log('file reading has failed')
-      reader.onload = () => {
-      // Do whatever you want with the file contents
-        const binaryStr = reader.result
-        console.log(binaryStr)
-      }
-      reader.readAsArrayBuffer(file)
-    })
+      reader.onload = () => {}
+      reader.readAsBinaryString(file);
+      const formData = new FormData();
+        formData.append("file", file);
+        let url = process.env.REACT_APP_RESTAPI + "/reference/referencefile/file_upload/?reference_curie=" + referenceCurie + "&display_name=" + file.name.split(".").slice(0, -1) + "&file_class=" + main_or_supp + "&file_publication_status=final&file_extension=" + file.name.split(".").pop()+ "&pdf_type=null&is_annotation=false&mod_abbreviation=WB";
+        axios.post(url, formData, {
+          headers: {
+            "Authorization": "Bearer " + accessToken,
+            "Content-Type": "multipart/form-data",
+          }
+        })
+            .then((res) => {
+
+            })
+            .catch((error) => {
+              console.log(error)
+            })
+      //reader.readAsBinaryString();
+    });
     
   }, [])
   const {getRootProps, getInputProps} = useDropzone({onDrop})
@@ -69,7 +59,7 @@ const FileUpload = ({main_or_supp}) => {
       <Col lg={{ span: 10 }}>
         <div className="dropzone" {...getRootProps()} >
           <input {...getInputProps()} />
-          <p>Drag and drop {main_or_supp} files here, or click to select files</p>
+          <p>Drag and drop {main_or_supp} file here, or click to select files</p>
         </div></Col>
     </Row>
   );
@@ -80,338 +70,6 @@ const BiblioCitationDisplay = () => {
   const referenceJsonDb = useSelector(state => state.biblio.referenceJsonDb);
   const fieldName = 'citation';
   return (<RowDisplayString key={fieldName} fieldName={fieldName} referenceJsonLive={referenceJsonLive} referenceJsonDb={referenceJsonDb} />);
-}
-
-
-  const curieToNameAtp = { 'ATP:0000005': 'gene', 'ATP:0000006': 'allele', 'ATP:0000122': 'entity type', 'ATP:0000132': 'additional display', 'ATP:0000129': 'headline display', 'ATP:0000131': 'other primary display', 'ATP:0000130': 'review display', 'ATP:0000116': 'high priority', '': '' };
-  const qualifierList = [ '', 'ATP:0000131', 'ATP:0000132', 'ATP:0000130', 'ATP:0000129', 'ATP:0000116' ];
-  const curieToNameTaxon = { 'NCBITaxon:559292': 'Saccharomyces cerevisiae', 'NCBITaxon:6239': 'Caenorhabditis elegans', 'NCBITaxon:7227': 'Drosophila melanogaster', 'NCBITaxon:7955': 'Danio rerio', 'NCBITaxon:10116': 'Rattus norvegicus', 'NCBITaxon:10090': 'Mus musculus', 'NCBITaxon:8355': 'Xenopus laevis', 'NCBITaxon:8364': 'Xenopus tropicalis', 'NCBITaxon:9606': 'Homo sapiens', '': '' };
-
-const EntityEditor = () => {
-  const dispatch = useDispatch();
-//   const curieToNameAtp = { 'ATP:0000005': 'gene', 'ATP:0000122': 'entity type', 'ATP:0000132': 'additional display', 'ATP:0000129': 'headline display', 'ATP:0000131': 'other primary display', 'ATP:0000130': 'review display', 'ATP:0000116': 'high priority', '': '' };
-//   const qualifierList = [ '', 'ATP:0000132', 'ATP:0000129', 'ATP:0000131', 'ATP:0000130', 'ATP:0000116' ];
-//   const curieToNameTaxon = { 'NCBITaxon:559292': 'S. cerevisiae S288C', 'NCBITaxon:6239': 'Caenorhabditis elegans' };
-
-  const biblioAction = useSelector(state => state.biblio.biblioAction);
-  const accessToken = useSelector(state => state.isLogged.accessToken);
-  const [topicEntityTags, setTopicEntityTags] = useState([]);
-  const [entityEntityMappings, setEntityEntityMappings] = useState({});
-  const biblioUpdatingEntityRemoveEntity = useSelector(state => state.biblio.biblioUpdatingEntityRemoveEntity);
-  const biblioUpdatingEntityAdd = useSelector(state => state.biblio.biblioUpdatingEntityAdd);
-  const referenceCurie = useSelector(state => state.biblio.referenceCurie);
-  const [totalTagsCount, setTotalTagsCount] = useState(undefined);
-  const [offset, setOffset] = useState(0);
-  //const [limit, setLimit] = useState(10);
-  const limit = 10; // fixed limit value for now
-
-
-  useEffect(() => {
-    const fetchMappings = async () => {
-      let config = {
-        headers: {
-          'content-type': 'application/json',
-          'authorization': 'Bearer ' + accessToken
-        }
-      };
-      const resultMappings = await axios.get(process.env.REACT_APP_RESTAPI + "/topic_entity_tag/map_entity_curie_to_name/?curie_or_reference_id=" + referenceCurie + "&token=" + accessToken,
-          config);
-      setEntityEntityMappings(resultMappings.data);
-    }
-    fetchMappings().then();
-  }, [accessToken, referenceCurie, biblioUpdatingEntityAdd, biblioUpdatingEntityRemoveEntity]);
-
-  useEffect(() => {
-    const fetchTotalTagsCount = async () => {
-      const resultTags = await axios.get(process.env.REACT_APP_RESTAPI + '/topic_entity_tag/by_reference/' + referenceCurie + "?count_only=true");
-      setTotalTagsCount(resultTags.data);
-    }
-    fetchTotalTagsCount().then();
-  }, [referenceCurie, biblioUpdatingEntityAdd, biblioUpdatingEntityRemoveEntity])
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const resultTags = await axios.get(process.env.REACT_APP_RESTAPI + '/topic_entity_tag/by_reference/' + referenceCurie + "?offset=" + offset + "&limit=" + limit);
-      setTopicEntityTags(resultTags.data);
-    }
-    fetchData().then();
-  }, [referenceCurie, biblioUpdatingEntityAdd, biblioUpdatingEntityRemoveEntity, offset, limit]);
-
-  const changePage = (action) => {
-      let maxOffset= Math.max(0, Math.floor(totalTagsCount/limit) * limit);
-      switch (action){
-        case 'Next':
-          setOffset(Math.min(maxOffset, offset + limit));
-          break;
-        case 'Prev':
-          setOffset(Math.max(0, offset - limit));
-          break;
-        case 'First':
-          setOffset(0);
-          break;
-        case 'Last':
-          setOffset(maxOffset);
-          break;
-        default:
-          setOffset(0);
-          break;
-      }
-    }
-
-  return (
-      <div>
-        <Container fluid>
-          <RowDivider />
-          <Row className="form-group row" >
-            <Col className="form-label col-form-label" sm="3"><h3>Entity and Topic Editor</h3></Col></Row>
-          <Row className="form-group row" >
-            <Col className="div-grey-border" sm="1">topic</Col>
-            <Col className="div-grey-border" sm="1">entity type</Col>
-            <Col className="div-grey-border" sm="1">species (taxon)</Col>
-            <Col className="div-grey-border" sm="2">entity name</Col>
-            <Col className="div-grey-border" sm="2">entity curie</Col>
-            <Col className="div-grey-border" sm="1">qualifier</Col>
-            <Col className="div-grey-border" sm="3">internal notes</Col>
-            <Col className="div-grey-border" sm="1">button</Col>
-          </Row>
-          { topicEntityTags.map( (tetDict, index) => {
-            let qualifierValue = ''; let qualifierId = ''; let qualifierIndex = '';
-            // UI only allows display/selection of one priority qualifier, but someone could connect in the database multiple priority qualifier in topic_entity_tag_prop to the same topic_entity_tag, even though that would be wrong.
-            if ('props' in tetDict && tetDict['props'].length > 0) {
-              // for (const tetpDict of tetDict['props'].values())
-              for (const[indexPriority, tetpDict] of tetDict['props'].entries()) {
-                if ('qualifier' in tetpDict && tetpDict['qualifier'] !== '' && qualifierList.includes(tetpDict['qualifier'])) {
-                  qualifierId = tetpDict['topic_entity_tag_prop_id'];
-                  qualifierIndex = indexPriority;
-                  qualifierValue = tetpDict['qualifier']; } } }
-            const entityName = tetDict.alliance_entity in entityEntityMappings ? entityEntityMappings[tetDict.alliance_entity] : 'unknown';
-            if ( (biblioAction === 'entity') && (tetDict.topic !== 'ATP:0000122') ) { return ""; }
-            // else if ( (biblioAction === 'topic') && (tetDict.topic === 'ATP:0000122') ) { return ""; } // topic no longer a separate section
-            else {
-              return (
-                  <Row key={`geneEntityContainerrows ${tetDict.topic_entity_tag_id}`}>
-                    <Col className="div-grey-border" sm="1">{tetDict.topic in curieToNameAtp ? curieToNameAtp[tetDict.topic] : tetDict.topic }</Col>
-                    <Col className="div-grey-border" sm="1">{tetDict.entity_type in curieToNameAtp ? curieToNameAtp[tetDict.entity_type] : tetDict.entity_type }</Col>
-                    <Col className="div-grey-border" sm="1">{tetDict.taxon in curieToNameTaxon ? curieToNameTaxon[tetDict.taxon] : tetDict.taxon }</Col>
-                    <Col className="div-grey-border" sm="2">{entityName}</Col>
-                    <Col className="div-grey-border" sm="2">{tetDict.alliance_entity}</Col>
-
-                    <Col sm="1">
-                      {/* changeFieldEntityEditorPriority changes which value to display, but does not update database. ideally this would update the databasewithout reloading referenceJsonLive, because API would return entities in a different order, so things would jump. but if creating a new qualifier where there wasn't any, there wouldn't be a tetpId until created, and it wouldn't be in the prop when changing again. could get the tetpId from the post and inject it, but it starts to get more complicated.  needs to display to patch existing tetp prop, or post to create a new one */}
-                      <Form.Control as="select" id={`qualifier ${index} ${qualifierIndex} ${qualifierId}`} type="tetqualifierSelect" disabled="disabled" value={qualifierValue} onChange={(e) => dispatch(changeFieldEntityEditorPriority(e))} >
-                        { qualifierList.map((optionValue, index) => (
-                            <option key={`tetqualifierSelect ${optionValue}`} value={optionValue}>{curieToNameAtp[optionValue]}</option>
-                        ))}
-                      </Form.Control>
-                    </Col>
-
-                    <Col className="form-label col-form-label" sm="3" style={{position: 'relative'}}>
-              <span style={{position: 'absolute', top: '0.2em', right: '1.2em'}}>
-                <span style={{color: '#007bff'}}
-                      onClick={() => {
-                        dispatch(updateButtonBiblioEntityEditEntity(accessToken, tetDict.topic_entity_tag_id, {'note': tetDict.note || ''}, 'PATCH', 'UPDATE_BUTTON_BIBLIO_ENTITY_EDIT_NOTE')) } } >&#10003;</span><br/>
-                <span style={{color: '#dc3545'}}
-                      onClick={() => {
-                        dispatch(setFieldEntityEditor('note ' + index, ''));
-                        dispatch(updateButtonBiblioEntityEditEntity(accessToken, tetDict.topic_entity_tag_id, {'note': ''}, 'PATCH', 'UPDATE_BUTTON_BIBLIO_ENTITY_EDIT_NOTE')) } } >X</span>
-              </span>
-                      <Form.Control as="textarea" id={`note ${index}`} type="note" value={tetDict.note || ''} onChange={(e) => dispatch(changeFieldEntityEditor(e))} />
-                      <Button variant="outline-primary"
-                              onClick={() => {
-                                dispatch(updateButtonBiblioEntityEditEntity(accessToken, tetDict.topic_entity_tag_id, {'note': tetDict.note || ''}, 'PATCH', 'UPDATE_BUTTON_BIBLIO_ENTITY_EDIT_NOTE')) } } >
-                        Update note</Button>&nbsp;
-                      <Button variant="outline-danger"
-                              onClick={() => {
-                                dispatch(setFieldEntityEditor('note ' + index, ''));
-                                dispatch(updateButtonBiblioEntityEditEntity(accessToken, tetDict.topic_entity_tag_id, {'note': ''}, 'PATCH', 'UPDATE_BUTTON_BIBLIO_ENTITY_EDIT_NOTE')) } } >
-                        Remove note</Button>
-                    </Col>
-                    <Col className="form-label col-form-label" sm="1">
-                      <Button variant="outline-danger"
-                              disabled={biblioUpdatingEntityRemoveEntity[tetDict.topic_entity_tag_id] === true ? 'disabled' : ''}
-                              onClick={() => {
-                                dispatch(setBiblioEntityRemoveEntity(tetDict.topic_entity_tag_id, true));
-                                dispatch(updateButtonBiblioEntityEditEntity(accessToken, tetDict.topic_entity_tag_id, null, 'DELETE', 'UPDATE_BUTTON_BIBLIO_ENTITY_REMOVE_ENTITY')) } } >
-                        {biblioUpdatingEntityRemoveEntity[tetDict.topic_entity_tag_id] === true ? <Spinner animation="border" size="sm"/> : "Remove Entity"}</Button></Col>
-                  </Row> ) }
-          } ) }
-        </Container>
-        {totalTagsCount > 0 ?
-            <Pagination style={{display: 'flex', justifyContent: 'center', alignItems: 'center', height: '10vh'}}>
-              <Pagination.First  onClick={() => changePage('First')} />
-              <Pagination.Prev   onClick={() => changePage('Prev')} />
-              <Pagination.Item  disabled>{"Page " + (offset / limit + 1) + " of " + Math.ceil(totalTagsCount/limit)}</Pagination.Item>
-              <Pagination.Next   onClick={() => changePage('Next')} />
-              <Pagination.Last   onClick={() => changePage('Last')} />
-            </Pagination>
-            : null}
-      </div>);
-} // const EntityEditor
-
-
-//           <Col className="form-label col-form-label" sm="1"><Button variant="outline-danger" >Remove Entity</Button></Col>
-//           <Col className="form-label col-form-label" sm="1"><Button variant="outline-primary" disabled={disabledAddButton} onClick={() => createEntities(referenceJsonLive.curie)} >{biblioUpdatingEntityAdd > 0 ? <Spinner animation="border" size="sm"/> : "Add"}</Button></Col>
-
-
-// const ModalGeneric = ({showGenericModal, genericModalHeader, genericModalBody, onHideAction}) => {
-//   const dispatch = useDispatch();
-//   if (showGenericModal) {
-//     return (<Modal size="lg" show={showGenericModal} backdrop="static" onHide={() => dispatch(onHideAction)} >
-//              <Modal.Header closeButton><Modal.Title>{genericModalHeader}</Modal.Title></Modal.Header>
-//              <Modal.Body><div dangerouslySetInnerHTML={{__html:`${genericModalBody}`}}/></Modal.Body>
-//             </Modal>); }
-//   return null;
-// }
-
-const EntityCreate = () => {
-  const dispatch = useDispatch();
-  const referenceJsonLive = useSelector(state => state.biblio.referenceJsonLive);
-  const oktaGroups = useSelector(state => state.isLogged.oktaGroups);
-  const accessToken = useSelector(state => state.isLogged.accessToken);
-  const biblioAction = useSelector(state => state.biblio.biblioAction);
-  const biblioUpdatingEntityAdd = useSelector(state => state.biblio.biblioUpdatingEntityAdd);
-  const entityModalText = useSelector(state => state.biblio.entityModalText);
-  const entityText = useSelector(state => state.biblio.entityAdd.entitytextarea);
-  const noteText = useSelector(state => state.biblio.entityAdd.notetextarea);
-  const tetqualifierSelect = useSelector(state => state.biblio.entityAdd.tetqualifierSelect);
-  const taxonSelect = useSelector(state => state.biblio.entityAdd.taxonSelect);
-  const entityTypeSelect = useSelector(state => state.biblio.entityAdd.entityTypeSelect);
-  const entityResultList = useSelector(state => state.biblio.entityAdd.entityResultList);
-  const topicSelect = 'entity type ATP:0000122';
-//   let geneStringListDash = [];
-//   let geneStringListParen = [];
-//   if (geneResultList) {
-//     for (const geneResObject of geneResultList) {
-//       geneStringListParen.push(geneResObject.geneSymbol + " ( " + geneResObject.curie + " ) ");
-//       geneStringListDash.push(geneResObject.geneSymbol + " -- " + geneResObject.curie); } }
-
-  useEffect( () => {
-    if (!(taxonSelect === '' || taxonSelect === undefined)) {
-      dispatch(changeFieldEntityEntityList(entityText, accessToken, taxonSelect, curieToNameEntityType[entityTypeSelect])) }
-  }, [entityText, taxonSelect]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  function createEntities(refCurie) {
-    const forApiArray = []
-    if ( entityResultList && entityResultList.length > 0 ) {
-      for (const entityResult of entityResultList.values()) {
-        console.log(entityResult);
-        console.log(entityResult.curie);
-        if (entityResult.curie !== 'no Alliance curie') {
-          let updateJson = {};
-          updateJson['reference_curie'] = refCurie;
-          updateJson['topic'] = biblioAction === 'entity' ? 'ATP:0000122' : 'insert topic here';
-          // updateJson['entity_type'] = 'ATP:0000005';
-          updateJson['entity_type'] = entityTypeSelect;
-          updateJson['alliance_entity'] = entityResult.curie;
-          // updateJson['taxon'] = 'NCBITaxon:559292';	// to hardcode if they don't want a dropdown
-          updateJson['taxon'] = taxonSelect;
-          updateJson['note'] = noteText;
-          if (tetqualifierSelect && tetqualifierSelect !== '') {
-            updateJson['props'] = [ { 'qualifier': tetqualifierSelect } ]; }
-          // console.log(updateJson);
-          let subPath = 'topic_entity_tag/';
-          let method = 'POST';
-          // let array = [ subPath, updateJson, method, 0, null, null]
-          let array = [ subPath, updateJson, method]
-          forApiArray.push( array );
-    } } }
-
-    let dispatchCount = forApiArray.length;
-
-    // console.log('dispatchCount ' + dispatchCount)
-    dispatch(setBiblioUpdatingEntityAdd(dispatchCount))
-
-    for (const arrayData of forApiArray.values()) {
-      arrayData.unshift(accessToken);
-      console.log(arrayData);
-      dispatch(updateButtonBiblioEntityAdd(arrayData))
-    }
-  }
-
-  const modToTaxon = { 'ZFIN': ['NCBITaxon:7955'], 'FB': ['NCBITaxon:7227'], 'WB': ['NCBITaxon:6239'], 'RGD': ['NCBITaxon:10116'], 'MGI': ['NCBITaxon:10090'], 'SGD': ['NCBITaxon:559292'], 'XB': ['NCBITaxon:8355', 'NCBITaxon:8364'] }
-  const unsortedTaxonList = [ '', 'NCBITaxon:559292', 'NCBITaxon:6239', 'NCBITaxon:7227', 'NCBITaxon:7955', 'NCBITaxon:10116', 'NCBITaxon:10090', 'NCBITaxon:8355', 'NCBITaxon:8364', 'NCBITaxon:9606' ];
-  let taxonList = unsortedTaxonList.sort((a, b) => (curieToNameTaxon[a] > curieToNameTaxon[b] ? 1 : -1));
-  const entityTypeList = ['ATP:0000005', 'ATP:0000006'];
-  const access = getOktaModAccess(oktaGroups);
-  // const access = 'WB';	// uncomment if you have developer okta access and need to test a specific mod
-  if (access in modToTaxon) {
-    let filteredTaxonList = taxonList.filter((x) => !modToTaxon[access].includes(x));
-    taxonList = modToTaxon[access].concat(filteredTaxonList); }
-  useEffect( () => {
-    if (access in modToTaxon) {
-      dispatch(changeFieldEntityAddTaxonSelect(modToTaxon[access][0])) }
-  }, [access]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // const taxonSelect = 'NCBITaxon:4932';	// to hardcode if they don't want a dropdown
-  // const taxonSelect = 'NCBITaxon:6239';	// to hardcode if they don't want a dropdown
-  // figure out if they want general disabling to work the same for the whole row, in which case combine the next two variables
-  const disabledEntityList = (taxonSelect === '' || taxonSelect === undefined) ? 'disabled' : '';
-  const disabledAddButton = (taxonSelect === '' || taxonSelect === undefined) ? 'disabled' : '';
-
-  return (
-    <Container fluid>
-    <ModalGeneric showGenericModal={entityModalText !== '' ? true : false} genericModalHeader="Entity Error"
-                  genericModalBody={entityModalText} onHideAction={setEntityModalText('')} />
-    <RowDivider />
-    <Row className="form-group row" >
-      <Col className="form-label col-form-label" sm="3"><h3>Entity and Topic Addition</h3></Col></Row>
-    <Row className="form-group row" >
-      <Col className="div-grey-border" sm="1">topic</Col>
-      <Col className="div-grey-border" sm="1">entity type</Col>
-      <Col className="div-grey-border" sm="1">species</Col>
-      <Col className="div-grey-border" sm="2">entity list (one per line, case insensitive)</Col>
-      <Col className="div-grey-border" sm="2">entity validation</Col>
-      <Col className="div-grey-border" sm="1">qualifier</Col>
-      <Col className="div-grey-border" sm="3">internal notes</Col>
-      <Col className="div-grey-border" sm="1">button</Col>
-    </Row>
-    <Row className="form-group row" >
-      <Col sm="1">
-        <Form.Control as="select" id="topicSelect" type="topicSelect" value={topicSelect} onChange={(e) => {} } >
-          <option key={`topicSelect ${topicSelect}`} value={topicSelect}>{topicSelect}</option>
-        </Form.Control>
-      </Col>
-      <Col sm="1">
-        <Form.Control as="select" id="entityTypeSelect" type="entityTypeSelect" value={entityTypeSelect} onChange={(e) => { dispatch(changeFieldEntityAddGeneralField(e)) } } >
-          { entityTypeList.map((optionValue, index) => (
-            <option key={`entityTypeSelect ${optionValue}`} value={optionValue}>{curieToNameEntityType[optionValue]} {optionValue}</option>
-          ))}
-        </Form.Control>
-      </Col>
-      <Col sm="1">
-        <Form.Control as="select" id="taxonSelect" type="taxonSelect" value={taxonSelect} onChange={(e) => { dispatch(changeFieldEntityAddGeneralField(e)) } } >
-          { taxonList.map((optionValue, index) => (
-            <option key={`taxonSelect ${optionValue}`} value={optionValue}>{curieToNameTaxon[optionValue]}</option>
-          ))}
-        </Form.Control>
-      </Col>
-      <Col className="form-label col-form-label" sm="2" >
-        <Form.Control as="textarea" id="entitytextarea" type="entitytextarea" value={entityText} disabled={disabledEntityList} onChange={(e) => { dispatch(changeFieldEntityAddGeneralField(e)); } } />
-      </Col>
-      <Col className="form-label col-form-label" sm="2" >
-        <Container>
-          { entityResultList && entityResultList.length > 0 && entityResultList.map( (entityResult, index) => {
-            const colDisplayClass = (entityResult.curie === 'no Alliance curie') ? 'Col-display-warn' : 'Col-display';
-            return (
-              <Row key={`entityEntityContainerrows ${index}`}>
-                <Col className={`Col-general ${colDisplayClass} Col-display-left`} sm="5">{entityResult.entityTypeSymbol}</Col>
-                <Col className={`Col-general ${colDisplayClass} Col-display-right`} sm="7">{entityResult.curie}</Col>
-              </Row>)
-          } ) }
-        </Container>
-      </Col>
-      <Col sm="1">
-        <Form.Control as="select" id="tetqualifierSelect" type="tetqualifierSelect" value={tetqualifierSelect} onChange={(e) => dispatch(changeFieldEntityAddGeneralField(e))} >
-          { qualifierList.map((optionValue, index) => (
-            <option key={`tetqualifierSelect ${optionValue}`} value={optionValue}>{curieToNameAtp[optionValue]}</option>
-          ))}
-        </Form.Control>
-      </Col>
-      <Col className="form-label col-form-label" sm="3">
-        <Form.Control as="textarea" id="notetextarea" type="notetextarea" value={noteText} onChange={(e) => dispatch(changeFieldEntityAddGeneralField(e))} />
-      </Col>
-      <Col className="form-label col-form-label" sm="1"><Button variant="outline-primary" disabled={disabledAddButton} onClick={() => createEntities(referenceJsonLive.curie)} >{biblioUpdatingEntityAdd > 0 ? <Spinner animation="border" size="sm"/> : "Add"}</Button></Col>
-    </Row></Container>);
 }
 
 export default BiblioFileManagement;

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -5,7 +5,9 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Spinner from "react-bootstrap/Spinner";
 import Button from 'react-bootstrap/Button';
+import Alert from 'react-bootstrap/Alert'
 import axios from "axios";
+
 import RowDivider from './RowDivider';
 import {RowDisplayString} from './BiblioDisplay';
 import ModalGeneric from './ModalGeneric';
@@ -15,7 +17,8 @@ import {
   fileUploadResult,
   setFileUploadingCount,
   setFileUploadingModalText,
-  setFileUploadingShowModal
+  setFileUploadingShowModal,
+  setFileUploadingShowSuccess
 } from '../../actions/biblioActions';
 
 import {useDropzone} from 'react-dropzone';
@@ -28,6 +31,7 @@ const BiblioFileManagement = () => {
           <FileEditor />
           <RowDivider />
           <BiblioCitationDisplay key="filemanagementCitationDisplay" />
+          <AlertDismissibleFileUploadSuccess />
           <FileUpload main_or_supp="main" />
           <FileUpload main_or_supp="supplement" />
         </Container>
@@ -107,6 +111,21 @@ const FileUpload = ({main_or_supp}) => {
         </Row>
       </>
   );
+}
+
+const AlertDismissibleFileUploadSuccess = () => {
+  const dispatch = useDispatch();
+  const fileUploadingShowSuccess = useSelector(state => state.biblio.fileUploadingShowSuccess);
+  if (fileUploadingShowSuccess) {
+    setTimeout(() => {
+      dispatch(setFileUploadingShowSuccess(false))
+    }, 2000);
+    return (
+      <Alert variant="success" onClose={() => dispatch(setFileUploadingShowSuccess(false))} dismissible>
+        <Alert.Heading>All files uploaded</Alert.Heading>
+      </Alert>
+    );
+  } else { return null; }
 }
 
 const BiblioCitationDisplay = () => {

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -4,28 +4,40 @@ import { useSelector, useDispatch } from 'react-redux';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
+import Spinner from "react-bootstrap/Spinner";
+import Button from 'react-bootstrap/Button';
 import axios from "axios";
 
+
+import { getOktaModAccess } from '../Biblio';
+import RowDivider from './RowDivider';
 import { RowDisplayString } from './BiblioDisplay';
 import ModalGeneric from './ModalGeneric';
 
-import {fileUploadResult, setFileUploadingModalText} from '../../actions/biblioActions';
+import { fileUploadResult, setFileUploadingModalText } from '../../actions/biblioActions';
 import { setFileUploadingCount } from '../../actions/biblioActions';
 import { setFileUploadingShowModal } from '../../actions/biblioActions';
+import {
+  downloadReferencefile,
+  queryId,
+  setReferenceCurie
+} from '../../actions/biblioActions';
 
 import {useDropzone} from 'react-dropzone';
+
 
 export const curieToNameEntityType = { 'ATP:0000005': 'gene', 'ATP:0000006': 'allele' };
 
 const BiblioFileManagement = () => {
   return (<>
             <Container>
+              <FileEditor />
+              <RowDivider />
               <BiblioCitationDisplay key="filemanagementCitationDisplay" />
               <FileUpload main_or_supp="main" />
               <FileUpload main_or_supp="supplement" />
             </Container>
           </>); }
-
 
 const FileUpload = ({main_or_supp}) => {
   const dispatch = useDispatch();
@@ -93,6 +105,77 @@ const BiblioCitationDisplay = () => {
   const referenceJsonDb = useSelector(state => state.biblio.referenceJsonDb);
   const fieldName = 'citation';
   return (<RowDisplayString key={fieldName} fieldName={fieldName} referenceJsonLive={referenceJsonLive} referenceJsonDb={referenceJsonDb} />);
+}
+
+const FileEditor = () => {
+  const displayOrEditor = 'display';
+  const fieldName = 'referencefiles';
+  const referenceJsonLive = useSelector(state => state.biblio.referenceJsonLive);
+
+  const dispatch = useDispatch();
+  const oktaGroups = useSelector(state => state.isLogged.oktaGroups);
+  const accessToken = useSelector(state => state.isLogged.accessToken);
+  const supplementExpand = useSelector(state => state.biblio.supplementExpand);
+  const loadingFileNames = useSelector(state => state.biblio.loadingFileNames);
+  let cssDisplayLeft = 'Col-display Col-display-left';
+  let cssDisplay = 'Col-display';
+  let cssDisplayRight = 'Col-display Col-display-right';
+  if (displayOrEditor === 'editor') {
+    cssDisplay = 'Col-editor-disabled';
+    cssDisplayLeft = ''; cssDisplayRight = 'Col-editor-disabled'; }
+  const access = getOktaModAccess(oktaGroups);
+  if ('referencefiles' in referenceJsonLive && referenceJsonLive['referencefiles'] !== null) {
+    let tarballChecked = ''; let listChecked = '';
+    if (supplementExpand === 'tarball') { tarballChecked = 'checked'; }
+      else if (supplementExpand === 'list') { listChecked = 'checked'; }
+    const rowReferencefileElements = []
+
+    // for (const[index, referencefileDict] of referenceJsonLive['referencefiles'].filter(x => x['file_class'] === 'main').entries())
+    let hasAccessToTarball = false;
+    for (const[index, referencefileDict] of referenceJsonLive['referencefiles'].entries()) {
+      let is_ok = false;
+      let allowed_mods = [];
+      for (const rfm of referencefileDict['referencefile_mods']) {
+        if (rfm['mod_abbreviation'] !== null) { allowed_mods.push(rfm['mod_abbreviation']); }
+          else { allowed_mods.push('PMC'); }
+        if (rfm['mod_abbreviation'] === null || rfm['mod_abbreviation'] === access) { is_ok = true; }
+      }
+      const source = allowed_mods.join(", ");
+      let filename = referencefileDict['display_name'] + '.' + referencefileDict['file_extension'];
+      let referencefileValue = (<div>{filename}</div>);
+      if (access === 'developer') { is_ok = true; }
+        else if (access === 'No') { is_ok = false; referencefileValue = (<div>{filename}</div>); }
+      if (is_ok) {
+        hasAccessToTarball = true;
+        referencefileValue = (<div><button className='button-to-link' onClick={ () =>
+            dispatch(downloadReferencefile(referencefileDict['referencefile_id'], filename, accessToken))
+        } >{filename}</button>&nbsp;{loadingFileNames.has(filename) ? <Spinner animation="border" size="sm"/> : null}</div>); }
+        const referencefileRow = (
+            <Row key={`${fieldName} ${index}`} className="Row-general" xs={2} md={4} lg={6}>
+              <Col className={`Col-general ${cssDisplayLeft} `} lg={{ span: 2 }}>{referencefileDict['file_class']}</Col>
+              <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}>{referencefileValue}</Col>
+              <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}>{source}</Col>
+              <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}>{ referencefileDict['pdf_type'] === 'null' ? 'pdf' : referencefileDict['pdf_type'] }</Col>
+              <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}>{referencefileDict['file_publication_status']}</Col>
+              <Col className={`Col-general ${cssDisplayRight} `} lg={{ span: 2 }}><Button variant="outline-primary">delete</Button></Col>
+            </Row>);
+        rowReferencefileElements.push( referencefileRow );
+      }
+
+    if (rowReferencefileElements.length > 0) {
+      const referencefileHeaderRow = (
+              <Row key={`${fieldName} header`} className="Row-general" xs={2} md={4} lg={6}>
+                <Col className={`Col-general ${cssDisplayLeft} `} lg={{ span: 2 }}><strong>File Class</strong></Col>
+                <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}><strong>File Name</strong></Col>
+                <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}><strong>Source</strong></Col>
+                <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}><strong>Pdf Type</strong></Col>
+                <Col className={`Col-general ${cssDisplay} `} lg={{ span: 2 }}><strong>File Publication Status</strong></Col>
+                <Col className={`Col-general ${cssDisplayRight} `} lg={{ span: 2 }}><strong>Delete placeholder</strong></Col>
+              </Row>);
+      rowReferencefileElements.unshift( referencefileHeaderRow ); }
+
+    return (<>{rowReferencefileElements}</>); }
+  else { return null; } 
 }
 
 export default BiblioFileManagement;

--- a/src/components/biblio/NoAccessAlert.js
+++ b/src/components/biblio/NoAccessAlert.js
@@ -1,0 +1,11 @@
+import Container from 'react-bootstrap/Container';
+import Alert from 'react-bootstrap/Alert'
+
+const NoAccessAlert = () => { 
+  return (
+    <Container>
+      <Alert variant="danger">This feature is only available for logged in users.</Alert>
+    </Container>
+  ); }
+
+export default NoAccessAlert;

--- a/src/reducers/biblioReducer.js
+++ b/src/reducers/biblioReducer.js
@@ -21,6 +21,7 @@ const initialState = {
   fileUploadingCount: 0,
   fileUploadResultMap: {},
   fileUploadingShowModal: false,
+  fileUploadingModalText: '',
 
   biblioUpdating: 0,
   biblioEditorModalText: '',
@@ -395,15 +396,20 @@ export default function(state = initialState, action) {
       console.log('reducer FILE_UPLOAD_RESULT ');
       console.log(action.payload);
       let fileUpload_showModal = state.fileUploadingShowModal;
+      let fileUpload_modalText = state.fileUploadingModalText;
       const fileUpload_fileUploadResultMap = _.cloneDeep(state.fileUploadResultMap);
       fileUpload_fileUploadResultMap[action.payload.filename] = action.payload.resultMessage;
       let fileUpload_getReferenceCurieFlag = state.getReferenceCurieFlag;
       if (Object.keys(fileUpload_fileUploadResultMap).length === state.fileUploadingCount) {
         fileUpload_showModal = true;
+        fileUpload_modalText = Object.entries(fileUpload_fileUploadResultMap).filter( ([, value]) => value !== 'success' ).length > 0 ?
+            Object.entries(fileUpload_fileUploadResultMap).map( ([key, value]) => key + ' ' + value ).join("<br/>") :
+            'All files uploaded';
         fileUpload_getReferenceCurieFlag = true;
       }
       return {
         ...state,
+        fileUploadingModalText: fileUpload_modalText,
         fileUploadResultMap: fileUpload_fileUploadResultMap,
         fileUploadingShowModal: fileUpload_showModal,
         getReferenceCurieFlag: fileUpload_getReferenceCurieFlag
@@ -423,6 +429,12 @@ export default function(state = initialState, action) {
       return {
         ...state,
         fileUploadingShowModal: action.payload
+      }
+
+    case 'SET_FILE_UPLOADING_MODAL_TEXT':
+      return {
+        ...state,
+        fileUploadingModalText: action.payload
       }
 
     case 'VALIDATE_FORM_UPDATE_BIBLIO':

--- a/src/reducers/biblioReducer.js
+++ b/src/reducers/biblioReducer.js
@@ -18,6 +18,10 @@ const initialState = {
   workflowModalText: '',
   isUpdatingWorkflowCuratability: false,
 
+  fileUploadingCount: 0,
+  fileUploadResultMap: {},
+  fileUploadingShowModal: false,
+
   biblioUpdating: 0,
   biblioEditorModalText: '',
   updateBiblioFlag: false,
@@ -385,6 +389,40 @@ export default function(state = initialState, action) {
         ...state,
         updateAlert: 0,
         updateMessages: []
+      }
+
+    case 'FILE_UPLOAD_RESULT':
+      console.log('reducer FILE_UPLOAD_RESULT ');
+      console.log(action.payload);
+      let fileUpload_showModal = state.fileUploadingShowModal;
+      const fileUpload_fileUploadResultMap = _.cloneDeep(state.fileUploadResultMap);
+      fileUpload_fileUploadResultMap[action.payload.filename] = action.payload.resultMessage;
+      let fileUpload_getReferenceCurieFlag = state.getReferenceCurieFlag;
+      if (Object.keys(fileUpload_fileUploadResultMap).length === state.fileUploadingCount) {
+        fileUpload_showModal = true;
+        fileUpload_getReferenceCurieFlag = true;
+      }
+      return {
+        ...state,
+        fileUploadResultMap: fileUpload_fileUploadResultMap,
+        fileUploadingShowModal: fileUpload_showModal,
+        getReferenceCurieFlag: fileUpload_getReferenceCurieFlag
+      }
+
+    case 'SET_FILE_UPLOADING_COUNT':
+      console.log("reducer SET_FILE_UPLOADING_COUNT");
+      return {
+        ...state,
+        fileUploadResultMap: {},
+        fileUploadingShowModal: false,
+        fileUploadingCount: action.payload
+      }
+
+    case 'SET_FILE_UPLOADING_SHOW_MODAL':
+      console.log("reducer SET_FILE_UPLOADING_SHOW_MODAL");
+      return {
+        ...state,
+        fileUploadingShowModal: action.payload
       }
 
     case 'VALIDATE_FORM_UPDATE_BIBLIO':

--- a/src/reducers/biblioReducer.js
+++ b/src/reducers/biblioReducer.js
@@ -20,6 +20,7 @@ const initialState = {
 
   fileUploadingCount: 0,
   fileUploadResultMap: {},
+  fileUploadingShowSuccess: false,
   fileUploadingShowModal: false,
   fileUploadingModalText: '',
 
@@ -398,17 +399,20 @@ export default function(state = initialState, action) {
       let fileUpload_showModal = state.fileUploadingShowModal;
       let fileUpload_modalText = state.fileUploadingModalText;
       const fileUpload_fileUploadResultMap = _.cloneDeep(state.fileUploadResultMap);
+      let fileUpload_fileUploadingShowSuccess = state.fileUploadingShowSuccess;
       fileUpload_fileUploadResultMap[action.payload.filename] = action.payload.resultMessage;
       let fileUpload_getReferenceCurieFlag = state.getReferenceCurieFlag;
       if (Object.keys(fileUpload_fileUploadResultMap).length === state.fileUploadingCount) {
-        fileUpload_showModal = true;
-        fileUpload_modalText = Object.entries(fileUpload_fileUploadResultMap).filter( ([, value]) => value !== 'success' ).length > 0 ?
-            Object.entries(fileUpload_fileUploadResultMap).map( ([key, value]) => key + ' ' + value ).join("<br/>") :
-            'All files uploaded';
+        if (Object.entries(fileUpload_fileUploadResultMap).filter( ([, value]) => value !== 'success' ).length > 0) {
+          fileUpload_showModal = true;
+          fileUpload_modalText = Object.entries(fileUpload_fileUploadResultMap).map( ([key, value]) => key + ' ' + value ).join("<br/>") }
+        else {
+          fileUpload_fileUploadingShowSuccess = true; }
         fileUpload_getReferenceCurieFlag = true;
       }
       return {
         ...state,
+        fileUploadingShowSuccess: fileUpload_fileUploadingShowSuccess,
         fileUploadingModalText: fileUpload_modalText,
         fileUploadResultMap: fileUpload_fileUploadResultMap,
         fileUploadingShowModal: fileUpload_showModal,
@@ -422,6 +426,13 @@ export default function(state = initialState, action) {
         fileUploadResultMap: {},
         fileUploadingShowModal: false,
         fileUploadingCount: action.payload
+      }
+
+    case 'SET_FILE_UPLOADING_SHOW_SUCCESS':
+      console.log("reducer SET_FILE_UPLOADING_SHOW_SUCCESS");
+      return {
+        ...state,
+        fileUploadingShowSuccess: action.payload
       }
 
     case 'SET_FILE_UPLOADING_SHOW_MODAL':


### PR DESCRIPTION
- added new tab for file management
- two dropzone components to upload one or more files for main and supplements - drag and drop or open, multiple files and folder uploads
- table to list files associated with the reference under the dropzones, sorted by file_class and display name
- error handling with modals and an alert in case of success
- UI constraint on file names with multiple periods
- okta based extraction of MOD to associate files to
- now hiding all editors if not logged-in