### PR TITLE
Style fixes for SCRUM-3299

### DIFF
--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -110,9 +110,9 @@ const DatePicker = ({facetName,currentValue,setValueFunction}) => {
     }
 
     return(
-        <div key={facetName} style={{textAlign: "left", paddingLeft: "2em"}}>
+        <div key={facetName} style={{textAlign: "left", paddingLeft: "2em", paddingBottom: "0.5em"}}>
             <h5>{facetName}</h5>
-            <ButtonGroup aria-label="DateSetter" size ="sm">
+            <ButtonGroup aria-label="DateSetter" size ="sm" style={{display: "block"}}>
                 <Button variant="secondary" style={{'border-bottom-left-radius' : 0}} onClick={() => {handleFixedTimeClick('Day')}}>Day</Button>
                 <Button variant="secondary" onClick={() => {handleFixedTimeClick('Week')}}>Week</Button>
                 <Button variant="secondary" onClick={() => {handleFixedTimeClick('Month')}}>Month</Button>


### PR DESCRIPTION
Making sure the buttons always render on their own line.  Also adding padding to the bottom of the facet to give a bit more room between date elements.