### PR TITLE
completeMergeReferences should not hide MergeDataTransferModal, inste…

### DIFF
--- a/src/components/Merge.js
+++ b/src/components/Merge.js
@@ -172,7 +172,7 @@ const MergeSelectionSection = () => {
       ) }
     })()}
 
-    { dataTransferHappened && mergeTransferringCount === 0 ?
+    { ( ( dataTransferHappened && mergeTransferringCount === 0 ) || ( mergeCompletingCount > 0 ) ) ?
       <MergeDataTransferredModal /> : null
     }
 
@@ -265,7 +265,6 @@ const MergeSubmitCompleteMergeUpdateButton = () => {
     console.log('completing merge');
     console.log(array);
     dispatch(setDataTransferHappened(false));
-    dispatch(setShowDataTransferModal(false));
     dispatch(setMergeCompleting(1));
     dispatch(mergeButtonApiDispatch(array));
   }

--- a/src/reducers/mergeReducer.js
+++ b/src/reducers/mergeReducer.js
@@ -362,6 +362,7 @@ export default function(state = initialState, action) {
         updateMessages: newArrayUpdateMessages,
         // getReferenceCurieFlag: getReferenceCurieFlagUpdateButton,
         // referenceJsonHasChange: hasChangeUpdateButton,
+        showDataTransferModal: false,
         mergeCompletingCount: mergeCompletingCountApiDispatch,
         mergeTransferringCount: mergeTransferringCountApiDispatch
       }


### PR DESCRIPTION
…ad when MERGE_BUTTON_API_DISPATCH reducer returns, it should set that to hide.  Also MergeDataTransferredModal can show when dataTransferHappened and mergeTransferringCount is zero, or also when mergeCompletingCount is not zero, because the merging is still happening, but the modal hasn't come up yet.  This is confusing, but it works and fits the story