### PR TITLE
Scrum 3045 - updated UI to use new topic entity tag APIs

### DIFF
--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -147,6 +147,34 @@ export const changeFieldDatePublishedRange = (datePublishedRange) => {
   };
 }
 
+export const getCuratorSourceId = async (mod, accessToken) => {
+  try{
+    const res = await axios.get(process.env.REACT_APP_RESTAPI + '/topic_entity_tag/source/curator/abc_literature_system/' + mod);
+    return res.data.topic_entity_tag_source_id;
+  } catch (error) {
+    if (error.response.status === 404) {
+      try {
+        const newSourceId = await axios.post(process.env.REACT_APP_RESTAPI + '/topic_entity_tag/source', {
+          "source_type": "curator",
+          "source_method": "abc_literature_system",
+          "validation_type": "curator",
+          "evidence": "set_eco_code_here",
+          "description": "describe source here",
+          "mod_abbreviation": mod
+        },{ headers: {
+            'content-type': 'application/json',
+            'mode': 'cors',
+            'authorization': 'Bearer ' + accessToken
+          }
+        });
+        return newSourceId;
+      } catch(error){
+        return undefined;
+      }
+    }
+  }
+}
+
 
 export const setBiblioUpdatingEntityAdd = (payload) => { return { type: 'SET_BIBLIO_UPDATING_ENTITY_ADD', payload: payload }; };
 

--- a/src/components/biblio/BiblioEntity.js
+++ b/src/components/biblio/BiblioEntity.js
@@ -310,12 +310,10 @@ const EntityCreate = () => {
     updateJson['topic'] = topicSelect;
     updateJson['species'] = taxonSelect;
     // TODO: add entity_published_as field when synonyms are in the A-team system
-    updateJson['sources'] = [
-      {
-        'source': 'curator',
-        'mod_abbreviation': accessLevel,
-        'note': noteText
-      }];
+    updateJson['note'] = noteText;
+    updateJson['negated'] = false;
+    updateJson['confidence_level'] = null;
+    updateJson['topic_entity_tag_source_id'] = topicEntitySourceId;
     if (tetdisplayTagSelect && tetdisplayTagSelect !== '') {
       updateJson['display_tag'] = tetdisplayTagSelect;
     }

--- a/src/components/biblio/BiblioEntity.js
+++ b/src/components/biblio/BiblioEntity.js
@@ -8,7 +8,7 @@ import {
   changeFieldEntityAddTaxonSelect,
   changeFieldEntityEditorPriority,
   changeFieldEntityEntityList,
-  fetchDisplayTagData,
+  fetchDisplayTagData, getCuratorSourceId,
   setBiblioUpdatingEntityAdd,
   setEntityModalText,
   setTypeaheadName2CurieMap,
@@ -250,6 +250,8 @@ const EntityCreate = () => {
   }, {});
   const displayTagList = displayTagData.map(option=> option.curie);  
   displayTagList.unshift('');
+
+  const [topicEntitySourceId, setTopicEntitySourceId] = useState(undefined);
     
   const modToTaxon = { 'ZFIN': ['NCBITaxon:7955'],
 		       'FB': ['NCBITaxon:7227'],
@@ -263,6 +265,15 @@ const EntityCreate = () => {
 			      'NCBITaxon:8355', 'NCBITaxon:8364', 'NCBITaxon:9606' ];
   let taxonList = unsortedTaxonList.sort((a, b) => (curieToNameTaxon[a] > curieToNameTaxon[b] ? 1 : -1));
   const entityTypeList = ['', 'ATP:0000005', 'ATP:0000006', 'ATP:0000123'];
+
+  useEffect(() => {
+    const fetchSourceId = async () => {
+      if (accessToken !== null) {
+        setTopicEntitySourceId(await getCuratorSourceId(accessLevel, accessToken));
+      }
+    }
+    fetchSourceId().catch(console.error);
+  }, [accessLevel, accessToken]);
 
   const topicDescendants = useSelector(state => state.biblio.topicDescendants);
   useEffect(() => {
@@ -385,7 +396,7 @@ const EntityCreate = () => {
   // const taxonSelect = 'NCBITaxon:6239';	// to hardcode if they don't want a dropdown
   // figure out if they want general disabling to work the same for the whole row, in which case combine the next two variables
   const disabledEntityList = (taxonSelect === '' || taxonSelect === undefined) ? 'disabled' : '';
-  const disabledAddButton = (taxonSelect === '' || taxonSelect === undefined) ? 'disabled' : '';
+  const disabledAddButton = (taxonSelect === '' || taxonSelect === undefined || topicEntitySourceId === undefined) ? 'disabled' : '';
 
   if (accessLevel === 'SGD') {
     return (


### PR DESCRIPTION
- get or create "curator" source at startup
- send data according to new schema when creating new topic entity tags