### PR TITLE
Adding Entity Filter

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -450,19 +450,24 @@ em {
   visibility: visible;
 }
 
-.species-filter {
-  width: 200px;
+.custom-filter > * {
+  margin: 5px;
 }
 
-.species-filter > * {
-  margin: 8px;
-}
-
-.species-filter > div:first-child {
+.custom-filter > div:first-child {
   font-weight: bold;
   text-align: center;
 }
 
-.species-filter > div {
+.custom-filter > div {
   text-align: left;
 }
+
+.custom-filter input {
+  margin-right: 10px;
+}
+
+.custom-filter label {
+  margin-bottom: 0px;
+}
+

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,4 @@
 // import logo from './logo.svg';
-import './App.css';
-
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import AppWithRouterAccess from './components/AppWithRouterAccess';

--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -1119,6 +1119,11 @@ export const setAllSpecies = (allSpecies) => ({
   payload: allSpecies
 });
 
+export const setAllEntities = (allEntities) => ({
+  type: 'SET_ALL_ENTITIES',
+  payload: allEntities
+});
+
 export const setTopicEntitySourceId = (topicEntitySourceId) => ({
   type: 'SET_TOPIC_ENTITY_SOURCE_ID',
   payload: topicEntitySourceId

--- a/src/components/AgGrid/EntityFilter.jsx
+++ b/src/components/AgGrid/EntityFilter.jsx
@@ -47,7 +47,7 @@ export default ({ model, onModelChange }) => {
 
     return (
         <div className="custom-filter">
-            <div>Select Entity</div><hr/>
+            <div>Select Entity Type</div><hr/>
             {allEntities.map((entity) => {
                 let DisplayEntity = entity ? entity : 'None';
                 return  <div>

--- a/src/components/AgGrid/EntityFilter.jsx
+++ b/src/components/AgGrid/EntityFilter.jsx
@@ -6,11 +6,10 @@ import {useSelector} from "react-redux";
 export default ({ model, onModelChange }) => {
     const [closeFilter, setCloseFilter] = useState();
     const [unappliedModel, setUnappliedModel] = useState(model);
-    const curieToNameTaxon = useSelector(state => state.biblio.curieToNameTaxon);
-    const allSpecies = useSelector(state => state.biblio.allSpecies);
+    const allEntities = useSelector(state => state.biblio.allEntities);
     const doesFilterPass = useCallback((params) => {
         // doesFilterPass only gets called if the filter is active
-        return model.includes(params.data.species);
+        return model.includes(params.data.entity_type_name);
     }, [model]);
 
     const afterGuiAttached = useCallback(({ hidePopup }) => {
@@ -27,8 +26,9 @@ export default ({ model, onModelChange }) => {
         setUnappliedModel(model);
     }, [model]);
 
-    const onSpeciesChange = ({ target: { value,checked } } ) => {
+    const onEntitiesChange = ({ target: { value,checked } } ) => {
         let newModel = [];
+        value = value === 'None' ? null : value;
         if(checked){
             newModel = unappliedModel ? unappliedModel.concat([value]) : [value];
         }
@@ -47,12 +47,13 @@ export default ({ model, onModelChange }) => {
 
     return (
         <div className="custom-filter">
-            <div>Select Species</div><hr/>
-            {Object.entries(curieToNameTaxon).filter(([key, value]) => allSpecies.includes(key)).map( ([key,value]) => {
+            <div>Select Entity</div><hr/>
+            {allEntities.map((entity) => {
+                let DisplayEntity = entity ? entity : 'None';
                 return  <div>
-                            <input type="checkbox" id={key} value ={key} onChange={onSpeciesChange}/>
-                            <label htmlFor={key}> {value}</label>
-                        </div>
+                    <input type="checkbox" id={entity} value ={DisplayEntity} onChange={onEntitiesChange}/>
+                    <label htmlFor={entity}> {DisplayEntity}</label>
+                </div>
             })}
             <hr/><button onClick={onClick}>Apply</button>
         </div>

--- a/src/components/biblio/topic_entity_tag/TopicEntityTable.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityTable.js
@@ -1,13 +1,14 @@
 import { Spinner } from 'react-bootstrap';
 import {useSelector, useDispatch} from "react-redux";
 import {useEffect, useState, useMemo, useCallback, useRef} from "react";
-import { setCurieToNameTaxon,setAllSpecies } from "../../../actions/biblioActions";
+import { setCurieToNameTaxon,setAllSpecies, setAllEntities} from "../../../actions/biblioActions";
 import axios from "axios";
 import {getCurieToNameTaxon} from "./TaxonUtils";
 import Modal from 'react-bootstrap/Modal';
 import TopicEntityTagActions from '../../AgGrid/TopicEntityTagActions.jsx';
 import ValidationByCurator from '../../AgGrid/ValidationByCurator.jsx';
 import SpeciesFilter from '../../AgGrid/SpeciesFilter.jsx';
+import EntityFilter from '../../AgGrid/EntityFilter.jsx';
 
 import { AgGridReact } from 'ag-grid-react'; // React Grid Logic
 import "ag-grid-community/styles/ag-grid.css"; // Core CSS
@@ -55,7 +56,9 @@ const TopicEntityTable = () => {
         if (JSON.stringify(resultTags.data) !== JSON.stringify(topicEntityTags)) {
           setTopicEntityTags(resultTags.data);
           const uniqueSpecies = [...new Set( resultTags.data.map(obj => obj.species)) ];
+          const uniqueEntities = [...new Set( resultTags.data.map(obj => obj.entity_type_name))];
           dispatch(setAllSpecies(uniqueSpecies));
+          dispatch(setAllEntities(uniqueEntities));
           Object.entries(resultTags.data)
         }
     } catch (error) {
@@ -363,7 +366,7 @@ const CheckDropdownItem = React.forwardRef(
   let cols=[
     { field: "Actions" , lockPosition: 'left' , sortable: false, cellRenderer: TopicEntityTagActions},
     { headerName: "Topic", field: "topic_name", comparator: caseInsensitiveComparator, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.topic)}},
-    { headerName: "Entity Type", field: "entity_type_name", comparator: caseInsensitiveComparator, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.entity_type)} },
+    { headerName: "Entity Type", field: "entity_type_name", comparator: caseInsensitiveComparator, filter: EntityFilter, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.entity_type)} },
     { headerName: "Species", field: "species_name", comparator: caseInsensitiveComparator, filter: SpeciesFilter, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.species)}},
     { headerName: "Entity", field: "entity_name", comparator: caseInsensitiveComparator, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.entity)}},
     { headerName: "Entity Published As", field: "entity_published_as", comparator: caseInsensitiveComparator },

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-
 import 'bootstrap/dist/css/bootstrap.min.css';
+import './App.css';
 
 // import { createStore } from 'redux';
 import { createStore, applyMiddleware, compose } from 'redux';

--- a/src/reducers/biblioReducer.js
+++ b/src/reducers/biblioReducer.js
@@ -992,6 +992,7 @@ export default function(state = initialState, action) {
 	    tetPageSize: defaultTetPageSize,
         curieToNameTaxon: {},
         allSpecies: [],
+        allEntities: [],
         getReferenceCurieFlag: true
       }
     case 'SET_GET_REFERENCE_CURIE_FLAG':
@@ -1116,6 +1117,12 @@ export default function(state = initialState, action) {
       return {
         ...state,
         allSpecies: action.payload
+      };
+
+    case 'SET_ALL_ENTITIES':
+      return {
+        ...state,
+        allEntities: action.payload
       };
 
     case 'SET_TOPIC_ENTITY_SOURCE_ID':


### PR DESCRIPTION
Adds the entity filter.  Functions almost exactly the same as the species filter but we dont need to use any mappings for the ID.  This filter also has the option for "None" to show entries that have no entity type.  Adds css that applies to the other filter to make it look nice.  Changes the location of the app.css import so that bootstrap styling does not override our local style.