### PR TITLE
adding multi filter to Topic and Entity columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-icons": "^4.8.0",
     "react-popup": "^0.10.0",
     "react-redux": "^7.2.4",
+    "react-select": "^5.8.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^5.0.1",
     "reactjs-popup": "^2.0.4",

--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -1172,6 +1172,16 @@ export const setAllEntities = (allEntities) => ({
   payload: allEntities
 });
 
+export const setAllTopics = (allTopics) => ({
+  type: 'SET_ALL_TOPICS',
+  payload: allTopics
+});
+
+export const setAllEntityTypes = (allEntityTypes) => ({
+  type: 'SET_ALL_ENTITY_TYPES',
+  payload: allEntityTypes
+});
+
 export const setTopicEntitySourceId = (topicEntitySourceId) => ({
   type: 'SET_TOPIC_ENTITY_SOURCE_ID',
   payload: topicEntitySourceId

--- a/src/components/AgGrid/EntityFilter.jsx
+++ b/src/components/AgGrid/EntityFilter.jsx
@@ -1,7 +1,7 @@
 import { useGridFilter } from 'ag-grid-react';
 import React, { useCallback, useEffect, useState } from 'react';
-import {useSelector} from "react-redux";
-
+import { useSelector } from 'react-redux';
+import Select from 'react-select';
 
 export default ({ model, onModelChange }) => {
     const [closeFilter, setCloseFilter] = useState();
@@ -9,7 +9,7 @@ export default ({ model, onModelChange }) => {
     const allEntities = useSelector(state => state.biblio.allEntities);
     const doesFilterPass = useCallback((params) => {
         // doesFilterPass only gets called if the filter is active
-        return model.includes(params.data.entity_type_name);
+        return model.includes(params.data.entity_name);
     }, [model]);
 
     const afterGuiAttached = useCallback(({ hidePopup }) => {
@@ -26,16 +26,20 @@ export default ({ model, onModelChange }) => {
         setUnappliedModel(model);
     }, [model]);
 
-    const onEntitiesChange = ({ target: { value,checked } } ) => {
+    const onEntitiesChangeCheckbox = ({ target: { value, checked } }) => {
         let newModel = [];
         value = value === 'None' ? null : value;
-        if(checked){
+        if (checked) {
             newModel = unappliedModel ? unappliedModel.concat([value]) : [value];
+        } else {
+            newModel = unappliedModel.filter(f => f !== value);
         }
-        else{
-            newModel = unappliedModel.filter(f => f !== value)
-        }
-        setUnappliedModel(newModel.length===0 ? null : newModel);
+        setUnappliedModel(newModel.length === 0 ? null : newModel);
+    };
+
+    const onEntitiesChangeTypeAhead = (selectedOptions) => {
+        const newModel = selectedOptions ? selectedOptions.map(option => option.value) : [];
+        setUnappliedModel(newModel.length === 0 ? null : newModel);
     };
 
     const onClick = () => {
@@ -47,14 +51,31 @@ export default ({ model, onModelChange }) => {
 
     return (
         <div className="custom-filter">
-            <div>Select Entity Type</div><hr/>
-            {allEntities.map((entity) => {
-                let DisplayEntity = entity ? entity : 'None';
-                return  <div>
-                    <input type="checkbox" id={entity} value ={DisplayEntity} onChange={onEntitiesChange}/>
-                    <label htmlFor={entity}> {DisplayEntity}</label>
-                </div>
-            })}
+            <div>Select Entity</div><hr/>
+            {allEntities.length <= 10 ? (
+                allEntities.map((entity) => {
+                    let DisplayEntity = entity ? entity : 'None';
+                    return (
+                        <div key={entity}>
+                            <input
+                                type="checkbox"
+                                id={entity}
+                                value={DisplayEntity}
+                                onChange={onEntitiesChangeCheckbox}
+                                checked={unappliedModel && unappliedModel.includes(DisplayEntity)}
+                            />
+                            <label htmlFor={entity}> {DisplayEntity}</label>
+                        </div>
+                    );
+                })
+            ) : (
+                <Select
+                    isMulti
+                    options={allEntities.map(entity => ({ value: entity, label: entity }))}
+                    onChange={onEntitiesChangeTypeAhead}
+                    value={unappliedModel ? unappliedModel.map(entity => ({ value: entity, label: entity })) : []}
+                />
+            )}
             <hr/><button onClick={onClick}>Apply</button>
         </div>
     );

--- a/src/components/AgGrid/EntityFilter.jsx
+++ b/src/components/AgGrid/EntityFilter.jsx
@@ -1,82 +1,17 @@
-import { useGridFilter } from 'ag-grid-react';
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
-import Select from 'react-select';
+import MultiFilter from './MultiFilter';
 
-export default ({ model, onModelChange }) => {
-    const [closeFilter, setCloseFilter] = useState();
-    const [unappliedModel, setUnappliedModel] = useState(model);
+const EntityFilter = ({ model, onModelChange }) => {
     const allEntities = useSelector(state => state.biblio.allEntities);
-    const doesFilterPass = useCallback((params) => {
-        // doesFilterPass only gets called if the filter is active
-        return model.includes(params.data.entity_name);
-    }, [model]);
-
-    const afterGuiAttached = useCallback(({ hidePopup }) => {
-        setCloseFilter(() => hidePopup);
-    }, []);
-
-    // register filter handlers with the grid
-    useGridFilter({
-        doesFilterPass,
-        afterGuiAttached,
-    });
-
-    useEffect(() => {
-        setUnappliedModel(model);
-    }, [model]);
-
-    const onEntitiesChangeCheckbox = ({ target: { value, checked } }) => {
-        let newModel = [];
-        value = value === 'None' ? null : value;
-        if (checked) {
-            newModel = unappliedModel ? unappliedModel.concat([value]) : [value];
-        } else {
-            newModel = unappliedModel.filter(f => f !== value);
-        }
-        setUnappliedModel(newModel.length === 0 ? null : newModel);
-    };
-
-    const onEntitiesChangeTypeAhead = (selectedOptions) => {
-        const newModel = selectedOptions ? selectedOptions.map(option => option.value) : [];
-        setUnappliedModel(newModel.length === 0 ? null : newModel);
-    };
-
-    const onClick = () => {
-        onModelChange(unappliedModel);
-        if (closeFilter) {
-            closeFilter();
-        }
-    };
-
     return (
-        <div className="custom-filter">
-            <div>Select Entity</div><hr/>
-            {allEntities.length <= 10 ? (
-                allEntities.map((entity) => {
-                    let DisplayEntity = entity ? entity : 'None';
-                    return (
-                        <div key={entity}>
-                            <input
-                                type="checkbox"
-                                id={entity}
-                                value={DisplayEntity}
-                                onChange={onEntitiesChangeCheckbox}
-                                checked={unappliedModel && unappliedModel.includes(DisplayEntity)}
-                            />
-                            <label htmlFor={entity}> {DisplayEntity}</label>
-                        </div>
-                    );
-                })
-            ) : (
-                <Select
-                    isMulti
-                    options={allEntities.map(entity => ({ value: entity, label: entity }))}
-                    onChange={onEntitiesChangeTypeAhead}
-                    value={unappliedModel ? unappliedModel.map(entity => ({ value: entity, label: entity })) : []}
-                />
-            )}
-            <hr/><button onClick={onClick}>Apply</button>
-        </div>
+        <MultiFilter
+            model={model}
+            onModelChange={onModelChange}
+            items={allEntities}
+            label="entity_name"
+        />
     );
 };
+
+export default EntityFilter;

--- a/src/components/AgGrid/EntityTypeFilter.jsx
+++ b/src/components/AgGrid/EntityTypeFilter.jsx
@@ -1,0 +1,61 @@
+import { useGridFilter } from 'ag-grid-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import {useSelector} from "react-redux";
+
+
+export default ({ model, onModelChange }) => {
+    const [closeFilter, setCloseFilter] = useState();
+    const [unappliedModel, setUnappliedModel] = useState(model);
+    const allEntityTypes = useSelector(state => state.biblio.allEntityTypes);
+    const doesFilterPass = useCallback((params) => {
+        // doesFilterPass only gets called if the filter is active
+        return model.includes(params.data.entity_type_name);
+    }, [model]);
+
+    const afterGuiAttached = useCallback(({ hidePopup }) => {
+        setCloseFilter(() => hidePopup);
+    }, []);
+
+    // register filter handlers with the grid
+    useGridFilter({
+        doesFilterPass,
+        afterGuiAttached,
+    });
+
+    useEffect(() => {
+        setUnappliedModel(model);
+    }, [model]);
+
+    const onEntityTypesChange = ({ target: { value,checked } } ) => {
+        let newModel = [];
+        value = value === 'None' ? null : value;
+        if(checked){
+            newModel = unappliedModel ? unappliedModel.concat([value]) : [value];
+        }
+        else{
+            newModel = unappliedModel.filter(f => f !== value)
+        }
+        setUnappliedModel(newModel.length===0 ? null : newModel);
+    };
+
+    const onClick = () => {
+        onModelChange(unappliedModel);
+        if (closeFilter) {
+            closeFilter();
+        }
+    };
+
+    return (
+        <div className="custom-filter">
+            <div>Select Entity Type</div><hr/>
+            {allEntityTypes.map((entityType) => {
+                let DisplayEntityType = entityType ? entityType : 'None';
+                return  <div>
+                    <input type="checkbox" id={entityType} value ={DisplayEntityType} onChange={onEntityTypesChange}/>
+                    <label htmlFor={entityType}> {DisplayEntityType}</label>
+                </div>
+            })}
+            <hr/><button onClick={onClick}>Apply</button>
+        </div>
+    );
+};

--- a/src/components/AgGrid/MultiFilter.jsx
+++ b/src/components/AgGrid/MultiFilter.jsx
@@ -57,6 +57,9 @@ const MultiFilter = ({ model, onModelChange, items, label }) => {
             ...provided,
             maxHeight: 200, 
         }),
+        dropdownIndicator: () => ({
+            display: 'none'
+        }),
     };
 
     const sortedItems = items.slice().sort((a, b) => a.localeCompare(b));
@@ -85,6 +88,7 @@ const MultiFilter = ({ model, onModelChange, items, label }) => {
                     <Select
                         isMulti
                         defaultMenuIsOpen={true}
+                        menuIsOpen={true}
                         styles={customStyles}
                         options={sortedItems.map(item => ({ value: item, label: item }))}
                         onChange={onItemsChangeTypeAhead}

--- a/src/components/AgGrid/MultiFilter.jsx
+++ b/src/components/AgGrid/MultiFilter.jsx
@@ -48,6 +48,17 @@ const MultiFilter = ({ model, onModelChange, items, label }) => {
         }
     };
 
+    const customStyles = {
+        menu: (provided) => ({
+            ...provided,
+            zIndex: 9999,
+        }),
+        menuList: (provided) => ({
+            ...provided,
+            maxHeight: 300, 
+        }),
+    };
+
     return (
         <div className="custom-filter">
             <div>Select {label.replace("_name", "")}</div><hr/>
@@ -68,9 +79,10 @@ const MultiFilter = ({ model, onModelChange, items, label }) => {
                     );
                 })
             ) : (
-	      <div style={{ height: '200px' }}> 
+	      <div style={{ height: '300px' }}> 
                 <Select
                     isMulti
+                    styles={customStyles}
                     options={items.map(item => ({ value: item, label: item }))}
                     onChange={onItemsChangeTypeAhead}
                     value={unappliedModel ? unappliedModel.map(item => ({ value: item, label: item })) : []}

--- a/src/components/AgGrid/MultiFilter.jsx
+++ b/src/components/AgGrid/MultiFilter.jsx
@@ -1,0 +1,83 @@
+import { useGridFilter } from 'ag-grid-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import Select from 'react-select';
+
+const MultiFilter = ({ model, onModelChange, items, label }) => {
+    const [closeFilter, setCloseFilter] = useState();
+    const [unappliedModel, setUnappliedModel] = useState(model);
+    const doesFilterPass = useCallback((params) => {
+        // doesFilterPass only gets called if the filter is active
+        return model.includes(params.data[label]);
+    }, [model, label]);
+
+    const afterGuiAttached = useCallback(({ hidePopup }) => {
+        setCloseFilter(() => hidePopup);
+    }, []);
+
+    // register filter handlers with the grid
+    useGridFilter({
+        doesFilterPass,
+        afterGuiAttached,
+    });
+
+    useEffect(() => {
+        setUnappliedModel(model);
+    }, [model]);
+
+    const onItemsChangeCheckbox = ({ target: { value, checked } }) => {
+        let newModel = [];
+        value = value === 'None' ? null : value;
+        if (checked) {
+            newModel = unappliedModel ? unappliedModel.concat([value]) : [value];
+        } else {
+            newModel = unappliedModel.filter(f => f !== value);
+        }
+        setUnappliedModel(newModel.length === 0 ? null : newModel);
+    };
+
+    const onItemsChangeTypeAhead = (selectedOptions) => {
+        const newModel = selectedOptions ? selectedOptions.map(option => option.value) : [];
+        setUnappliedModel(newModel.length === 0 ? null : newModel);
+    };
+
+    const onClick = () => {
+        onModelChange(unappliedModel);
+        if (closeFilter) {
+            closeFilter();
+        }
+    };
+
+    return (
+        <div className="custom-filter">
+            <div>Select {label}</div><hr/>
+            {items.length <= 10 ? (
+                items.map((item) => {
+                    let DisplayItem = item ? item : 'None';
+                    return (
+                        <div key={item}>
+                            <input
+                                type="checkbox"
+                                id={item}
+                                value={DisplayItem}
+                                onChange={onItemsChangeCheckbox}
+                                checked={unappliedModel && unappliedModel.includes(DisplayItem)}
+                            />
+                            <label htmlFor={item}> {DisplayItem}</label>
+                        </div>
+                    );
+                })
+            ) : (
+                <Select
+                    isMulti
+                    options={items.map(item => ({ value: item, label: item }))}
+                    onChange={onItemsChangeTypeAhead}
+                    value={unappliedModel ? unappliedModel.map(item => ({ value: item, label: item })) : []}
+                />
+            )}
+            <hr/><button onClick={onClick}>Apply</button>
+        </div>
+    );
+};
+
+export default MultiFilter;

--- a/src/components/AgGrid/MultiFilter.jsx
+++ b/src/components/AgGrid/MultiFilter.jsx
@@ -81,15 +81,16 @@ const MultiFilter = ({ model, onModelChange, items, label }) => {
                     );
                 })
             ) : (
-	      <div style={{ height: '200px' }}> 
-                <Select
-                    isMulti
-                    styles={customStyles}
-                    options={sortedItems.map(item => ({ value: item, label: item }))}
-                    onChange={onItemsChangeTypeAhead}
-                    value={unappliedModel ? unappliedModel.map(item => ({ value: item, label: item })) : []}
-                />
-	      </div>
+                <div style={{ height: '250px' }}>
+                    <Select
+                        isMulti
+                        defaultMenuIsOpen={true}
+                        styles={customStyles}
+                        options={sortedItems.map(item => ({ value: item, label: item }))}
+                        onChange={onItemsChangeTypeAhead}
+                        value={unappliedModel ? unappliedModel.map(item => ({ value: item, label: item })) : []}
+                    />
+                </div>
             )}
             <hr/><button onClick={onClick}>Apply</button>
         </div>

--- a/src/components/AgGrid/MultiFilter.jsx
+++ b/src/components/AgGrid/MultiFilter.jsx
@@ -55,15 +55,17 @@ const MultiFilter = ({ model, onModelChange, items, label }) => {
         }),
         menuList: (provided) => ({
             ...provided,
-            maxHeight: 300, 
+            maxHeight: 200, 
         }),
     };
 
+    const sortedItems = items.slice().sort((a, b) => a.localeCompare(b));
+ 
     return (
         <div className="custom-filter">
             <div>Select {label.replace("_name", "")}</div><hr/>
             {items.length <= 10 ? (
-                items.map((item) => {
+                sortedItems.map((item) => {
                     let DisplayItem = item ? item : 'None';
                     return (
                         <div key={item}>
@@ -79,11 +81,11 @@ const MultiFilter = ({ model, onModelChange, items, label }) => {
                     );
                 })
             ) : (
-	      <div style={{ height: '300px' }}> 
+	      <div style={{ height: '200px' }}> 
                 <Select
                     isMulti
                     styles={customStyles}
-                    options={items.map(item => ({ value: item, label: item }))}
+                    options={sortedItems.map(item => ({ value: item, label: item }))}
                     onChange={onItemsChangeTypeAhead}
                     value={unappliedModel ? unappliedModel.map(item => ({ value: item, label: item })) : []}
                 />

--- a/src/components/AgGrid/MultiFilter.jsx
+++ b/src/components/AgGrid/MultiFilter.jsx
@@ -50,7 +50,7 @@ const MultiFilter = ({ model, onModelChange, items, label }) => {
 
     return (
         <div className="custom-filter">
-            <div>Select {label}</div><hr/>
+            <div>Select {label.replace("_name", "")}</div><hr/>
             {items.length <= 10 ? (
                 items.map((item) => {
                     let DisplayItem = item ? item : 'None';
@@ -68,12 +68,14 @@ const MultiFilter = ({ model, onModelChange, items, label }) => {
                     );
                 })
             ) : (
+	      <div style={{ height: '200px' }}> 
                 <Select
                     isMulti
                     options={items.map(item => ({ value: item, label: item }))}
                     onChange={onItemsChangeTypeAhead}
                     value={unappliedModel ? unappliedModel.map(item => ({ value: item, label: item })) : []}
                 />
+	      </div>
             )}
             <hr/><button onClick={onClick}>Apply</button>
         </div>

--- a/src/components/AgGrid/TopicFilter.jsx
+++ b/src/components/AgGrid/TopicFilter.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import MultiFilter from './MultiFilter';
+
+const TopicFilter = ({ model, onModelChange }) => {
+    const allTopics = useSelector(state => state.biblio.allTopics);
+    return (
+        <MultiFilter
+            model={model}
+            onModelChange={onModelChange}
+            items={allTopics}
+            label="topic_name"
+        />
+    );
+};
+
+export default TopicFilter;

--- a/src/components/biblio/topic_entity_tag/TopicEntityCreateSGD.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityCreateSGD.js
@@ -267,7 +267,11 @@ const TopicEntityCreateSGD = () => {
         console.log(entityResult.curie);
         if ( (entityResult.curie !== 'no Alliance curie') && (entityResult.curie !== 'duplicate') ) {
           let updateJson = initializeUpdateJson(refCurie);
-          updateJson['entity_id_validation'] = 'alliance'; // TODO: make this a select with 'alliance', 'mod', 'new'
+	  if (entityTypeSelect === 'ATP:0000128' || entityTypeSelect === 'ATP:0000022') {
+	    updateJson['entity_id_validation'] = 'SGD';
+	  } else {
+	    updateJson['entity_id_validation'] = 'alliance';
+          }
           updateJson['entity_type'] = (entityTypeSelect === '') ? null : entityTypeSelect;
           updateJson['entity'] = entityResult.curie;
           let array = [subPath, updateJson, method]

--- a/src/components/biblio/topic_entity_tag/TopicEntityTable.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityTable.js
@@ -1,13 +1,15 @@
 import { Spinner } from 'react-bootstrap';
 import {useSelector, useDispatch} from "react-redux";
 import {useEffect, useState, useMemo, useCallback, useRef} from "react";
-import { setCurieToNameTaxon,setAllSpecies, setAllEntities} from "../../../actions/biblioActions";
+import { setCurieToNameTaxon,setAllSpecies, setAllEntities, setAllTopics, setAllEntityTypes} from "../../../actions/biblioActions";
 import axios from "axios";
 import {getCurieToNameTaxon} from "./TaxonUtils";
 import Modal from 'react-bootstrap/Modal';
 import TopicEntityTagActions from '../../AgGrid/TopicEntityTagActions.jsx';
 import ValidationByCurator from '../../AgGrid/ValidationByCurator.jsx';
 import SpeciesFilter from '../../AgGrid/SpeciesFilter.jsx';
+import EntityTypeFilter from '../../AgGrid/EntityTypeFilter.jsx';
+import TopicFilter from '../../AgGrid/TopicFilter.jsx';
 import EntityFilter from '../../AgGrid/EntityFilter.jsx';
 
 import { AgGridReact } from 'ag-grid-react'; // React Grid Logic
@@ -56,9 +58,13 @@ const TopicEntityTable = () => {
         if (JSON.stringify(resultTags.data) !== JSON.stringify(topicEntityTags)) {
           setTopicEntityTags(resultTags.data);
           const uniqueSpecies = [...new Set( resultTags.data.map(obj => obj.species)) ];
-          const uniqueEntities = [...new Set( resultTags.data.map(obj => obj.entity_type_name))];
+          const uniqueEntityTypes = [...new Set( resultTags.data.map(obj => obj.entity_type_name))];
+	  const uniqueTopics = [...new Set( resultTags.data.map(obj => obj.topic_name))];
+	  const uniqueEntities = [...new Set( resultTags.data.map(obj => obj.entity_name))];  
           dispatch(setAllSpecies(uniqueSpecies));
-          dispatch(setAllEntities(uniqueEntities));
+          dispatch(setAllEntityTypes(uniqueEntityTypes));
+	  dispatch(setAllTopics(uniqueTopics));
+	  dispatch(setAllEntities(uniqueEntities));  
           Object.entries(resultTags.data)
         }
     } catch (error) {
@@ -365,10 +371,10 @@ const CheckDropdownItem = React.forwardRef(
 
   let cols=[
     { field: "Actions" , lockPosition: 'left' , sortable: false, cellRenderer: TopicEntityTagActions},
-    { headerName: "Topic", field: "topic_name", comparator: caseInsensitiveComparator, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.topic)}},
-    { headerName: "Entity Type", field: "entity_type_name", comparator: caseInsensitiveComparator, filter: EntityFilter, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.entity_type)} },
+      { headerName: "Topic", field: "topic_name", comparator: caseInsensitiveComparator, filter: TopicFilter, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.topic)}},
+    { headerName: "Entity Type", field: "entity_type_name", comparator: caseInsensitiveComparator, filter: EntityTypeFilter, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.entity_type)} },
     { headerName: "Species", field: "species_name", comparator: caseInsensitiveComparator, filter: SpeciesFilter, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.species)}},
-    { headerName: "Entity", field: "entity_name", comparator: caseInsensitiveComparator, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.entity)}},
+      { headerName: "Entity", field: "entity_name", comparator: caseInsensitiveComparator, filter: EntityFilter, onCellClicked: (params) => {handleCurieClick(params.value+":"+params.data.entity)}},
     { headerName: "Entity Published As", field: "entity_published_as", comparator: caseInsensitiveComparator },
     { headerName: "No Data", field: "negated", cellDataType: "text", valueGetter: (params) =>   params.data.negated === true ? 'no data': '' },
     { headerName: "Novel Data", field: "novel_topic_data", cellDataType: "text", valueGetter: (params) =>   params.data.novel_topic_data === true ? 'new data': ''},

--- a/src/reducers/biblioReducer.js
+++ b/src/reducers/biblioReducer.js
@@ -1125,6 +1125,18 @@ export default function(state = initialState, action) {
         allEntities: action.payload
       };
 
+    case 'SET_ALL_TOPICS':
+      return {
+        ...state,
+        allTopics: action.payload
+      };
+
+    case 'SET_ALL_ENTITY_TYPES':
+      return {
+        ...state,
+        allEntityTypes: action.payload
+      };
+      
     case 'SET_TOPIC_ENTITY_SOURCE_ID':
       return {
         ...state,


### PR DESCRIPTION
1. adding a generic multi filter that will shows up as a typeahead if there are more than 10 options; otherwise shows up as a list of checkboxes for the options.
2. creating TopicFilter and EntityFilter by calling the generic MultiFilter
3. applying the TopicFilter and EntityFilter  to the Topic and Entity Columns in the Topic Entity Table
4. Renaming original EntityFilter to EntityTypeFilter (it is for entity types, not for entities)