### PR TITLE
Fixed the search UI to make the facets section always visible 

### DIFF
--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -25,16 +25,25 @@ const SearchLayout = () => {
                     </Col>
                 </Row>
                 <Row><Col>&nbsp;</Col></Row>
-                 <Row>
-                     <Col>
-                         <BreadCrumbs/>
-                     </Col>
-                 </Row>
+                <Row>
+                    <Col>
+                        <BreadCrumbs/>
+                    </Col>
+                </Row>
                 <Row><Col>&nbsp;</Col></Row>
                 <Row>
                     <Col>
                         <div style={{display: "flex"}}>
-                            <div style={{maxWidth: "32em", flex: "1", position: "sticky", top: "0px", alignSelf: "flex-start", zIndex: 1000}}>
+                            <div style={{
+                                maxWidth: "32em",
+                                flex: "1",
+                                position: "sticky", // to make the facets section always visible
+                                top: "0px",
+                                alignSelf: "flex-start",
+                                zIndex: 1000,
+                                maxHeight: "100vh", // set maximum height to 100% of the viewport height
+                                overflowY: "auto" // enable vertical scrolling within the facets container
+                            }}>
                                 <Facets/>
                             </div>
                             <div style={{flex: "3", marginLeft: "20px"}}>

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -34,16 +34,16 @@ const SearchLayout = () => {
                 <Row>
                     <Col>
                         <div style={{display: "flex"}}>
-                            <div style={{maxWidth: "32em", flex: "1"}}>
+                            <div style={{maxWidth: "32em", flex: "1", position: "sticky", top: "0px", alignSelf: "flex-start", zIndex: 1000}}>
                                 <Facets/>
                             </div>
-                            <div style={{flex: "1", }}>
+                            <div style={{flex: "3", marginLeft: "20px"}}>
                                 <SearchResults/>
                             </div>
                         </div>
                     </Col>
                 </Row>
-                <Row ><Col  sm={6}></Col><Col  sm={4}><SearchPagination/></Col></Row>
+                <Row><Col sm={6}></Col><Col sm={4}><SearchPagination/></Col></Row>
             </Container>
         </div>
     )


### PR DESCRIPTION
Fixed the search UI to make the facets section always visible on the left side of the screen as users scroll down the search results page. Also added code to make facets section scrollable.

Should we put the css code for this in App.css?
