### PR TITLE
Sometimes this line resolves to bucket.docs_count.doc_count but bucke…

### DIFF
--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -226,7 +226,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                                                 </Col>
                                                 <Col>
                                                 <Badge variant="secondary">
-                                                    {['topics', 'confidence_levels', 'source_methods', 'source_evidence_assertions'].includes(key) ? bucket.docs_count.doc_count : bucket.doc_count}
+                                                    {['topics', 'confidence_levels', 'source_methods', 'source_evidence_assertions'].includes(key) && bucket.docs_count !== undefined ? bucket.docs_count.doc_count : bucket.doc_count}
                                                 </Badge>
                                                 </Col>
                                             </Row>


### PR DESCRIPTION
…t.docs_count is undefined, and on 3002 that crashes the page.  I don't know why that doesn't happen on stage.  I think this fixes it without breaking anything, but I don't really know how search works, so it might be breaking something