### PR TITLE
update code to work with nested object type for topic_entity_tags and tet single tag search option

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -63,13 +63,29 @@ const getSearchParams = (state) => {
     query: state.search.searchQuery.replace(/\|/g,'\\|').replace(/\+/g,'\\+').replace(/OR/g,"|").replace(/AND/g,"+").trim(),
     size_result_count: state.search.searchSizeResultsCount,
     page: state.search.searchResultsPage,
-    facets_values: state.search.searchFacetsValues,
     negated_facets_values: state.search.searchExcludedFacetsValues,
     facets_limits: state.search.searchFacetsLimits,
     author_filter: state.search.authorFilter,
     query_fields: state.search.query_fields,
     sort_by_published_date_order: state.search.sortByPublishedDate,
     partial_match: state.search.partialMatch
+  }
+  if (state.search.applyToSingleTag) {
+    const tet_nested_facets_values = {};
+    const facets_values = {};
+    const facetsValues = state.search.searchFacetsValues;  
+    for (const key in facetsValues) {
+      if (key.startsWith("topic_entity_tags")) {
+        tet_nested_facets_values[key] = facetsValues[key];
+      } else {
+        facets_values[key] = facetsValues[key];
+      }
+    }
+    params.facets_values = facets_values;
+    params.tet_nested_facets_values = tet_nested_facets_values;
+  } else {
+    params.facets_values = state.search.searchFacetsValues;
+    params.tet_nested_facets_values = {};
   }
   if(state.search.datePubmedModified){
     params.date_pubmed_modified = state.search.datePubmedModified;
@@ -83,12 +99,6 @@ const getSearchParams = (state) => {
   if(state.search.dateCreated){
     params.date_created = state.search.dateCreated;
   }
-  
-  // if (state.search.applyToSingleTag) {
-  //  params.apply_selections_to_single_tag = state.search.applyToSingleTag;
-  // }
-
-  params.apply_selections_to_single_tag = state.search.applyToSingleTag;
     
   console.log("searchParams =" + JSON.stringify(params, null, 2));  
     

--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -76,13 +76,13 @@ const getSearchParams = (state) => {
   const data = state.search.searchFacetsValues;
   const tetNestedFacetsValues = [];
   const facetsValues = {};
-  if (state.search.applyToSingleTag && data["nested_topics"] && data["nested_topics"].length > 0 &&
-      data["nested_confidence_level"] && data["nested_confidence_level"].length > 0) {
+  if (state.search.applyToSingleTag && data["topics"] && data["topics"].length > 0 &&
+      data["confidence_levels"] && data["confidence_levels"].length > 0) {
       const seenEntries = new Set();
       for (const key in data) {
-         if (key.startsWith("nested")) {
-	   const topics = data["nested_topics"];
-	   const confidences = data["nested_confidence_level"];
+         if (key === 'topics' || key === 'confidence_levels') {
+	   const topics = data["topics"];
+	   const confidences = data["confidence_levels"];
 	   topics.forEach(topic => {
              confidences.forEach(confidence => {
 	       const entry = {
@@ -102,9 +102,9 @@ const getSearchParams = (state) => {
       }
   } else {
       for (const key in data) {
-	 if (key.startsWith("nested")) {
-	    const topics = data["nested_topics"];
-	    const confidences = data["nested_confidence_level"];
+	 if (key === 'topics' || key === 'confidence_levels') {
+	    const topics = data["topics"];
+	    const confidences = data["confidence_levels"];
 	    if (topics && topics.length > 0) {
 	        topics.forEach(topic => {
 		    const newEntry = { "topic_entity_tags.topic.keyword": topic };

--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -105,11 +105,11 @@ const getSearchParams = (state) => {
        params.tet_nested_facets_values = tetNestedFacetsValues;
     } else {
        params.facets_values = state.search.searchFacetsValues;
-       params.tet_nested_facets_values = {};
+       params.tet_nested_facets_values = [];
     }
   } else {
     params.facets_values = state.search.searchFacetsValues;
-    params.tet_nested_facets_values = {};
+    params.tet_nested_facets_values = [];
   }
 
   if(state.search.datePubmedModified){

--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -27,6 +27,7 @@ export const SEARCH_SET_SEARCH_QUERY_FIELDS = 'SEARCH_SET_SEARCH_QUERY_FIELDS';
 export const SEARCH_SET_SORT_BY_PUBLISHED_DATE = 'SEARCH_SET_SORT_BY_PUBLISHED_DATE';
 export const SEARCH_SET_PARTIAL_MATCH = 'SEARCH_SET_PARTIAL_MATCH';
 export const SEARCH_SET_MOD_PREFERENCES_LOADED = 'SEARCH_SET_MOD_PREFERENCES_LOADED';
+export const SEARCH_SET_APPLY_TO_SINGLE_TAG = 'SEARCH_SET_APPLY_TO_SINGLE_TAG';
 
 const restUrl = process.env.REACT_APP_RESTAPI;
 
@@ -82,7 +83,12 @@ const getSearchParams = (state) => {
   if(state.search.dateCreated){
     params.date_created = state.search.dateCreated;
   }
+  if (state.search.applyToSingleTag) {
+    params.apply_selections_to_single_tag = state.search.applyToSingleTag;
+  }
 
+  console.log("searchParams =" + JSON.stringify(params, null, 2));  
+    
   return params;
 }
 
@@ -308,4 +314,11 @@ export const setModPreferencesLoaded = (modPreferencesLoaded) => ({
   payload: {
     modPreferencesLoaded : modPreferencesLoaded
   }
+});
+
+export const setApplyToSingleTag = (applyToSingleTag) => ({
+    type: SEARCH_SET_APPLY_TO_SINGLE_TAG,
+    payload: {
+        applyToSingleTag
+    }
 });

--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -83,10 +83,13 @@ const getSearchParams = (state) => {
   if(state.search.dateCreated){
     params.date_created = state.search.dateCreated;
   }
-  if (state.search.applyToSingleTag) {
-    params.apply_selections_to_single_tag = state.search.applyToSingleTag;
-  }
+  
+  // if (state.search.applyToSingleTag) {
+  //  params.apply_selections_to_single_tag = state.search.applyToSingleTag;
+  // }
 
+  params.apply_selections_to_single_tag = state.search.applyToSingleTag;
+    
   console.log("searchParams =" + JSON.stringify(params, null, 2));  
     
   return params;
@@ -316,9 +319,8 @@ export const setModPreferencesLoaded = (modPreferencesLoaded) => ({
   }
 });
 
-export const setApplyToSingleTag = (applyToSingleTag) => ({
-    type: SEARCH_SET_APPLY_TO_SINGLE_TAG,
-    payload: {
-        applyToSingleTag
-    }
+export const setApplyToSingleTag = (value) => ({
+    type: 'SEARCH_SET_APPLY_TO_SINGLE_TAG',
+    payload: value
 });
+

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -198,7 +198,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
         <div>
 	    {showWarning && (
                 <div className="alert alert-warning" role="alert">
-                    You can only pick one topic and one confidence_level since you checked the "apply selections to one tag" checkbox.
+                    You can only pick one topic and one confidence_level since you checked the "apply selections to one tag" checkbox. Please remove the extra one from the selected list.
                 </div>
             )}
             {Object.entries(searchFacets).length > 0 && facetsToInclude.map(facetToInclude => {

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -15,7 +15,8 @@ import {
     setDatePubmedModified,
     setDatePublished,
     setDateCreated,
-    setModPreferencesLoaded
+    setModPreferencesLoaded,
+    setApplyToSingleTag
 } from '../../actions/searchActions';
 import Form from 'react-bootstrap/Form';
 import {Badge, Button, Collapse} from 'react-bootstrap';
@@ -115,14 +116,13 @@ const Facet = ({facetsToInclude, renameFacets}) => {
     const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
     const searchExcludedFacetsValues = useSelector(state => state.search.searchExcludedFacetsValues);
     const dispatch = useDispatch();
-    const [applyToSingleTag, setApplyToSingleTag] = useState(true);
+    const applyToSingleTag = useSelector(state => state.search.applyToSingleTag);
     const [showWarning, setShowWarning] = useState(false);
  
     const negatedFacetCategories = ["pubmed publication status","mod reference types", "category", "pubmed types"];
 
-    const handleCheckboxChange = (evt) => {
-        setApplyToSingleTag(evt.target.checked);
-        dispatch(filterFacets());
+    const handleCheckboxChange = (event) => {
+        dispatch(setApplyToSingleTag(event.target.checked));
     };
 
     useEffect(() => {

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -116,14 +116,31 @@ const Facet = ({facetsToInclude, renameFacets}) => {
     const searchExcludedFacetsValues = useSelector(state => state.search.searchExcludedFacetsValues);
     const dispatch = useDispatch();
     const [applyToSingleTag, setApplyToSingleTag] = useState(true);
-
+    const [showWarning, setShowWarning] = useState(false);
+ 
     const negatedFacetCategories = ["pubmed publication status","mod reference types", "category", "pubmed types"];
 
     const handleCheckboxChange = (evt) => {
         setApplyToSingleTag(evt.target.checked);
-        // Optionally dispatch an action or filter facets based on this new state
-        dispatch(filterFacets()); // Example: Refilter facets based on new checkbox state
+        dispatch(filterFacets());
     };
+
+    useEffect(() => {
+        if (applyToSingleTag) {
+            const topics = searchFacetsValues['topic_entity_tags.topic.keyword'] || [];
+            const confidenceLevels = searchFacetsValues['topic_entity_tags.confidence_level.keyword'] || [];
+            if (topics.length > 1 || confidenceLevels.length > 1) {
+                setShowWarning(true);
+		setTimeout(() => {
+                    setShowWarning(false);
+                }, 6000);
+            } else {
+                setShowWarning(false);
+            }
+        } else {
+            setShowWarning(false);
+        }
+    }, [applyToSingleTag, searchFacetsValues]);
     
     const StandardFacetCheckbox = ({facet, value}) => {
         return(
@@ -179,6 +196,11 @@ const Facet = ({facetsToInclude, renameFacets}) => {
 
     return (
         <div>
+	    {showWarning && (
+                <div className="alert alert-warning" role="alert">
+                    You can only pick one topic and one confidence_level since you checked the "apply selections to one tag" checkbox.
+                </div>
+            )}
             {Object.entries(searchFacets).length > 0 && facetsToInclude.map(facetToInclude => {
                     let key = facetToInclude + '.keyword';
                     key = key.replaceAll(' ', '_');

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -116,44 +116,8 @@ const Facet = ({facetsToInclude, renameFacets}) => {
     const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
     const searchExcludedFacetsValues = useSelector(state => state.search.searchExcludedFacetsValues);
     const dispatch = useDispatch();
-    const applyToSingleTag = useSelector(state => state.search.applyToSingleTag);
-    // const [showWarning, setShowWarning] = useState(false);
- 
-    const negatedFacetCategories = ["pubmed publication status","mod reference types", "category", "pubmed types"];
-
-    const handleCheckboxChange = (event) => {
-        dispatch(setApplyToSingleTag(event.target.checked));
-	refreshData();
-    };
-
-    const refreshData = () => {
-        dispatch(searchReferences());
-    };
-
-    // useEffect hook to trigger refresh when applyToSingleTag changes
-    useEffect(() => {
-        refreshData();
-    }, [applyToSingleTag, dispatch]);
-
-    /*
-    useEffect(() => {
-        if (applyToSingleTag) {
-            const topics = searchFacetsValues['topic_entity_tags.topic.keyword'] || [];
-            const confidenceLevels = searchFacetsValues['topic_entity_tags.confidence_level.keyword'] || [];
-            if (topics.length > 1 || confidenceLevels.length > 1) {
-                setShowWarning(true);
-		setTimeout(() => {
-                    setShowWarning(false);
-                }, 6000);
-            } else {
-                setShowWarning(false);
-            }
-        } else {
-            setShowWarning(false);
-        }
-    }, [applyToSingleTag, searchFacetsValues]);
     
-    */
+    const negatedFacetCategories = ["pubmed publication status","mod reference types", "category", "pubmed types"];
     
     const StandardFacetCheckbox = ({facet, value}) => {
         return(
@@ -217,15 +181,6 @@ const Facet = ({facetsToInclude, renameFacets}) => {
 	    return facetData.buckets || [];
 	}
     };
-
-    /*
-     {showWarning && (
-                <div className="alert alert-warning" role="alert">                                                                               
-                    You can only pick one topic and one confidence_level since you checked the "apply selections to one tag" checkbox.           
-                </div>
-            )} 
-      
-    */
     
     return (
         <div> 
@@ -243,15 +198,6 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                             <div key={facetToInclude} style={{textAlign: "left", paddingLeft: "2em"}}>
                                 <div>
                                     <h5>{renameFacets.hasOwnProperty(key) ? renameFacets[key] : key.replace('.keyword', '').replaceAll('_', ' ')}
-                                      {facetToInclude === "nested_topics" && (
-                                        <Form.Check
-                                            type="checkbox"
-                                            label="apply selections to single tag"
-                                            checked={applyToSingleTag}
-                                            onChange={handleCheckboxChange}
-                                            style={{ display: 'inline-block', marginLeft: '10px', fontSize: '0.8rem' }}
-                                        />
-                                      )}
 				    </h5>
                                     {facetToInclude === 'authors.name' ? <AuthorFilter/> : ''}
                                     {buckets.map(bucket =>
@@ -358,8 +304,23 @@ const Facets = () => {
     const datePublished= useSelector(state => state.search.datePublished);
     const oktaMod = useSelector(state => state.isLogged.oktaMod);
     const modPreferencesLoaded = useSelector(state => state.search.modPreferencesLoaded);
+    const applyToSingleTag = useSelector(state => state.search.applyToSingleTag);
     const dispatch = useDispatch();
 
+    const handleCheckboxChange = (event) => {
+	dispatch(setApplyToSingleTag(event.target.checked));
+	refreshData();
+    };
+
+    const refreshData = () => {
+	dispatch(searchReferences());
+    };
+
+    // to trigger refresh when applyToSingleTag changes
+    useEffect(() => {
+	refreshData();
+    }, [applyToSingleTag, dispatch]);
+    
     const toggleFacetGroup = (facetGroupLabel) => {
         let newOpenFacets = new Set([...openFacets]);
         if (newOpenFacets.has(facetGroupLabel)) {
@@ -424,6 +385,15 @@ const Facets = () => {
                         </Button>
                         <Collapse in={openFacets.has(facetCategory)}>
                             <div>
+				{facetCategory === 'Topics and Entities' && (
+				   <Form.Check
+                                     type="checkbox"
+                                     label="apply selections to single tag"
+                                     checked={applyToSingleTag}
+                                     onChange={handleCheckboxChange}
+                                     style={{ display: 'inline-block', marginLeft: '30px', fontSize: '0.8rem' }}
+                                  />
+				)}
                                 {facetCategory === 'Date Range' ? <DateFacet facetsToInclude={facetsInCategory}/> : <Facet facetsToInclude={facetsInCategory} renameFacets={RENAME_FACETS}/>}
                             </div>
                         </Collapse>

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -215,7 +215,9 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                                             type="checkbox"
                                             label="apply selections to single tag"
                                             checked={applyToSingleTag}
-                                            onChange={(event) => dispatch(setApplyToSingleTag(event.target.checked))}
+                                            onChange={(event) => {
+						dispatch(setApplyToSingleTag(event.target.checked));
+					    }}
                                             style={{ display: 'inline-block', marginLeft: '10px', fontSize: '0.8rem' }}
                                         />
                                       )}

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -115,8 +115,16 @@ const Facet = ({facetsToInclude, renameFacets}) => {
     const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
     const searchExcludedFacetsValues = useSelector(state => state.search.searchExcludedFacetsValues);
     const dispatch = useDispatch();
+    const [applyToSingleTag, setApplyToSingleTag] = useState(true);
+
     const negatedFacetCategories = ["pubmed publication status","mod reference types", "category", "pubmed types"];
 
+    const handleCheckboxChange = (evt) => {
+        setApplyToSingleTag(evt.target.checked);
+        // Optionally dispatch an action or filter facets based on this new state
+        dispatch(filterFacets()); // Example: Refilter facets based on new checkbox state
+    };
+    
     const StandardFacetCheckbox = ({facet, value}) => {
         return(
 
@@ -179,7 +187,17 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                         return (
                             <div key={facetToInclude} style={{textAlign: "left", paddingLeft: "2em"}}>
                                 <div>
-                                    <h5>{renameFacets.hasOwnProperty(key) ? renameFacets[key] : key.replace('.keyword', '').replaceAll('_', ' ')}</h5>
+                                    <h5>{renameFacets.hasOwnProperty(key) ? renameFacets[key] : key.replace('.keyword', '').replaceAll('_', ' ')}
+                                      {facetToInclude === "topic entity tags.topic" && (
+                                        <Form.Check
+                                            type="checkbox"
+                                            label="apply selections to single tag"
+                                            checked={applyToSingleTag}
+                                            onChange={(event) => dispatch(setApplyToSingleTag(event.target.checked))}
+                                            style={{ display: 'inline-block', marginLeft: '10px', fontSize: '0.8rem' }}
+                                        />
+                                      )}
+				    </h5>
                                     {facetToInclude === 'authors.name' ? <AuthorFilter/> : ''}
                                     {value.buckets.map(bucket =>
                                         <Container key={bucket.key}>

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -117,13 +117,23 @@ const Facet = ({facetsToInclude, renameFacets}) => {
     const searchExcludedFacetsValues = useSelector(state => state.search.searchExcludedFacetsValues);
     const dispatch = useDispatch();
     const applyToSingleTag = useSelector(state => state.search.applyToSingleTag);
-    const [showWarning, setShowWarning] = useState(false);
+    // const [showWarning, setShowWarning] = useState(false);
  
     const negatedFacetCategories = ["pubmed publication status","mod reference types", "category", "pubmed types"];
 
     const handleCheckboxChange = (event) => {
         dispatch(setApplyToSingleTag(event.target.checked));
+	refreshData();
     };
+
+    const refreshData = () => {
+        dispatch(searchReferences());
+    };
+
+    // useEffect hook to trigger refresh when applyToSingleTag changes
+    useEffect(() => {
+        refreshData();
+    }, [applyToSingleTag, dispatch]);
 
     /*
     useEffect(() => {
@@ -238,9 +248,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                                             type="checkbox"
                                             label="apply selections to single tag"
                                             checked={applyToSingleTag}
-                                            onChange={(event) => {
-						dispatch(setApplyToSingleTag(event.target.checked));
-					    }}
+                                            onChange={handleCheckboxChange}
                                             style={{ display: 'inline-block', marginLeft: '10px', fontSize: '0.8rem' }}
                                         />
                                       )}

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -50,7 +50,7 @@ const initialState = {
   sort_by_published_date_order:"relevance",
   partialMatch:"true",
   modPreferencesLoaded:"false",
-  applyToSingleTag: false
+  applyToSingleTag: true
 };
 
 // to ignore a warning about Unexpected default export of anonymous function

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -11,7 +11,7 @@ import {
   SEARCH_SET_DATE_PUBLISHED, SEARCH_SET_SEARCH_QUERY_FIELDS,
   SEARCH_SET_SORT_BY_PUBLISHED_DATE, SEARCH_SET_PARTIAL_MATCH,
   SEARCH_SET_DATE_CREATED, SEARCH_SET_CROSS_REFERENCE_RESULTS,
-  SEARCH_SET_MOD_PREFERENCES_LOADED
+  SEARCH_SET_MOD_PREFERENCES_LOADED, SEARCH_SET_APPLY_TO_SINGLE_TAG 
 } from '../actions/searchActions';
 
 import _ from "lodash";
@@ -246,6 +246,12 @@ export default function(state = initialState, action) {
         ...state,
         modPreferencesLoaded: action.payload.modPreferencesLoaded
       }
+
+   case SEARCH_SET_APPLY_TO_SINGLE_TAG:
+    return {
+        ...state,
+        applyToSingleTag: action.payload.applyToSingleTag
+    }
 
 //     case 'FETCH_POSTS':
 //       console.log('in postReducer case FETCH_POSTS');

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -49,7 +49,8 @@ const initialState = {
   query_fields:"All",
   sort_by_published_date_order:"relevance",
   partialMatch:"true",
-  modPreferencesLoaded:"false"
+  modPreferencesLoaded:"false",
+  applyToSingleTag: "false"
 };
 
 // to ignore a warning about Unexpected default export of anonymous function
@@ -247,11 +248,12 @@ export default function(state = initialState, action) {
         modPreferencesLoaded: action.payload.modPreferencesLoaded
       }
 
-   case SEARCH_SET_APPLY_TO_SINGLE_TAG:
-    return {
+    case SEARCH_SET_APPLY_TO_SINGLE_TAG:
+      console.log('Updating applyToSingleTag to:', action.payload);
+      return {
         ...state,
-        applyToSingleTag: action.payload.applyToSingleTag
-    }
+        applyToSingleTag: action.payload
+      }
 
 //     case 'FETCH_POSTS':
 //       console.log('in postReducer case FETCH_POSTS');

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -50,7 +50,7 @@ const initialState = {
   sort_by_published_date_order:"relevance",
   partialMatch:"true",
   modPreferencesLoaded:"false",
-  applyToSingleTag: "false"
+  applyToSingleTag: false
 };
 
 // to ignore a warning about Unexpected default export of anonymous function


### PR DESCRIPTION
1. adding "apply selections to single tag" checkbox
2. adding a warning message when multiple topics or multiple confidence levels are selected and the "apply selections to single tag" checkbox is checked
3. adding code in searchActions.js to preprocess facets selection data to construct nested search data structure