### PR TITLE
SCRUM-2736 OR search.

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -58,7 +58,7 @@ export const searchReferences = () => {
     dispatch(setSearchLoading());
 
     let params = {
-      query: state.search.searchQuery,
+      query: state.search.searchQuery.replace(/\|/g,'\\|').replace(/OR/g,"|"),
       size_result_count: state.search.searchSizeResultsCount,
       page: state.search.searchResultsPage,
       facets_values: state.search.searchFacetsValues,


### PR DESCRIPTION
First does a find and replace for the OR characters... then escapes the  | character in case its in any searches.