### PR TITLE
getXrefPatterns from actions into store when BiblioEditor loads, from…

### DIFF
--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -178,6 +178,20 @@ export const getCuratorSourceId = async (mod, accessToken) => {
   }
 }
 
+export const getXrefPatterns = (datatype) => { return dispatch => {
+  const url = process.env.REACT_APP_RESTAPI + '/cross_reference/check/patterns/' + datatype;
+  axios({ url: url })
+  .then(res => {
+    console.log(res);
+    dispatch({
+      type: 'UPDATE_XREF_PATTERNS',
+      payload: { datatype: datatype, data: res.data }
+    })
+  })
+  .catch(err =>
+    console.log(err)
+  );
+} }
 
 export const setBiblioUpdatingEntityAdd = (payload) => { return { type: 'SET_BIBLIO_UPDATING_ENTITY_ADD', payload: payload }; };
 

--- a/src/reducers/biblioReducer.js
+++ b/src/reducers/biblioReducer.js
@@ -70,6 +70,7 @@ const initialState = {
   updateAlert: 0,
   updateFailure: 0,
   updateMessages: [],
+  xrefPatterns: {},
   loadingFileNames: new Set()
 };
 
@@ -1116,6 +1117,15 @@ export default function(state = initialState, action) {
         allSpecies: action.payload
       };
      
+    case 'UPDATE_XREF_PATTERNS':
+      // console.log('UPDATE_XREF_PATTERNS');
+      const cloneXrefPatterns = _.cloneDeep(state.xrefPatterns);
+      cloneXrefPatterns[action.payload.datatype] = action.payload.data;
+      return {
+        ...state,
+        xrefPatterns: cloneXrefPatterns
+      };
+
 //     case 'QUERY_BUTTON':
 //       console.log("query button reducer set " + action.payload);
 //       let responseField = action.payload;


### PR DESCRIPTION
… API endpoint to get all reference xref patterns.  validateXref pattern when changing prefix dropdown, or blurring curie input.