### PR TITLE
Fixing Author Filter and Code Cleanup

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -57,35 +57,40 @@ export const fetchInitialFacets = (facetsLimits) => {
   }
 }
 
+const getSearchParams = (state) => {
+  let params = {
+    query: state.search.searchQuery.replace(/\|/g,'\\|').replace(/\+/g,'\\+').replace(/OR/g,"|").replace(/AND/g,"+").trim(),
+    size_result_count: state.search.searchSizeResultsCount,
+    page: state.search.searchResultsPage,
+    facets_values: state.search.searchFacetsValues,
+    negated_facets_values: state.search.searchExcludedFacetsValues,
+    facets_limits: state.search.searchFacetsLimits,
+    author_filter: state.search.authorFilter,
+    query_fields: state.search.query_fields,
+    sort_by_published_date_order: state.search.sortByPublishedDate,
+    partial_match: state.search.partialMatch
+  }
+  if(state.search.datePubmedModified){
+    params.date_pubmed_modified = state.search.datePubmedModified;
+  }
+  if(state.search.datePubmedAdded){
+    params.date_pubmed_arrive = state.search.datePubmedAdded;
+  }
+  if(state.search.datePublished){
+    params.date_published = state.search.datePublished;
+  }
+  if(state.search.dateCreated){
+    params.date_created = state.search.dateCreated;
+  }
+
+  return params;
+}
+
 export const searchReferences = () => {
   return (dispatch,getState) => {
     const state = getState();
     dispatch(setSearchLoading());
-
-    let params = {
-      query: state.search.searchQuery.replace(/\|/g,'\\|').replace(/\+/g,'\\+').replace(/OR/g,"|").replace(/AND/g,"+").trim(),
-      size_result_count: state.search.searchSizeResultsCount,
-      page: state.search.searchResultsPage,
-      facets_values: state.search.searchFacetsValues,
-      negated_facets_values: state.search.searchExcludedFacetsValues,
-      facets_limits: state.search.searchFacetsLimits,
-      author_filter: state.search.authorFilter,
-      query_fields: state.search.query_fields,
-      sort_by_published_date_order: state.search.sortByPublishedDate,
-      partial_match: state.search.partialMatch
-    }
-    if(state.search.datePubmedModified){
-      params.date_pubmed_modified = state.search.datePubmedModified;
-    }
-    if(state.search.datePubmedAdded){
-      params.date_pubmed_arrive = state.search.datePubmedAdded;
-    }
-    if(state.search.datePublished){
-      params.date_published = state.search.datePublished;
-    }
-    if(state.search.dateCreated){
-      params.date_created = state.search.dateCreated;
-    }
+    let params = getSearchParams(state);
     axios.post(restUrl + '/search/references/', params )
 
         .then(res => {
@@ -108,28 +113,11 @@ export const searchReferences = () => {
   }
 }
 
-export const filterFacets = (query, facetsValues, excludedFacetsValues, facetsLimits, sizeResultsCount, searchResultsPage, authorFilter, datePubmedAdded, datePubmedModified, datePublished, sortByPublishedDate) => {
-  return dispatch => {
+export const filterFacets = () => {
+  return (dispatch,getState) => {
     dispatch(setFacetsLoading());
-    let params = {
-      query: query.replace(/\|/g,'\\|').replace(/\+/g,'\\+').replace(/OR/g,"|").replace(/AND/g,"+").trim(),
-      size_result_count: sizeResultsCount,
-      page: searchResultsPage,
-      facets_values: facetsValues,
-      negated_facets_values: excludedFacetsValues,
-      facets_limits: facetsLimits,
-      author_filter: authorFilter,
-      sort_by_published_date_order: sortByPublishedDate
-    }
-    if(datePubmedModified){
-      params.date_pubmed_modified = datePubmedModified;
-    }
-    if(datePubmedAdded){
-      params.date_pubmed_arrive = datePubmedAdded;
-    }
-    if(datePublished){
-      params.date_published = datePublished;
-    }
+    let state= getState();
+    let params= getSearchParams(state);
 
     axios.post(restUrl + '/search/references/', params)
         .then(res => {

--- a/src/components/biblio/topic_entity_tag/TopicEntityTable.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityTable.js
@@ -108,7 +108,7 @@ const TopicEntityTable = () => {
     { headerName: "Date Updated", field: "date_updated" , valueFormatter: dateFormatter },
     { headerName: "Validation By Author", field: "validation_by_author" },
     { headerName: "Validation By Professional Biocurator", field: "validation_by_professional_biocurator" },
-    { headerName: "Display Tag", field: "display_tag" },
+    { headerName: "Display Tag", field: "display_tag_name" },
     { headerName: "Source Secondary Data Provider", field: "topic_entity_tag_source.secondary_data_provider_abbreviation" },
     { headerName: "Source Data Provider", field: "topic_entity_tag_source.data_provider" },
     { headerName: "Source Evidence Assertion", field: "topic_entity_tag_source.source_evidence_assertion" ,valueFormatter: nameFormatter },

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -207,15 +207,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
 }
 
 const AuthorFilter = () => {
-  const searchQuery = useSelector(state => state.search.searchQuery);
-  const searchFacetsLimits = useSelector(state => state.search.searchFacetsLimits);
-  const searchSizeResultsCount = useSelector(state => state.search.searchSizeResultsCount);
-  const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
   const authorFilter = useSelector(state => state.search.authorFilter);
-  const searchResultsPage  = useSelector(state => state.search.searchResultsPage);
-  const datePubmedModified = useSelector(state => state.search.datePubmedModified);
-  const datePubmedAdded = useSelector(state => state.search.datePubmedAdded);
-  const datePublished = useSelector(state => state.search.datePublished);
   const dispatch = useDispatch();
 
   return (
@@ -224,35 +216,25 @@ const AuthorFilter = () => {
                   onChange={(e) => dispatch(setAuthorFilter(e.target.value))}
                   onKeyPress={(event) => {
                       if (event.charCode === 13) {
-                          dispatch(filterFacets(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount,searchResultsPage,authorFilter,datePubmedAdded,datePubmedModified,datePublished))
+                          dispatch(filterFacets())
                       }
                   }}
     />
     <Button inline="true" style={{width: "4em"}} size="sm"
       onClick={() => {
-        dispatch(filterFacets(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount,searchResultsPage,authorFilter,datePubmedAdded,datePubmedModified,datePublished))
+        dispatch(filterFacets())
       }}>Filter</Button>
       <Button variant="danger" size = "sm"
         onClick={() => {
           dispatch(setAuthorFilter(''));
-          dispatch(filterFacets(searchQuery, searchFacetsValues, searchFacetsLimits, searchSizeResultsCount,searchResultsPage,"",datePubmedAdded,datePubmedModified,datePublished)
-      )}}>X</Button></InputGroup>
+          dispatch(filterFacets())
+      }}>X</Button></InputGroup>
   )
 }
 
 
 const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
-
-    const searchQuery = useSelector(state => state.search.searchQuery);
     const searchFacetsLimits = useSelector(state => state.search.searchFacetsLimits);
-    const searchSizeResultsCount = useSelector(state => state.search.searchSizeResultsCount);
-    const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
-    const searchExcludedFacetsValues = useSelector(state => state.search.searchExcludedFacetsValues);
-    const authorFilter = useSelector(state => state.search.authorFilter);
-    const searchResultsPage  = useSelector(state => state.search.searchResultsPage);
-    const datePubmedModified = useSelector(state => state.search.datePubmedModified);
-    const datePubmedAdded = useSelector(state => state.search.datePubmedAdded);
-    const datePublished = useSelector(state => state.search.datePublished);
     const dispatch = useDispatch();
 
     return (
@@ -262,7 +244,7 @@ const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
                     let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
                     newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] * 2;
                     dispatch(setSearchFacetsLimits(newSearchFacetsLimits));
-                    dispatch(filterFacets(searchQuery, searchFacetsValues, searchExcludedFacetsValues, newSearchFacetsLimits, searchSizeResultsCount,searchResultsPage,authorFilter,datePubmedAdded,datePubmedModified,datePublished));
+                    dispatch(filterFacets());
                 }}>+Show More</button> : null
             }
             {searchFacetsLimits[facetLabel] > INITIAL_FACETS_LIMIT ?
@@ -270,7 +252,7 @@ const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
                     let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
                     newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] = INITIAL_FACETS_LIMIT;
                     dispatch(setSearchFacetsLimits(newSearchFacetsLimits));
-                    dispatch(filterFacets(searchQuery, searchFacetsValues, searchExcludedFacetsValues, newSearchFacetsLimits, searchSizeResultsCount,searchResultsPage,authorFilter,datePubmedAdded,datePubmedModified,datePublished));
+                    dispatch(filterFacets());
                 }}>-Show Less</button></span> : null
             }
             {facetValue.buckets.length >= searchFacetsLimits[facetLabel] ? <span>&nbsp;&nbsp;&nbsp;&nbsp;
@@ -278,7 +260,7 @@ const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
                     let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
                     newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] = 1000;
                     dispatch(setSearchFacetsLimits(newSearchFacetsLimits));
-                    dispatch(filterFacets(searchQuery, searchFacetsValues, searchExcludedFacetsValues, newSearchFacetsLimits, searchSizeResultsCount,searchResultsPage,authorFilter,datePubmedAdded,datePubmedModified,datePublished));
+                    dispatch(filterFacets());
                 }}>+Show All</button></span> : null }
             </div>
     )


### PR DESCRIPTION
Author filter was broken because the function did not have the exclude facet value.  This is because we pass in a huge list of variables for every ES call... but now we grab all those from state instead.  Also created a function to build search params values so that this code is not duplicated.

This also fixes display tag name since we did that in the AG Grid demo.