### PR TITLE
Scrum 3678 Added facets for TET source fields

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -28,6 +28,7 @@ export const SEARCH_SET_SORT_BY_PUBLISHED_DATE = 'SEARCH_SET_SORT_BY_PUBLISHED_D
 export const SEARCH_SET_PARTIAL_MATCH = 'SEARCH_SET_PARTIAL_MATCH';
 export const SEARCH_SET_MOD_PREFERENCES_LOADED = 'SEARCH_SET_MOD_PREFERENCES_LOADED';
 export const SEARCH_SET_APPLY_TO_SINGLE_TAG = 'SEARCH_SET_APPLY_TO_SINGLE_TAG';
+export const SEARCH_SET_READY_TO_FACET_SEARCH = "SEARCH_SET_READY_TO_FACET_SEARCH";
 
 const restUrl = process.env.REACT_APP_RESTAPI;
 
@@ -165,6 +166,7 @@ export const searchReferences = () => {
                 dispatch(setCrossReferenceResults(curieToCrossRefMap));
                 dispatch(setSearchResults(res.data.hits, res.data.return_count));
                 dispatch(setSearchFacets(res.data.aggregations));
+                dispatch(setReadyToFacetSearch(true));
               })
               .catch(err => dispatch(setSearchError(true)));
         })
@@ -276,6 +278,13 @@ export const setSearchFacets = (facets) => ({
     facets: facets
   }
 });
+
+export const setReadyToFacetSearch = (value) => ({
+  type: SEARCH_SET_READY_TO_FACET_SEARCH,
+  payload: {
+    value: value
+  }
+})
 
 export const addFacetValue = (facet, value) => ({
   type: SEARCH_ADD_FACET_VALUE,

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -43,12 +43,13 @@ export const RENAME_FACETS = {
     "mod_reference_types.keyword": "MOD reference type",
     "topics": "Topic",
     "confidence_levels": "Confidence level",
+    "source_methods": "Source method"
 }
 
 export const FACETS_CATEGORIES_WITH_FACETS = {
     "Alliance Metadata": ["mods in corpus", "mods needs review", "mods in corpus or needs review"],
     "Bibliographic Data": ["mod reference types", "pubmed types", "category", "pubmed publication status", "authors.name"],
-    "Topics and Entities": ["topics", "confidence_levels"],
+    "Topics and Entities": ["topics", "confidence_levels", "source_methods"],
     "Date Range": ["Date Modified in Pubmed", "Date Added To Pubmed", "Date Published","Date Added to ABC"]
 
 }
@@ -203,7 +204,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
         <div>
             {Object.entries(searchFacets).length > 0 && facetsToInclude.map(facetToInclude => {
 		    let key = facetToInclude.replaceAll(' ', '_');
-                    if (key !== 'topics' && key !== 'confidence_levels'){
+                    if (!['topics', 'confidence_levels', 'source_methods'].includes(key)){
                         key = key + '.keyword';
                     }
                     if (key in searchFacets) {
@@ -224,7 +225,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                                                 </Col>
                                                 <Col>
                                                 <Badge variant="secondary">
-                                                    {['topics', 'confidence_levels'].includes(key) ? bucket.docs_count.doc_count : bucket.doc_count}
+                                                    {['topics', 'confidence_levels', 'source_methods'].includes(key) ? bucket.docs_count.doc_count : bucket.doc_count}
                                                 </Badge>
                                                 </Col>
                                             </Row>

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -43,13 +43,14 @@ export const RENAME_FACETS = {
     "mod_reference_types.keyword": "MOD reference type",
     "topics": "Topic",
     "confidence_levels": "Confidence level",
-    "source_methods": "Source method"
+    "source_methods": "Source method",
+    "source_evidence_assertions": "Source evidence assertion"
 }
 
 export const FACETS_CATEGORIES_WITH_FACETS = {
     "Alliance Metadata": ["mods in corpus", "mods needs review", "mods in corpus or needs review"],
     "Bibliographic Data": ["mod reference types", "pubmed types", "category", "pubmed publication status", "authors.name"],
-    "Topics and Entities": ["topics", "confidence_levels", "source_methods"],
+    "Topics and Entities": ["topics", "confidence_levels", "source_methods", "source_evidence_assertions"],
     "Date Range": ["Date Modified in Pubmed", "Date Added To Pubmed", "Date Published","Date Added to ABC"]
 
 }
@@ -204,7 +205,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
         <div>
             {Object.entries(searchFacets).length > 0 && facetsToInclude.map(facetToInclude => {
 		    let key = facetToInclude.replaceAll(' ', '_');
-                    if (!['topics', 'confidence_levels', 'source_methods'].includes(key)){
+                    if (!['topics', 'confidence_levels', 'source_methods', 'source_evidence_assertions'].includes(key)){
                         key = key + '.keyword';
                     }
                     if (key in searchFacets) {
@@ -225,7 +226,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                                                 </Col>
                                                 <Col>
                                                 <Badge variant="secondary">
-                                                    {['topics', 'confidence_levels', 'source_methods'].includes(key) ? bucket.docs_count.doc_count : bucket.doc_count}
+                                                    {['topics', 'confidence_levels', 'source_methods', 'source_evidence_assertions'].includes(key) ? bucket.docs_count.doc_count : bucket.doc_count}
                                                 </Badge>
                                                 </Col>
                                             </Row>

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -315,6 +315,7 @@ const Facets = () => {
     const searchExcludedFacetsValues = useSelector(state => state.search.searchExcludedFacetsValues);
     const searchFacetsLimits = useSelector(state => state.search.searchFacetsLimits);
     const searchQuery = useSelector(state => state.search.searchQuery);
+    const readyToFacetSearch = useSelector(state => state.search.readyToFacetSearch);
     const facetsLoading = useSelector(state => state.search.facetsLoading);
     const datePubmedModified = useSelector(state => state.search.datePubmedModified);
     const datePubmedAdded = useSelector(state => state.search.datePubmedAdded);
@@ -327,17 +328,7 @@ const Facets = () => {
 
     const handleCheckboxChange = (event) => {
         dispatch(setApplyToSingleTag(event.target.checked));
-        refreshData();
     };
-
-    const refreshData = () => {
-        dispatch(searchReferences());
-    };
-
-    // to trigger refresh when applyToSingleTag changes
-    useEffect(() => {
-        refreshData();
-    }, [applyToSingleTag, dispatch])
     
     const toggleFacetGroup = (facetGroupLabel) => {
         let newOpenFacets = new Set([...openFacets]);
@@ -353,13 +344,13 @@ const Facets = () => {
         if (Object.keys(searchFacets).length === 0 && searchResults.length === 0) {
             dispatch(fetchInitialFacets(searchFacetsLimits));
         } else {
-            if (searchQuery !== "" || searchResults.length > 0 || Object.keys(searchFacetsValues).length > 0 || Object.keys(searchExcludedFacetsValues).length > 0) {
+            if (readyToFacetSearch === true && (searchQuery !== "" || searchResults.length > 0 || Object.keys(searchFacetsValues).length > 0 || Object.keys(searchExcludedFacetsValues).length > 0)) {
                 dispatch(setSearchResultsPage(1));
                 dispatch(setAuthorFilter(""));
                 dispatch(searchReferences());
             }
         }
-    }, [searchFacetsValues,searchExcludedFacetsValues]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [searchFacetsValues,searchExcludedFacetsValues, applyToSingleTag]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         let newOpenFacets = new Set([...openFacets]);
@@ -384,7 +375,7 @@ const Facets = () => {
                     dispatch(addFacetValue("mods_in_corpus_or_needs_review.keyword", oktaMod));
                 }
             }
-            else{
+            else {
                 dispatch(addFacetValue("mods_in_corpus_or_needs_review.keyword", oktaMod));
             }
             dispatch(searchReferences());

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -40,7 +40,8 @@ const initialState = {
     'authors.name.keyword': INITIAL_FACETS_LIMIT,
     'topics': INITIAL_FACETS_LIMIT,
     'confidence_levels': INITIAL_FACETS_LIMIT,
-    'source_methods': INITIAL_FACETS_LIMIT
+    'source_methods': INITIAL_FACETS_LIMIT,
+    'source_evidence_assertions': INITIAL_FACETS_LIMIT
   },
   searchFacetsShowMore: {},
   searchQuery: "",

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -39,7 +39,8 @@ const initialState = {
     'pubmed_publication_status.keyword': INITIAL_FACETS_LIMIT,
     'authors.name.keyword': INITIAL_FACETS_LIMIT,
     'topics': INITIAL_FACETS_LIMIT,
-    'confidence_levels': INITIAL_FACETS_LIMIT
+    'confidence_levels': INITIAL_FACETS_LIMIT,
+    'source_methods': INITIAL_FACETS_LIMIT
   },
   searchFacetsShowMore: {},
   searchQuery: "",

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -11,7 +11,7 @@ import {
   SEARCH_SET_DATE_PUBLISHED, SEARCH_SET_SEARCH_QUERY_FIELDS,
   SEARCH_SET_SORT_BY_PUBLISHED_DATE, SEARCH_SET_PARTIAL_MATCH,
   SEARCH_SET_DATE_CREATED, SEARCH_SET_CROSS_REFERENCE_RESULTS,
-  SEARCH_SET_MOD_PREFERENCES_LOADED, SEARCH_SET_APPLY_TO_SINGLE_TAG 
+  SEARCH_SET_MOD_PREFERENCES_LOADED, SEARCH_SET_APPLY_TO_SINGLE_TAG, SEARCH_SET_READY_TO_FACET_SEARCH
 } from '../actions/searchActions';
 
 import _ from "lodash";
@@ -37,10 +37,13 @@ const initialState = {
     'mod_reference_types.keyword': INITIAL_FACETS_LIMIT,
     'category.keyword': INITIAL_FACETS_LIMIT,
     'pubmed_publication_status.keyword': INITIAL_FACETS_LIMIT,
-    'authors.name.keyword': INITIAL_FACETS_LIMIT
+    'authors.name.keyword': INITIAL_FACETS_LIMIT,
+    'topics': INITIAL_FACETS_LIMIT,
+    'confidence_levels': INITIAL_FACETS_LIMIT
   },
   searchFacetsShowMore: {},
   searchQuery: "",
+  readyToFacetSearch: false,
   authorFilter: "",
   datePubmedAdded: "",
   datePubmedModified: "",
@@ -62,6 +65,12 @@ export default function(state = initialState, action) {
       return {
         ...state,
         [action.payload.field]: action.payload.value
+      }
+
+    case SEARCH_SET_READY_TO_FACET_SEARCH:
+      return {
+        ...state,
+        readyToFacetSearch: action.payload.value
       }
 
     case SEARCH_SET_SEARCH_RESULTS:


### PR DESCRIPTION
- Added the new facets
- Added the ability to "show more" to all TET facets
- Removed extra calls to API to get initial facets
- Added a new redux state variable to avoid sending search requests until all default facet values are set (only mod_in_corpus_or_needs_review per logged in user for now)