### PR TITLE
SCRUM-3386 Removing Whitespace from searches

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -63,7 +63,7 @@ export const searchReferences = () => {
     dispatch(setSearchLoading());
 
     let params = {
-      query: state.search.searchQuery.replace(/\|/g,'\\|').replace(/\+/g,'\\+').replace(/OR/g,"|").replace(/AND/g,"+"),
+      query: state.search.searchQuery.replace(/\|/g,'\\|').replace(/\+/g,'\\+').replace(/OR/g,"|").replace(/AND/g,"+").trim(),
       size_result_count: state.search.searchSizeResultsCount,
       page: state.search.searchResultsPage,
       facets_values: state.search.searchFacetsValues,
@@ -112,7 +112,7 @@ export const filterFacets = (query, facetsValues, excludedFacetsValues, facetsLi
   return dispatch => {
     dispatch(setFacetsLoading());
     let params = {
-      query: query,
+      query: query.replace(/\|/g,'\\|').replace(/\+/g,'\\+').replace(/OR/g,"|").replace(/AND/g,"+").trim(),
       size_result_count: sizeResultsCount,
       page: searchResultsPage,
       facets_values: facetsValues,


### PR DESCRIPTION
Search now trims whitespace from both ends before sending to ES.  This prevents weird behavior that happens with wildcards.  Also changed so that ES always gets the search string after the translation of AND's and OR's.