### PR TITLE
Adding Mod Preferences

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -26,6 +26,7 @@ export const SEARCH_SET_DATE_CREATED = 'SEARCH_SET_DATE_CREATED';
 export const SEARCH_SET_SEARCH_QUERY_FIELDS = 'SEARCH_SET_SEARCH_QUERY_FIELDS';
 export const SEARCH_SET_SORT_BY_PUBLISHED_DATE = 'SEARCH_SET_SORT_BY_PUBLISHED_DATE';
 export const SEARCH_SET_PARTIAL_MATCH = 'SEARCH_SET_PARTIAL_MATCH';
+export const SEARCH_SET_MOD_PREFERENCES_LOADED = 'SEARCH_SET_MOD_PREFERENCES_LOADED';
 
 const restUrl = process.env.REACT_APP_RESTAPI;
 
@@ -310,5 +311,12 @@ export const setPartialMatch = (partialMatch) => ({
   type: SEARCH_SET_PARTIAL_MATCH,
   payload: {
     partialMatch : partialMatch
+  }
+});
+
+export const setModPreferencesLoaded = (modPreferencesLoaded) => ({
+  type: SEARCH_SET_MOD_PREFERENCES_LOADED,
+  payload: {
+    modPreferencesLoaded : modPreferencesLoaded
   }
 });

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -340,7 +340,15 @@ const Facets = () => {
     useEffect(()=> {
         if(modPreferencesLoaded === 'false' && oktaMod !== 'No'){
             dispatch(setModPreferencesLoaded(true));
-            dispatch(addFacetValue("mods_in_corpus_or_needs_review.keyword", oktaMod));
+            if(searchFacetsValues["mods_in_corpus_or_needs_review.keyword"]){
+                if(!searchFacetsValues["mods_in_corpus_or_needs_review.keyword"].includes(oktaMod)) {
+                    dispatch(addFacetValue("mods_in_corpus_or_needs_review.keyword", oktaMod));
+                }
+            }
+            else{
+                dispatch(addFacetValue("mods_in_corpus_or_needs_review.keyword", oktaMod));
+            }
+
         }
     }, [oktaMod]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -14,7 +14,8 @@ import {
     setDatePubmedAdded,
     setDatePubmedModified,
     setDatePublished,
-    setDateCreated
+    setDateCreated,
+    setModPreferencesLoaded
 } from '../../actions/searchActions';
 import Form from 'react-bootstrap/Form';
 import {Badge, Button, Collapse} from 'react-bootstrap';
@@ -295,6 +296,8 @@ const Facets = () => {
     const datePubmedModified = useSelector(state => state.search.datePubmedModified);
     const datePubmedAdded = useSelector(state => state.search.datePubmedAdded);
     const datePublished= useSelector(state => state.search.datePublished);
+    const oktaMod = useSelector(state => state.isLogged.oktaMod);
+    const modPreferencesLoaded = useSelector(state => state.search.modPreferencesLoaded);
     const dispatch = useDispatch();
 
     const toggleFacetGroup = (facetGroupLabel) => {
@@ -333,6 +336,13 @@ const Facets = () => {
         }
         setOpenFacets(newOpenFacets);
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(()=> {
+        if(modPreferencesLoaded === 'false' && oktaMod !== 'No'){
+            dispatch(setModPreferencesLoaded(true));
+            dispatch(addFacetValue("mods_in_corpus_or_needs_review.keyword", oktaMod));
+        }
+    }, [oktaMod]) // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <>

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -10,10 +10,12 @@ import {
   SEARCH_SET_FACETS_LOADING, SEARCH_SET_DATE_PUBMED_MODIFIED,
   SEARCH_SET_DATE_PUBLISHED, SEARCH_SET_SEARCH_QUERY_FIELDS,
   SEARCH_SET_SORT_BY_PUBLISHED_DATE, SEARCH_SET_PARTIAL_MATCH,
-  SEARCH_SET_DATE_CREATED, SEARCH_SET_CROSS_REFERENCE_RESULTS
+  SEARCH_SET_DATE_CREATED, SEARCH_SET_CROSS_REFERENCE_RESULTS,
+  SEARCH_SET_MOD_PREFERENCES_LOADED
 } from '../actions/searchActions';
 
 import _ from "lodash";
+
 
 
 export const INITIAL_FACETS_LIMIT = 10;
@@ -46,7 +48,8 @@ const initialState = {
   dateCreated: "",
   query_fields:"All",
   sort_by_published_date_order:"relevance",
-  partialMatch:"true"
+  partialMatch:"true",
+  modPreferencesLoaded:"false"
 };
 
 // to ignore a warning about Unexpected default export of anonymous function
@@ -236,6 +239,12 @@ export default function(state = initialState, action) {
       return {
         ...state,
         partialMatch: action.payload.partialMatch
+      }
+
+    case SEARCH_SET_MOD_PREFERENCES_LOADED:
+      return {
+        ...state,
+        modPreferencesLoaded: action.payload.modPreferencesLoaded
       }
 
 //     case 'FETCH_POSTS':


### PR DESCRIPTION
When someone is logged in the facet "in corpus or needs review" is automatically selected.  This is accomplished by another variable in the reducer that tracks is we have loaded these yet.  Users can deselect the preloaded facet and it will only return on a page refresh.

Keeping as draft until Kimberly can look at it.