### PR TITLE
reverse priority in case of someone not being logged on having access…

### DIFF
--- a/src/components/Biblio.js
+++ b/src/components/Biblio.js
@@ -302,11 +302,11 @@ export const RowDisplayReferencefiles = ({displayOrEditor}) => {
     }
     let filename = referencefileDict['display_name'] + '.' + referencefileDict['file_extension'];
     let referencefileValue = (<div>{filename} &nbsp;({allowed_mods.join(", ")})</div>);
-    if (referenceJsonLive["copyright_license_open_access"] === true || accessLevel === 'developer') {
+    if (accessLevel === 'No') {
+      is_ok = false;
+      referencefileValue = (<div>{filename}</div>);
+    } else if (referenceJsonLive["copyright_license_open_access"] === true || accessLevel === 'developer') {
       is_ok = true;
-    } else if (accessLevel === 'No') {
-        is_ok = false;
-        referencefileValue = (<div>{filename}</div>);
     }
     if (is_ok) {
       hasAccessToTarball = true;


### PR DESCRIPTION
…Level be No, but the file being open access true, which was creating links for download, which could not be downloaded