### PR TITLE
SCRUM-2227 Adding check for hasAccess

### DIFF
--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -256,7 +256,7 @@ const FileEditor = () => {
               </Form.Control>
             </Col>
             <Col className={`Col-general ${cssDisplayRight} `} lg={{span: 1}}><Button
-                variant="outline-dark" onClick={() => deleteReferencefile(referenceFile.referencefile_id,accessToken)}>
+                variant="outline-dark" disabled={!hasAccess} onClick={() => deleteReferencefile(referenceFile.referencefile_id,accessToken)}>
                 <FontAwesomeIcon icon={faTrash}/></Button></Col>
           </Row>);
     });


### PR DESCRIPTION
If we needed these enforced rigidly this kind of check should be done at  the API level but this will prevent users from accidentally deleting  files they dont have access to.