### PR TITLE
SCRUM-2872 new button in Merge section to discard changes, swap input…

### DIFF
--- a/src/actions/mergeActions.js
+++ b/src/actions/mergeActions.js
@@ -39,7 +39,7 @@ export const mergeToggleIndependent = (fieldName, oneOrTwo, index) => {
 //   console.log("action mergeSwapPairSimple " + fieldName);
 // }
 
-export const mergeQueryReferences = (referenceInput1, referenceInput2) => dispatch => {
+export const mergeQueryReferences = (referenceInput1, referenceInput2, swapBool) => dispatch => {
   // console.log("ref1 " + referenceInput1);
   // console.log("ref2 " + referenceInput2);
   dispatch({
@@ -109,7 +109,7 @@ export const mergeQueryReferences = (referenceInput1, referenceInput2) => dispat
     return [curieValue, curieFound];
   }
 
-  const queryBothXrefs = async (referenceInput1, referenceInput2) => {
+  const queryBothXrefs = async (referenceInput1, referenceInput2, swapBool) => {
     let promiseXref1 = resolveReferenceCurie(referenceInput1);
     let promiseXref2 = resolveReferenceCurie(referenceInput2);
     let valuesXref = await Promise.allSettled([promiseXref1, promiseXref2]);
@@ -167,11 +167,12 @@ export const mergeQueryReferences = (referenceInput1, referenceInput2) => dispat
         curieValue2: curieValue2,
         referenceJson2: referenceJson2,
         referenceFound2: referenceFound2,
+        swapBool: swapBool,
         blah: 'blah'
     }});
   }
 
-  queryBothXrefs(referenceInput1, referenceInput2);
+  queryBothXrefs(referenceInput1, referenceInput2, swapBool);
 }
 
 export const mergeButtonApiDispatch = (updateArrayData) => dispatch => {

--- a/src/components/Merge.js
+++ b/src/components/Merge.js
@@ -135,8 +135,12 @@ const MergeSelectionSection = () => {
       <Row>
         <Col sm="12" >
           {(() => {
-            if (queryDoubleSuccess) { return (<Button variant='warning' onClick={() => dispatch(mergeResetReferences())} >Discard changes and new query</Button>) }
-            return (<Button variant='primary' onClick={(e) => dispatch(mergeQueryReferences(referenceMeta1.input, referenceMeta2.input))} >
+            if (queryDoubleSuccess) { 
+              return (<>
+                        <Button variant='warning' onClick={() => dispatch(mergeResetReferences())} >Discard changes and new query</Button>&nbsp;
+                        <Button variant='warning' onClick={(e) => dispatch(mergeQueryReferences(referenceMeta2.input, referenceMeta1.input, true))} >Swap and Start Over</Button>
+                      </>) }
+            return (<Button variant='primary' onClick={(e) => dispatch(mergeQueryReferences(referenceMeta1.input, referenceMeta2.input, false))} >
               {isLoadingReferences ? <Spinner animation="border" size="sm"/> : "Query for these references"}</Button>);
           })()}
         </Col>

--- a/src/reducers/mergeReducer.js
+++ b/src/reducers/mergeReducer.js
@@ -13,7 +13,7 @@ const initialState = {
     blah: ''
   },
   referenceMeta1: {
-    input: 'PMID:23524264',
+    input: 'CGC:cgc3',
     curie: '',
     referenceJson: '',
     referenceKeep: {},
@@ -240,6 +240,10 @@ export default function(state = initialState, action) {
       const mergeQueryHasPmid = (mergeQueryHasPmid1 || mergeQueryHasPmid2) ? true : false;
 
       initializeQueriedData(referenceMeta1Copy.referenceJson, referenceMeta2Copy.referenceJson);
+
+      if (action.payload.swapBool) {
+        referenceMeta1Copy.input = state.referenceMeta2.input;
+        referenceMeta2Copy.input = state.referenceMeta1.input; }
 
       return {
         ...state,


### PR DESCRIPTION
…, and re-query; which is distinct from just swapping the values in the form, which doesn't swap the right things when the winning paper doesn't have a PMID