### PR TITLE
Scrum 2845

### DIFF
--- a/.env.development_devserver
+++ b/.env.development_devserver
@@ -1,0 +1,13 @@
+# change the 3003 and 4003 to your ports (3006/4006, or whatever you use), don't change WDS_SOCKET_PORT from 443
+REACT_APP_OKTADOMAIN=dev-30456587.okta.com
+REACT_APP_CLIENTID=0oa1bn1wjdZiJWaJe5d7
+REACT_APP_UI_URL=https://dev3003.alliancegenome.org
+REACT_APP_RESTAPI=https://dev4003-literature-rest.alliancegenome.org
+REACT_APP_SWAGGERUI=https://dev4003-literature-rest.alliancegenome.org/openapi.json
+REACT_APP_GOOGLEID=0oa1crmy0xAPqqTa35d7
+REACT_APP_MICROSOFTID=0oa1lfrktejLMnemp5d7
+REACT_APP_DEV_OR_STAGE_OR_PROD=dev3003
+REACT_APP_ATEAM_API_BASE_URL=https://beta-curation.alliancegenome.org/
+COMPOSE_PROJECT_NAME=agr_literature_dev_3003
+LIT_UI_PORT=3003
+WDS_SOCKET_PORT=443

--- a/src/components/Biblio.js
+++ b/src/components/Biblio.js
@@ -13,9 +13,9 @@ import BiblioFileManagement from './biblio/BiblioFileManagement';
 import NoAccessAlert from './biblio/NoAccessAlert';
 
 import { RowDisplayString } from './biblio/BiblioDisplay';
-import { RowDisplaySimple } from './biblio/BiblioDisplay';
+// import { RowDisplaySimple } from './biblio/BiblioDisplay';
 
-import { splitCurie } from './biblio/BiblioEditor';
+// import { splitCurie } from './biblio/BiblioEditor';
 
 import {
   downloadReferencefile,
@@ -28,7 +28,7 @@ import { biblioQueryReferenceCurie } from '../actions/biblioActions';
 import { changeBiblioSupplementExpandToggler } from '../actions/biblioActions';
 
 import { changeBiblioActionToggler } from '../actions/biblioActions';
-import { updateButtonBiblio } from '../actions/biblioActions';
+// import { updateButtonBiblio } from '../actions/biblioActions';
 
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
@@ -446,7 +446,7 @@ const Biblio = () => {
 //   const loadingQuery = useSelector(state => state.biblio.loadingQuery);
   const isLoading = useSelector(state => state.biblio.isLoading);
 //   const queryFailure = useSelector(state => state.biblio.queryFailure);	// do something when user puts in invalid curie
-  const accessToken = useSelector(state => state.isLogged.accessToken);
+//   const accessToken = useSelector(state => state.isLogged.accessToken);
 //   const updateCitationFlag = useSelector(state => state.biblio.updateCitationFlag);	// citation now updates from database triggers
 
   const useQuery = () => { return new URLSearchParams(useLocation().search); }

--- a/src/components/Biblio.js
+++ b/src/components/Biblio.js
@@ -238,20 +238,20 @@ const BiblioTagging = () => {
             { (biblioAction === 'workflow') ? <BiblioWorkflow /> : <BiblioEntity /> }</>);
 } // const BiblioTagging
 
-export function getOktaModAccess(oktaGroups) {
-  let access = 'No';
-  if (oktaGroups) {
-    for (const oktaGroup of oktaGroups) {
-      if (oktaGroup.endsWith('Developer')) { access = 'developer'; }
-        else if (oktaGroup === 'SGDCurator') { access = 'SGD'; }
-        else if (oktaGroup === 'RGDCurator') { access = 'RGD'; }
-        else if (oktaGroup === 'MGICurator') { access = 'MGI'; }
-        else if (oktaGroup === 'ZFINCurator') { access = 'ZFIN'; }
-        else if (oktaGroup === 'XenbaseCurator') { access = 'XB'; }
-        else if (oktaGroup === 'FlyBaseCurator') { access = 'FB'; }
-        else if (oktaGroup === 'WormBaseCurator') { access = 'WB'; } } }
-  return access;
-}
+// export function getOktaModAccess(oktaGroups) {
+//   let access = 'No';
+//   if (oktaGroups) {
+//     for (const oktaGroup of oktaGroups) {
+//       if (oktaGroup.endsWith('Developer')) { access = 'developer'; }
+//         else if (oktaGroup === 'SGDCurator') { access = 'SGD'; }
+//         else if (oktaGroup === 'RGDCurator') { access = 'RGD'; }
+//         else if (oktaGroup === 'MGICurator') { access = 'MGI'; }
+//         else if (oktaGroup === 'ZFINCurator') { access = 'ZFIN'; }
+//         else if (oktaGroup === 'XenbaseCurator') { access = 'XB'; }
+//         else if (oktaGroup === 'FlyBaseCurator') { access = 'FB'; }
+//         else if (oktaGroup === 'WormBaseCurator') { access = 'WB'; } } }
+//   return access;
+// }
 
 export const RowDisplayReferencefiles = ({displayOrEditor}) => {
   const dispatch = useDispatch();
@@ -281,11 +281,15 @@ export const RowDisplayReferencefiles = ({displayOrEditor}) => {
   if (displayOrEditor === 'editor') {
     cssDisplay = 'Col-editor-disabled';
     cssDisplayLeft = ''; cssDisplayRight = 'Col-editor-disabled'; }
-  const access = getOktaModAccess(oktaGroups);
-    let tarballChecked = ''; let listChecked = '';
-    if (supplementExpand === 'tarball') { tarballChecked = 'checked'; }
-      else if (supplementExpand === 'list') { listChecked = 'checked'; }
-    const rowReferencefileElements = []
+  // const access = getOktaModAccess(oktaGroups);	// old way to get access before logging on put values in store 
+  const oktaMod = useSelector(state => state.isLogged.oktaMod);
+  const oktaDeveloper = useSelector(state => state.isLogged.oktaDeveloper);
+  const access = (oktaDeveloper ? 'developer' : oktaMod);
+  // const access = 'WB';	// for development to force access to a specific mod
+  let tarballChecked = ''; let listChecked = '';
+  if (supplementExpand === 'tarball') { tarballChecked = 'checked'; }
+    else if (supplementExpand === 'list') { listChecked = 'checked'; }
+  const rowReferencefileElements = []
 
   // for (const[index, referencefileDict] of referenceJsonLive['referencefiles'].filter(x => x['file_class'] === 'main').entries())
   const rowReferencefileSupplementElements = []

--- a/src/components/Biblio.js
+++ b/src/components/Biblio.js
@@ -13,9 +13,6 @@ import BiblioFileManagement from './biblio/BiblioFileManagement';
 import NoAccessAlert from './biblio/NoAccessAlert';
 
 import { RowDisplayString } from './biblio/BiblioDisplay';
-// import { RowDisplaySimple } from './biblio/BiblioDisplay';
-
-// import { splitCurie } from './biblio/BiblioEditor';
 
 import {
   downloadReferencefile,
@@ -28,7 +25,6 @@ import { biblioQueryReferenceCurie } from '../actions/biblioActions';
 import { changeBiblioSupplementExpandToggler } from '../actions/biblioActions';
 
 import { changeBiblioActionToggler } from '../actions/biblioActions';
-// import { updateButtonBiblio } from '../actions/biblioActions';
 
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
@@ -238,21 +234,6 @@ const BiblioTagging = () => {
             { (biblioAction === 'workflow') ? <BiblioWorkflow /> : <BiblioEntity /> }</>);
 } // const BiblioTagging
 
-// export function getOktaModAccess(oktaGroups) {
-//   let access = 'No';
-//   if (oktaGroups) {
-//     for (const oktaGroup of oktaGroups) {
-//       if (oktaGroup.endsWith('Developer')) { access = 'developer'; }
-//         else if (oktaGroup === 'SGDCurator') { access = 'SGD'; }
-//         else if (oktaGroup === 'RGDCurator') { access = 'RGD'; }
-//         else if (oktaGroup === 'MGICurator') { access = 'MGI'; }
-//         else if (oktaGroup === 'ZFINCurator') { access = 'ZFIN'; }
-//         else if (oktaGroup === 'XenbaseCurator') { access = 'XB'; }
-//         else if (oktaGroup === 'FlyBaseCurator') { access = 'FB'; }
-//         else if (oktaGroup === 'WormBaseCurator') { access = 'WB'; } } }
-//   return access;
-// }
-
 export const RowDisplayReferencefiles = ({displayOrEditor}) => {
   const dispatch = useDispatch();
   const oktaGroups = useSelector(state => state.isLogged.oktaGroups);
@@ -450,7 +431,6 @@ const Biblio = () => {
 //   const loadingQuery = useSelector(state => state.biblio.loadingQuery);
   const isLoading = useSelector(state => state.biblio.isLoading);
 //   const queryFailure = useSelector(state => state.biblio.queryFailure);	// do something when user puts in invalid curie
-//   const accessToken = useSelector(state => state.isLogged.accessToken);
 //   const updateCitationFlag = useSelector(state => state.biblio.updateCitationFlag);	// citation now updates from database triggers
 
   const useQuery = () => { return new URLSearchParams(useLocation().search); }

--- a/src/components/Tracker.js
+++ b/src/components/Tracker.js
@@ -21,20 +21,6 @@ const searchMissingFiles = (mod_abbreviation) => {
     }
 }
 
-// function getOktaModAccess(oktaGroups) {
-//   let access = 'No';
-//   if (oktaGroups) {
-//     for (const oktaGroup of oktaGroups) {
-//         if (oktaGroup.startsWith('SGD')) { access = 'SGD'; }
-//         else if (oktaGroup.startsWith('RGD')) { access = 'RGD'; }
-//         else if (oktaGroup.startsWith('MGI')) { access = 'MGI'; }
-//         else if (oktaGroup.startsWith('ZFIN')) { access = 'ZFIN'; }
-//         else if (oktaGroup.startsWith('Xen')) { access = 'XB'; }
-//         else if (oktaGroup.startsWith('Fly')) { access = 'FB'; }
-//         else if (oktaGroup.startsWith('Worm')) { access = 'WB'; } } }
-//   return access;
-// }
-
 const addWorkflowTag = (tag_id,mod_abbreviation,curie,accessToken) => {
   return dispatch => {
     let headers = {
@@ -88,7 +74,6 @@ const XrefElement = (xref) => {
 }
 
 const Tracker = () => {
-  // const oktaGroups = useSelector(state => state.isLogged.oktaGroups);
   const missingFileResults = useSelector(state => state.tracker.missingFileResults);
   const dispatch = useDispatch();
   // const access = getOktaModAccess(oktaGroups);	// old way before logging on put values in store

--- a/src/components/Tracker.js
+++ b/src/components/Tracker.js
@@ -21,19 +21,19 @@ const searchMissingFiles = (mod_abbreviation) => {
     }
 }
 
-function getOktaModAccess(oktaGroups) {
-  let access = 'No';
-  if (oktaGroups) {
-    for (const oktaGroup of oktaGroups) {
-        if (oktaGroup.startsWith('SGD')) { access = 'SGD'; }
-        else if (oktaGroup.startsWith('RGD')) { access = 'RGD'; }
-        else if (oktaGroup.startsWith('MGI')) { access = 'MGI'; }
-        else if (oktaGroup.startsWith('ZFIN')) { access = 'ZFIN'; }
-        else if (oktaGroup.startsWith('Xen')) { access = 'XB'; }
-        else if (oktaGroup.startsWith('Fly')) { access = 'FB'; }
-        else if (oktaGroup.startsWith('Worm')) { access = 'WB'; } } }
-  return access;
-}
+// function getOktaModAccess(oktaGroups) {
+//   let access = 'No';
+//   if (oktaGroups) {
+//     for (const oktaGroup of oktaGroups) {
+//         if (oktaGroup.startsWith('SGD')) { access = 'SGD'; }
+//         else if (oktaGroup.startsWith('RGD')) { access = 'RGD'; }
+//         else if (oktaGroup.startsWith('MGI')) { access = 'MGI'; }
+//         else if (oktaGroup.startsWith('ZFIN')) { access = 'ZFIN'; }
+//         else if (oktaGroup.startsWith('Xen')) { access = 'XB'; }
+//         else if (oktaGroup.startsWith('Fly')) { access = 'FB'; }
+//         else if (oktaGroup.startsWith('Worm')) { access = 'WB'; } } }
+//   return access;
+// }
 
 const addWorkflowTag = (tag_id,mod_abbreviation,curie,accessToken) => {
   return dispatch => {
@@ -88,10 +88,12 @@ const XrefElement = (xref) => {
 }
 
 const Tracker = () => {
-  const oktaGroups = useSelector(state => state.isLogged.oktaGroups);
+  // const oktaGroups = useSelector(state => state.isLogged.oktaGroups);
   const missingFileResults = useSelector(state => state.tracker.missingFileResults);
   const dispatch = useDispatch();
-  const access = getOktaModAccess(oktaGroups);
+  // const access = getOktaModAccess(oktaGroups);	// old way before logging on put values in store
+  const access = useSelector(state => state.isLogged.oktaMod);
+  // const access = 'ZFIN';				// to force a specific MOD
   const accessToken = useSelector(state => state.isLogged.accessToken);
 
   useEffect(() => {
@@ -118,7 +120,7 @@ const Tracker = () => {
         </thead>
         <tbody>
         { missingFileResults.map((reference, index) => (
-          <tr>
+          <tr key={`missingFile ${reference} ${index}`}>
             <td><Link to={{pathname: "/Biblio", search: "?action=display&referenceCurie=" + reference.curie}}>{reference.curie}</Link></td>
             <td><XrefElement xref={reference.mod_curie}/></td>
             <td><XrefElement xref={reference.pmid}/></td>

--- a/src/components/biblio/BiblioEntity.js
+++ b/src/components/biblio/BiblioEntity.js
@@ -17,8 +17,6 @@ import { changeFieldEntityEditorPriority } from '../../actions/biblioActions';
 import RowDivider from './RowDivider';
 import ModalGeneric from './ModalGeneric';
 
-// import { getOktaModAccess } from '../Biblio';
-
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
@@ -303,7 +301,6 @@ const EntityCreate = () => {
   const unsortedTaxonList = [ '', 'NCBITaxon:559292', 'NCBITaxon:6239', 'NCBITaxon:7227', 'NCBITaxon:7955', 'NCBITaxon:10116', 'NCBITaxon:10090', 'NCBITaxon:8355', 'NCBITaxon:8364', 'NCBITaxon:9606' ];
   let taxonList = unsortedTaxonList.sort((a, b) => (curieToNameTaxon[a] > curieToNameTaxon[b] ? 1 : -1));
   const entityTypeList = ['ATP:0000005', 'ATP:0000006'];
-  // const access = getOktaModAccess(oktaGroups);	// old way to get access before logging on put values in store
   const access = useSelector(state => state.isLogged.oktaMod);
   // const access = 'WB';	// uncomment if you have developer okta access and need to test a specific mod
   if (access in modToTaxon) {

--- a/src/components/biblio/BiblioEntity.js
+++ b/src/components/biblio/BiblioEntity.js
@@ -17,7 +17,7 @@ import { changeFieldEntityEditorPriority } from '../../actions/biblioActions';
 import RowDivider from './RowDivider';
 import ModalGeneric from './ModalGeneric';
 
-import { getOktaModAccess } from '../Biblio';
+// import { getOktaModAccess } from '../Biblio';
 
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
@@ -303,7 +303,8 @@ const EntityCreate = () => {
   const unsortedTaxonList = [ '', 'NCBITaxon:559292', 'NCBITaxon:6239', 'NCBITaxon:7227', 'NCBITaxon:7955', 'NCBITaxon:10116', 'NCBITaxon:10090', 'NCBITaxon:8355', 'NCBITaxon:8364', 'NCBITaxon:9606' ];
   let taxonList = unsortedTaxonList.sort((a, b) => (curieToNameTaxon[a] > curieToNameTaxon[b] ? 1 : -1));
   const entityTypeList = ['ATP:0000005', 'ATP:0000006'];
-  const access = getOktaModAccess(oktaGroups);
+  // const access = getOktaModAccess(oktaGroups);	// old way to get access before logging on put values in store
+  const access = useSelector(state => state.isLogged.oktaMod);
   // const access = 'WB';	// uncomment if you have developer okta access and need to test a specific mod
   if (access in modToTaxon) {
     let filteredTaxonList = taxonList.filter((x) => !modToTaxon[access].includes(x));

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -25,7 +25,7 @@ import {
 } from '../../actions/biblioActions';
 
 import {useDropzone} from 'react-dropzone';
-import {getOktaModAccess} from "../Biblio";
+// import {getOktaModAccess} from "../Biblio";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 const BiblioFileManagement = () => {
@@ -148,7 +148,10 @@ const FileUpload = ({main_or_supp}) => {
   const fileUploadingShowModal = useSelector(state => state.biblio.fileUploadingShowModal);
   const fileUploadingModalText = useSelector(state => state.biblio.fileUploadingModalText);
 
-  let access = getOktaModAccess(oktaGroups);
+  // let access = getOktaModAccess(oktaGroups);	// old way to get access before logging on put values in store
+  const oktaMod = useSelector(state => state.isLogged.oktaMod);
+  const oktaDeveloper = useSelector(state => state.isLogged.oktaDeveloper);
+  let access = (oktaDeveloper ? 'developer' : oktaMod);
   if (access === 'developer') {
     if (process.env.REACT_APP_DEV_OR_STAGE_OR_PROD === 'prod') {
       access = 'No';
@@ -365,7 +368,10 @@ const FileEditor = () => {
     cssDisplayLeft = ''; cssDisplayRight = 'Col-editor-disabled';
   }
   let rowReferencefileElements = [];
-  const access = getOktaModAccess(oktaGroups);
+  // const access = getOktaModAccess(oktaGroups);	// old way to get access before logging on put values in store
+  const oktaMod = useSelector(state => state.isLogged.oktaMod);
+  const oktaDeveloper = useSelector(state => state.isLogged.oktaDeveloper);
+  let access = (oktaDeveloper ? 'developer' : oktaMod);
   let referenceFilesWithAccess = referencefiles
       .filter((referenceFile) => referenceJsonLive["copyright_license_open_access"] === true || access === 'developer' || referenceFile.referencefile_mods
           .some((mod) => mod.mod_abbreviation === access || mod.mod_abbreviation === null));

--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -25,7 +25,6 @@ import {
 } from '../../actions/biblioActions';
 
 import {useDropzone} from 'react-dropzone';
-// import {getOktaModAccess} from "../Biblio";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 const BiblioFileManagement = () => {
@@ -148,7 +147,6 @@ const FileUpload = ({main_or_supp}) => {
   const fileUploadingShowModal = useSelector(state => state.biblio.fileUploadingShowModal);
   const fileUploadingModalText = useSelector(state => state.biblio.fileUploadingModalText);
 
-  // let access = getOktaModAccess(oktaGroups);	// old way to get access before logging on put values in store
   const oktaMod = useSelector(state => state.isLogged.oktaMod);
   const oktaDeveloper = useSelector(state => state.isLogged.oktaDeveloper);
   let access = (oktaDeveloper ? 'developer' : oktaMod);
@@ -368,7 +366,6 @@ const FileEditor = () => {
     cssDisplayLeft = ''; cssDisplayRight = 'Col-editor-disabled';
   }
   let rowReferencefileElements = [];
-  // const access = getOktaModAccess(oktaGroups);	// old way to get access before logging on put values in store
   const oktaMod = useSelector(state => state.isLogged.oktaMod);
   const oktaDeveloper = useSelector(state => state.isLogged.oktaDeveloper);
   let access = (oktaDeveloper ? 'developer' : oktaMod);

--- a/src/reducers/isLoggedReducer.js
+++ b/src/reducers/isLoggedReducer.js
@@ -4,6 +4,10 @@ const INTIAL_STATE = {
   isSignedIn: null,
   userId: null,
   oktaGroups: null,
+  oktaMod: 'No',
+  oktaDeveloper: false,
+  oktaTester: false,
+  oktaPOTester: false,
   accessToken: null
 };
 
@@ -11,9 +15,35 @@ const loggedReducer = (state = INTIAL_STATE, action) => {
   switch (action.type) {
     case 'SIGN_IN':
       const jsonToken = jwt_decode(action.payload.accessToken);
-      return {...state, isSignedIn: true, userId: action.payload.userId, accessToken: action.payload.accessToken, oktaGroups: jsonToken.Groups}
+      let oktaMod = null;
+      let oktaDeveloper = null;
+      let oktaTester = null;
+      let oktaPOTester = null;
+      if (jsonToken.Groups) {
+        for (const oktaGroup of jsonToken.Groups) {
+          if (oktaGroup.endsWith('Developer')) { oktaDeveloper = true; }
+          if (oktaGroup === 'Tester') { oktaTester = true; }
+          if (oktaGroup === 'POTester') { oktaPOTester = true; }
+          if (oktaGroup.startsWith('SGD')) { oktaMod = 'SGD'; }
+            else if (oktaGroup.startsWith('RGD')) { oktaMod = 'RGD'; }
+            else if (oktaGroup.startsWith('MGI')) { oktaMod = 'MGI'; }
+            else if (oktaGroup.startsWith('ZFIN')) { oktaMod = 'ZFIN'; }
+            else if (oktaGroup.startsWith('Xen')) { oktaMod = 'XB'; }
+            else if (oktaGroup.startsWith('Fly')) { oktaMod = 'FB'; }
+            else if (oktaGroup.startsWith('Worm')) { oktaMod = 'WB'; } }
+      }
+      return {
+        ...state,
+        isSignedIn: true,
+        userId: action.payload.userId,
+        accessToken: action.payload.accessToken,
+        oktaMod: oktaMod,
+        oktaDeveloper: oktaDeveloper,
+        oktaTester: oktaTester,
+        oktaPOTester: oktaPOTester,
+        oktaGroups: jsonToken.Groups }
     case 'SIGN_OUT':
-      return {...state, isSignedIn: false, userId: null, oktaGroups: null}
+      return {...state, isSignedIn: false, userId: null, oktaGroups: null, oktaMod: 'No', oktaDeveloper: false, oktaTester: false, oktaPOTester: false}
     default:
       return state;
   }


### PR DESCRIPTION
Hi @valearna and @pjhale .  This code probably works and could be merged, but making a draft PR in case either of you is really opposed to how it's changed (I left a bunch of stuff commented out instead of removing it).  Basically, when someone logs on to okta, I'm mostly using Paul's code to get the MOD, then using the old code to get whether they're a developer, and additionally now checking for Tester and POTester, and storing those as values in the store, as siblings to oktaGroups.  Then every component that would previously import getOktaModAccess and use that, can just useSelector to get it from the store, and in most cases the access is based on oktaMod + oktaDeveloper, but in the Tracker it can just use oktaMod because we explicitly don't want developer there.  I think just storing some extra booleans and a string is going to be simpler than understanding and importing the function, which works differently in different cases, and since we have to change the background color based on whether the oktaMod is different from the manual tester Mod, it will probably be easier with the store (I haven't figured that out yet, but I don't think it'll be a problem).  Up next, I'll probably add the Tester component to save a tester Mod value to the store, and probably a 'different-than-oktaMod' boolean that would set a different background color.

Edit: Also fixed a key warning in Tracker.js and some import warnings on Biblio.js