### PR TITLE
update code to work with nested object type for topic_entity_tags and tet single tag search option

### DIFF
--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -186,7 +186,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                                 <div>
                                     <h5>{renameFacets.hasOwnProperty(key) ? renameFacets[key] : key.replace('.keyword', '').replaceAll('_', ' ')}</h5>
                                     {facetToInclude === 'authors.name' ? <AuthorFilter/> : ''}
-                                    {value.buckets.map(bucket =>
+                                    {value.buckets && value.buckets.map(bucket =>
                                         <Container key={bucket.key}>
                                             <Row>
                                                 <Col sm={2}>
@@ -247,7 +247,7 @@ const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
 
     return (
         <div style={{paddingLeft: "1em"}}>
-            {facetValue.buckets.length >= searchFacetsLimits[facetLabel] ?
+            {facetValue.buckets && facetValue.buckets.length >= searchFacetsLimits[facetLabel] ?
                 <button className="button-to-link" onClick={()=> {
                     let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
                     newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] * 2;
@@ -263,7 +263,7 @@ const ShowMoreLessAllButtons = ({facetLabel, facetValue}) => {
                     dispatch(filterFacets());
                 }}>-Show Less</button></span> : null
             }
-            {facetValue.buckets.length >= searchFacetsLimits[facetLabel] ? <span>&nbsp;&nbsp;&nbsp;&nbsp;
+            {facetValue.buckets && facetValue.buckets.length >= searchFacetsLimits[facetLabel] ? <span>&nbsp;&nbsp;&nbsp;&nbsp;
                 <button className="button-to-link" onClick={() =>{
                     let newSearchFacetsLimits = _.cloneDeep(searchFacetsLimits);
                     newSearchFacetsLimits[facetLabel] = searchFacetsLimits[facetLabel] = 1000;

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -11,7 +11,7 @@ import {
   SEARCH_SET_DATE_PUBLISHED, SEARCH_SET_SEARCH_QUERY_FIELDS,
   SEARCH_SET_SORT_BY_PUBLISHED_DATE, SEARCH_SET_PARTIAL_MATCH,
   SEARCH_SET_DATE_CREATED, SEARCH_SET_CROSS_REFERENCE_RESULTS,
-  SEARCH_SET_MOD_PREFERENCES_LOADED
+  SEARCH_SET_MOD_PREFERENCES_LOADED, SEARCH_SET_APPLY_TO_SINGLE_TAG 
 } from '../actions/searchActions';
 
 import _ from "lodash";
@@ -49,7 +49,8 @@ const initialState = {
   query_fields:"All",
   sort_by_published_date_order:"relevance",
   partialMatch:"true",
-  modPreferencesLoaded:"false"
+  modPreferencesLoaded:"false",
+  applyToSingleTag: true
 };
 
 // to ignore a warning about Unexpected default export of anonymous function
@@ -245,6 +246,13 @@ export default function(state = initialState, action) {
       return {
         ...state,
         modPreferencesLoaded: action.payload.modPreferencesLoaded
+      }
+
+    case SEARCH_SET_APPLY_TO_SINGLE_TAG:
+      console.log('Updating applyToSingleTag to:', action.payload);
+      return {
+        ...state,
+        applyToSingleTag: action.payload
       }
 
 //     case 'FETCH_POSTS':


### PR DESCRIPTION
* adding "apply selections to single tag" checkbox
* adding a warning message when multiple topics or multiple confidence levels are selected and the "apply selections to single tag" checkbox is checked
* adding code in searchActions.js to preprocess facets selection data to construct nested search data structure