### PR TITLE
SCRUM-2492 bugfix

### DIFF
--- a/src/components/ATeamAlert.js
+++ b/src/components/ATeamAlert.js
@@ -13,8 +13,10 @@ export const AlertAteamApiDown = () => {
     const [status, setStatus] = useState(true);
 
     useEffect(() => {
-        testAteamAPI(accessToken, setStatus);
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+        if(accessToken) {
+            testAteamAPI(accessToken, setStatus);
+        }
+    }, [accessToken]); // eslint-disable-line react-hooks/exhaustive-deps
 
 
     if(!status){


### PR DESCRIPTION
Test won't trigger without an access Token... preventing the error if a user is either not logged in or the page hasn't gotten the token yet.