### PR TITLE
When loading to Edit from props.data check for entity_id_validation b…

### DIFF
--- a/src/components/AgGrid/TopicEntityTagActions.jsx
+++ b/src/components/AgGrid/TopicEntityTagActions.jsx
@@ -92,7 +92,13 @@ export default (props) => {
             dispatch(setEditTag(props.data.topic_entity_tag_id));
             dispatch(setTypeaheadName2CurieMap({[props.data.topic_name]: props.data.topic}));
             dispatch(changeFieldEntityAddGeneralField({ target: { id: 'topicSelect', value: props.data.topic} }));
-            dispatch(changeFieldEntityAddTaxonSelect(props.data.species));
+            if (props.data.entity_id_validation === 'WB') {
+                dispatch(changeFieldEntityAddGeneralField({ target: { id: 'taxonSelect', value: 'use_wb' } }));
+                dispatch(changeFieldEntityAddGeneralField({ target: { id: 'taxonSelectWB', value: props.data.species } }));
+            }
+            else{
+                dispatch(changeFieldEntityAddGeneralField({ target: { id: 'taxonSelect', value: props.data.species } }));
+            }
             dispatch(changeFieldEntityAddGeneralField({ target: { id: 'novelCheckbox', value: props.data.novel_topic_data } }));
             dispatch(changeFieldEntityAddGeneralField({ target: { id: 'noDataCheckbox', value: props.data.negated } }));
             dispatch(changeFieldEntityAddGeneralField({ target: { id: 'notetextarea', value: props.data.note ? props.data.note : '' } }));

--- a/src/components/biblio/topic_entity_tag/TopicEntityCreate.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityCreate.js
@@ -258,11 +258,11 @@ const TopicEntityCreate = () => {
           let updateJson = initializeUpdateJson(refCurie);
           updateJson['entity_id_validation'] = 'alliance'; // TODO: make this a select with 'alliance', 'mod', 'new'
           updateJson['entity_type'] = (entityTypeSelect === '') ? null : entityTypeSelect;
-	      updateJson['species'] = (taxonSelect === '') ? null : taxonSelect;
+          updateJson['species'] = (taxonSelect === '') ? null : taxonSelect;
           updateJson['entity'] = entityResult.curie;
           if (taxonSelect === 'use_wb' && taxonSelectWB !== '' && taxonSelectWB !== undefined && entityTypeSelect !== '') {
             updateJson['entity_id_validation'] = 'WB';
-	    updateJson['species'] = taxonSelectWB; }
+            updateJson['species'] = taxonSelectWB; }
           let array = [subPath, updateJson, method]
           forApiArray.push(array); } } }
     else if (taxonSelect !== '' && taxonSelect !== undefined) {
@@ -314,6 +314,9 @@ const TopicEntityCreate = () => {
       updateJson['entity_id_validation'] = (entityTypeSelect === '') ? null : 'alliance'; // TODO: make this a select with 'alliance', 'mod', 'new'
       updateJson['entity_type'] = (entityTypeSelect === '') ? null : entityTypeSelect;
       updateJson['species'] = (taxonSelect === '') ? null : taxonSelect;
+      if (taxonSelect === 'use_wb' && taxonSelectWB !== '' && taxonSelectWB !== undefined && entityTypeSelect !== '') {
+        updateJson['entity_id_validation'] = 'WB';
+        updateJson['species'] = taxonSelectWB; }
       if(entityResult){
         updateJson['entity'] = entityResult.curie;
       }


### PR DESCRIPTION
…eing WB to load taxonSelect and taxonSelectWB, otherwise load taxonSelect.  Generalize with changeFieldEntityAddGeneralField instead of changeFieldEntityAddTaxonSelect.  Patching data should also use WB values like Post does.