### PR TITLE
added code to automate qualifier addition for SGD when topics selected plus

### DIFF
--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -36,18 +36,6 @@ export const changeFieldArrayReferenceJson = (e) => {
   };
 };
 
-export const deleteFieldModReferenceReferenceJson = (e) => {
-  console.log('action delete field mod reference json ' + e.target.id + ' to delete');
-//   console.log(e);
-  const activeElement = getRevertButtonFromFontAwesomeElement(e.target);
-  return {
-    type: 'DELETE_FIELD_MOD_REFERENCE_REFERENCE_JSON',
-    payload: {
-      field: activeElement.id
-    }
-  };
-};
-
 export const changeFieldModReferenceReferenceJson = (e) => {
   console.log('action change field mod reference json ' + e.target.id + ' to ' + e.target.value);
 //   console.log(e);
@@ -56,18 +44,6 @@ export const changeFieldModReferenceReferenceJson = (e) => {
     payload: {
       field: e.target.id,
       value: e.target.value
-    }
-  };
-};
-
-export const deleteFieldCrossReferencesReferenceJson = (e) => {
-  console.log('action delete field cross references json ' + e.target.id + ' to delete');
-//   console.log(e);
-  const activeElement = getRevertButtonFromFontAwesomeElement(e.target);
-  return {
-    type: 'DELETE_FIELD_CROSS_REFERENCES_REFERENCE_JSON',
-    payload: {
-      field: activeElement.id
     }
   };
 };
@@ -85,23 +61,12 @@ export const changeFieldCrossReferencesReferenceJson = (e) => {
   };
 };
 
-export const deleteFieldModAssociationReferenceJson = (e) => {
-  console.log('action delete field mod association json ' + e.target.id + ' to delete');
-//   console.log(e);
-  const activeElement = getRevertButtonFromFontAwesomeElement(e.target);
-  return {
-    type: 'DELETE_FIELD_MOD_ASSOCIATION_REFERENCE_JSON',
-    payload: {
-      field: activeElement.id
-    }
-  };
-};
-
+// TODO to make live, add this to biblioActions.js  rename MOCK1_CHANGE_FIELD_MOD_ASSOCIATION_REFERENCE_JSON    create reducer action for it
 export const changeFieldModAssociationReferenceJson = (e) => {
   console.log('action change field mod association json ' + e.target.id + ' to ' + e.target.value + ' checked ' + e.target.checked);
 //   console.log(e);
   return {
-    type: 'CHANGE_FIELD_MOD_ASSOCIATION_REFERENCE_JSON',
+    type: 'CHANGE_FIELD_MOD_ASSOCIATION_REFERENCE_JSON',	// this doesn't do anything yet
     payload: {
       field: e.target.id,
       checked: e.target.checked,
@@ -331,7 +296,6 @@ export const updateButtonBiblioEntityAdd = (updateArrayData) => { return dispatc
     }));
 } };
 
-
 export const changeFieldEntityEntityList = (entityText, accessToken, taxon, entityType) => {
   return dispatch => {
     // console.log('action change field entity list ' + entityText + ' entityType ' + entityType);
@@ -551,6 +515,24 @@ export const fetchModReferenceTypes = async (mods) => {
     }
   }
   return modReferenceTypes
+}
+
+export const fetchQualifierData = async (accessToken) => {
+  try {
+    const response = await axios.get(`${process.env.REACT_APP_ATEAM_API_BASE_URL}api/atpterm/ATP:0000136/descendants`, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      mode: 'cors'
+    });
+    return response.data.entities;
+    // const qualifierData = response.data.entities.map(x => ({ curie: x.curie, name: x.name }));
+    // return qualifierData;
+  } catch (error) {
+    console.error('Error occurred:', error);
+    throw error;
+  }
 }
 
 export const biblioQueryReferenceCurie = (referenceCurie) => dispatch => {

--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -526,9 +526,13 @@ export const fetchQualifierData = async (accessToken) => {
       },
       mode: 'cors'
     });
-    return response.data.entities;
+    // return response.data.entities;
     // const qualifierData = response.data.entities.map(x => ({ curie: x.curie, name: x.name }));
     // return qualifierData;
+    const qualifierData = response.data.entities
+      .filter(x => x.name !== 'other primary display')
+      .map(x => ({ curie: x.curie, name: x.name }));
+    return qualifierData; 
   } catch (error) {
     console.error('Error occurred:', error);
     throw error;

--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -36,6 +36,18 @@ export const changeFieldArrayReferenceJson = (e) => {
   };
 };
 
+export const deleteFieldModReferenceReferenceJson = (e) => {
+  console.log('action delete field mod reference json ' + e.target.id + ' to delete');
+//   console.log(e);
+  const activeElement = getRevertButtonFromFontAwesomeElement(e.target);
+  return {
+    type: 'DELETE_FIELD_MOD_REFERENCE_REFERENCE_JSON',
+    payload: {
+      field: activeElement.id
+    }
+  };
+};
+
 export const changeFieldModReferenceReferenceJson = (e) => {
   console.log('action change field mod reference json ' + e.target.id + ' to ' + e.target.value);
 //   console.log(e);

--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -60,6 +60,18 @@ export const changeFieldModReferenceReferenceJson = (e) => {
   };
 };
 
+export const deleteFieldCrossReferencesReferenceJson = (e) => {
+  console.log('action delete field cross references json ' + e.target.id + ' to delete');
+//   console.log(e);
+  const activeElement = getRevertButtonFromFontAwesomeElement(e.target);
+  return {
+    type: 'DELETE_FIELD_CROSS_REFERENCES_REFERENCE_JSON',
+    payload: {
+      field: activeElement.id
+    }
+  };
+};
+
 export const changeFieldCrossReferencesReferenceJson = (e) => {
   console.log('action change field cross references json ' + e.target.id + ' to ' + e.target.value + ' checked ' + e.target.checked);
 //   console.log(e);
@@ -73,12 +85,23 @@ export const changeFieldCrossReferencesReferenceJson = (e) => {
   };
 };
 
-// TODO to make live, add this to biblioActions.js  rename MOCK1_CHANGE_FIELD_MOD_ASSOCIATION_REFERENCE_JSON    create reducer action for it
+export const deleteFieldModAssociationReferenceJson = (e) => {
+  console.log('action delete field mod association json ' + e.target.id + ' to delete');
+//   console.log(e);
+  const activeElement = getRevertButtonFromFontAwesomeElement(e.target);
+  return {
+    type: 'DELETE_FIELD_MOD_ASSOCIATION_REFERENCE_JSON',
+    payload: {
+      field: activeElement.id
+    }
+  };
+};
+
 export const changeFieldModAssociationReferenceJson = (e) => {
   console.log('action change field mod association json ' + e.target.id + ' to ' + e.target.value + ' checked ' + e.target.checked);
 //   console.log(e);
   return {
-    type: 'CHANGE_FIELD_MOD_ASSOCIATION_REFERENCE_JSON',	// this doesn't do anything yet
+    type: 'CHANGE_FIELD_MOD_ASSOCIATION_REFERENCE_JSON',
     payload: {
       field: e.target.id,
       checked: e.target.checked,
@@ -307,6 +330,7 @@ export const updateButtonBiblioEntityAdd = (updateArrayData) => { return dispatc
       payload: { responseMessage: 'error: ' + subPath + ' ' + err }
     }));
 } };
+
 
 export const changeFieldEntityEntityList = (entityText, accessToken, taxon, entityType) => {
   return dispatch => {
@@ -544,7 +568,7 @@ export const fetchQualifierData = async (accessToken) => {
     const qualifierData = response.data.entities
       .filter(x => x.name !== 'other primary display')
       .map(x => ({ curie: x.curie, name: x.name }));
-    return qualifierData; 
+    return qualifierData;
   } catch (error) {
     console.error('Error occurred:', error);
     throw error;

--- a/src/components/biblio/BiblioEntity.js
+++ b/src/components/biblio/BiblioEntity.js
@@ -250,7 +250,23 @@ const EntityCreate = () => {
 			      'NCBITaxon:8355', 'NCBITaxon:8364', 'NCBITaxon:9606' ];
   let taxonList = unsortedTaxonList.sort((a, b) => (curieToNameTaxon[a] > curieToNameTaxon[b] ? 1 : -1));
   const entityTypeList = ['', 'ATP:0000005', 'ATP:0000006'];
-
+  const sgdTopicList = [{'curie': 'ATP:0000012', 'name': 'gene ontology'},
+			{'curie': 'ATP:0000079', 'name': 'classical phenotype information'},
+	                {'curie': 'ATP:0000129', 'name': 'headline information'},
+			{'curie': 'ATP:0000128', 'name': 'protein containing complex'},
+			{'curie': 'ATP:0000???', 'name': 'other primary info(place holder)'},
+			{'curie': 'ATP:0000085', 'name': 'high throughput phenotype assay'},
+			{'curie': 'ATP:00000??', 'name': 'other HTP data (OMICs) (place holder)'},
+			{'curie': 'ATP:00?????', 'name': 'reviews (place holder)'},
+			{'curie': 'ATP:0000011', 'name': 'homology/disease'},
+			{'curie': 'ATP:0000088', 'name': 'post translational modification'},
+			{'curie': 'ATP:0000070', 'name': 'regulation information'},
+			{'curie': 'ATP:0000022', 'name': 'pathways'},
+			{'curie': 'ATP:0000149', 'name': 'metabolic engineering'},
+			{'curie': 'ATP:0000054', 'name': 'gene model'},
+			{'curie': 'ATP:0000006', 'name': 'allele'},
+			{'curie': 'ATP:000000?', 'name': 'other additional literature(place holder)'}];
+			  
   /*
    ATP:0000128: protein containing complex
    ATP:0000012: gene ontology
@@ -348,7 +364,7 @@ const EntityCreate = () => {
     }
     if (isPrimaryTopic) {
       if (isEntityEmpty || isEntityInvalid) {
-        return ["You need to add a valid gene or other entity.", false];
+        return ["This topic requires the inclusion of a valid gene or entity.", false];
       }
       return [false, primaryDisplay];
     }
@@ -360,7 +376,7 @@ const EntityCreate = () => {
     */
     if (sgdOmicsTopics.includes(topicSelect)) {
       if (isEntityEmpty === false) {
-	return ["There is no need to include any entities in a paper containing HTP data.", false];
+	return ["HTP topics do not require genes or entities", false];
       }
       return [false, omicsDisplay];
     }
@@ -375,7 +391,7 @@ const EntityCreate = () => {
         return [false, ''];
       }
       else if (isEntityInvalid) {
-	return ["You are not required to add an entity for this topic, but if you choose to do so, please ensure that it is valid. Otherwise, please omit the entity.", false];
+	return ["The addition of entities are not required for this topic, but if associated they must be valid genes or entities", false];
       }
       return [false, additionalDisplay];
     }
@@ -386,13 +402,22 @@ const EntityCreate = () => {
      -------------------------------------------------------------------
     */
     if (topicSelect === sgdReviewTopic) {
-      return [false, reviewDisplay];
+      if (isEntityEmpty) {
+        return [false, reviewDisplay];
+      }
+      else if (isEntityInvalid) {
+	return ["Entities are optional for papers assigned as reviews, but when associated they must be valid genes or entities", false];
+      }
+      else {
+	return [false, reviewDisplay];
+      }
     }
-    return ['You select an unknown topic for SGD. Please make the necessary correction.', false]
+    //return ['You select an unknown topic for SGD. Please make the necessary correction.', false]
+    return ['Pick a topic!', false]  
   }
 
   function getQualifierForTopic(topicSelect) {
-
+    setTopicSelect(topicSelect)
     if (accessLevel !== 'SGD') {
       return '';
     }
@@ -422,7 +447,7 @@ const EntityCreate = () => {
         setWarningMessage(warningMessage)
         setTimeout(() => {
           setWarningMessage('');
-        }, 5000);
+        }, 8000);
         return;
       }
       setNewQualifier(qualifier);
@@ -492,42 +517,15 @@ const EntityCreate = () => {
 	<Row className="form-group row">
 	  <Col sm="3">
 	    <div><label>Topic:</label></div>
-	    <AsyncTypeahead isLoading={topicSelectLoading} placeholder="Start typing to search topics"
-                            ref={topicTypeaheadRef} id="topicTypeahead"
-              onSearch={(query) => {
-                setTopicSelectLoading(true);
-                axios.post(process.env.REACT_APP_ATEAM_API_BASE_URL + 'api/atpterm/search?limit=10&page=0',
-                  {
-                    "searchFilters": {
-                      "nameFilter": {
-                        "name": {
-                          "queryString": query,
-                          "tokenOperator": "AND"
-                        }
-                      }
-                    },
-                    "sortOrders": [],
-                    "aggregations": [],
-                    "nonNullFieldsTable": []
-                  },
-                  { headers: {
-                      'content-type': 'application/json',
-                      'authorization': 'Bearer ' + accessToken
-                    }
-                  })
-                .then(res => {
-                  setTopicSelectLoading(false);
-                  setTypeaheadName2CurieMap(Object.fromEntries(res.data.results.map(item => [item.name, item.curie])))
-                  setTypeaheadOptions(res.data.results.map(item => item.name));
-                });
-              }}
-	      onChange={(selected) => {
-                setTopicSelect(typeaheadName2CurieMap[selected[0]]);
-                // Set the qualifier value based on the selected topic
-		setNewQualifier(getQualifierForTopic(typeaheadName2CurieMap[selected[0]]));
-              }}
-              options={typeaheadOptions}
-            />
+            <Form.Control as="select" id="topicSelect" type="topicSelect" value={topicSelect} onChange={(e) => { setNewQualifier(getQualifierForTopic(e.target.value)) }} >
+              <option value=""> Pick a topic </option> {/* Empty option */}
+              {sgdTopicList
+                .map((option, index) => (
+                  <option key={`topicSelect-${index}`} value={option.curie}>
+                    {option.name}
+                  </option>
+              ))}
+            </Form.Control>
 	  </Col>
 	  <Col sm="3">
             <div><label>Entity Type:</label></div>

--- a/src/components/biblio/BiblioEntity.js
+++ b/src/components/biblio/BiblioEntity.js
@@ -356,7 +356,7 @@ const EntityCreate = () => {
     */
     if (sgdOmicsTopics.includes(topicSelect)) {
       if (isEntityEmpty === false) {
-	return ["You don't need to add any entities to a paper with HTP phenotype data", false];
+	return ["There is no need to include any entities in a paper containing HTP data.", false];
       }
       return [false, omicsDisplay];
     }
@@ -371,7 +371,7 @@ const EntityCreate = () => {
         return [false, ''];
       }
       else if (isEntityInvalid) {
-	return ["If you want to add an entity, add a valid one; otherwise remove the entity", false];
+	return ["You are not required to add an entity for this topic, but if you choose to do so, please ensure that it is valid. Otherwise, please omit the entity.", false];
       }
       return [false, additionalDisplay];
     }
@@ -394,7 +394,7 @@ const EntityCreate = () => {
           return [false, reviewDisplay];
         }
         else if (isEntityInvalid) {
-          return ["If you want to add an entity, add a valid one; otherwise remove the entity", false];
+          return ["You are not required to add an entity for this topic, but if you choose to do so, please ensure that it is valid. Otherwise, please omit the entity.", false];
         }
         return [false, reviewDisplay];
       }
@@ -409,14 +409,18 @@ const EntityCreate = () => {
        then set qualifier = 'ATP:0000132' (additional display) if it a valid entity
       */
       if (isEntityInvalid) {
-	return ["If you want to add an entity, add a valid one; otherwise remove the entity and set qualifier to ''", false];
+	return ["You are not required to add an entity for this topic, but if you choose to do so, please ensure that it is valid. Otherwise, please omit the entity and set qualifier to ''", false];
       }
       return [false, additionalDisplay]
     }
-    return ['You pick an unknown topic for SGD', false]
+    return ['You select an unknown topic for SGD. Please make the necessary correction.', false]
   }
 
   function getQualifierForTopic(topicSelect) {
+
+    if (accessLevel !== 'SGD') {
+      return '';
+    }
     if (sgdPrimaryTopics.includes(topicSelect)) {
       return primaryDisplay;
     }
@@ -425,12 +429,12 @@ const EntityCreate = () => {
     }
     if (sgdAdditionalTopics.includes(topicSelect) || topicSelect === sgdEntityTopic) {
       /* 
-       Set qualifier to 'additional display' first. 
-       * It will be reset to '' if no entity is provided
-       * or changed to 'review display' by curators if it is an 'entity' topic 
-         and is a review paper
-       * or changed to 'other primary display' if it is an 'entity' topic and has info 
-       * about entity (decided by curators)
+       Set qualifier to 'additional display' first.
+       * curators can also manually change it to 'primary display' if it is an 'entity' topic 
+         and has info about entity
+       * curators can also manually change it to 'review display' if it is an 'entity' topic
+         and it is a review paper
+       * otherwise, it will be reset to '' unless a valid gene/entity is provided
       */
       return additionalDisplay;
     }

--- a/src/components/biblio/BiblioEntity.js
+++ b/src/components/biblio/BiblioEntity.js
@@ -256,34 +256,38 @@ const EntityCreate = () => {
    ATP:0000012: gene ontology
    ATP:0000079: Classical phenotype information
    ATP:0000129: Headline information
+   ATP:0000???: place holder for other primary literature
   */
-  const sgdPrimaryTopics = ['ATP:0000128', 'ATP:0000012', 'ATP:0000079', 'ATP:0000129'];
+  const sgdPrimaryTopics = ['ATP:0000128', 'ATP:0000012', 'ATP:0000079', 'ATP:0000129',
+			    'ATP:0000???'];
   const primaryDisplay = 'ATP:0000147';
     
   /*
    ATP:0000085: high throughput phenotype assay
-   TODO: add another one: other HTP?
+   ATP:00000??: placeholder for Other HTP data (OMICs)’
   */
-  const sgdOmicsTopics = ['ATP:0000085'];
+  const sgdOmicsTopics = ['ATP:0000085', 'ATP:00000??'];
   const omicsDisplay = 'ATP:0000148';
-    
-  /*
-   ATP:0000142: entity (Gene model/Alleles/Reviews/other primary?)
-  */
-  const sgdEntityTopic = 'ATP:0000142';
-    
+      
   /* 
    ATP:0000011: Homology/Disease
    ATP:0000088: post translational modification
    ATP:0000070: regulatory interaction
    ATP:0000022: pathway
    ATP:0000149: metabolic engineering
+   ATP:0000054: gene model
+   ATP:0000006: allele
+   ATP:000000?: placeholder for 'other additional literature'
   */  
   const sgdAdditionalTopics = ['ATP:0000142', 'ATP:0000011', 'ATP:0000088', 'ATP:0000070',
-			       'ATP:0000022', 'ATP:0000149'];
+			       'ATP:0000022', 'ATP:0000149', 'ATP:0000054', 'ATP:0000006',
+			       'ATP:000000?'];
   const additionalDisplay = 'ATP:0000132';
+
+  /* place holder for review topic */
+  const sgdReviewTopic = 'ATP:00?????';  
   const reviewDisplay = 'ATP:0000130';
-    
+  
   useEffect(() => {
      fetchQualifierData(accessToken).then((data) => setQualifierData(data));
   }, [])
@@ -378,40 +382,11 @@ const EntityCreate = () => {
 
     /*
      -------------------------------------------------------------------
-     it is an entity topic ATP:0000142:
-       it can be review or gene model, alleles or has data about entity
+     qualifier = 'review display', ATP:0000130
      -------------------------------------------------------------------
-     qualifier can be 'additional display' (ATP:0000132) or 'review display' (ATP:0000130)
-     or no qualifier  
-     * for a review paper, entity is optional => qualifier = 'review display' (ATP:0000130)
-     * for a not-review paper, if there is an entity, qualifier = 'additional display'; 
-       otherwise, no qualifier => qualifier = ''
     */
-    if (topicSelect === sgdEntityTopic) {
-      // if it is a review paper	  
-      if (tetqualifierSelect === reviewDisplay) { 	  
-	if (isEntityEmpty) { // no gene/entity
-          return [false, reviewDisplay];
-        }
-        else if (isEntityInvalid) {
-          return ["You are not required to add an entity for this topic, but if you choose to do so, please ensure that it is valid. Otherwise, please omit the entity.", false];
-        }
-        return [false, reviewDisplay];
-      }
-
-      /* if it is not a review paper and it has no entity provided so set qualifier to '' */
-      if (isEntityEmpty) {
-	return [false, ''];
-      }		  
-
-      /*
-       if it is not a review paper and it has an entity provided
-       then set qualifier = 'ATP:0000132' (additional display) if it a valid entity
-      */
-      if (isEntityInvalid) {
-	return ["You are not required to add an entity for this topic, but if you choose to do so, please ensure that it is valid. Otherwise, please omit the entity and set qualifier to ''", false];
-      }
-      return [false, additionalDisplay]
+    if (topicSelect === sgdReviewTopic) {
+      return [false, reviewDisplay];
     }
     return ['You select an unknown topic for SGD. Please make the necessary correction.', false]
   }
@@ -427,16 +402,11 @@ const EntityCreate = () => {
     if (sgdOmicsTopics.includes(topicSelect)) {
       return omicsDisplay;
     }
-    if (sgdAdditionalTopics.includes(topicSelect) || topicSelect === sgdEntityTopic) {
-      /* 
-       Set qualifier to 'additional display' first.
-       * curators can also manually change it to 'primary display' if it is an 'entity' topic 
-         and has info about entity
-       * curators can also manually change it to 'review display' if it is an 'entity' topic
-         and it is a review paper
-       * otherwise, it will be reset to '' unless a valid gene/entity is provided
-      */
+    if (sgdAdditionalTopics.includes(topicSelect)) {
       return additionalDisplay;
+    }
+    if (topicSelect === sgdReviewTopic) {
+      return reviewDisplay;
     }
     return '';
   }


### PR DESCRIPTION
* added code to get a list of qualifiers from A-team ATP ontology
* added code to make sure some topics (GO, phenotype, headline, protein complex, other primary literature) require entity
* also make sure Omics topics (HTP Phenotype data and other HTP data) do not require entity
* for review papers, the entity is optional, but they always get 'review display' 
* for other topics like 'pathway', 'regulation', PTM, gene model etc, the entity is optional, and they will get 'additional display' only if the entity is provided.

TODO: need to fix the warning message display. Hopefully, @valearna can lead a coding session to fix this along with other warnings across UI codebase.  