### PR TITLE
add more fields to TET table column options.  clean up some warnings.

### DIFF
--- a/src/components/biblio/topic_entity_tag/TopicEntityTable.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityTable.js
@@ -31,9 +31,6 @@ const TopicEntityTable = () => {
   const biblioUpdatingEntityAdd = useSelector(state => state.biblio.biblioUpdatingEntityAdd);
   const referenceCurie = useSelector(state => state.biblio.referenceCurie);
   const [isLoadingData, setIsLoadingData] = useState(false);
-  const ecoToName = {
-    'ECO:0000302': 'author statement used in manual assertion'
-  };
   const [selectedCurie, setSelectedCurie] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [fullNote, setFullNote] = useState('');
@@ -344,10 +341,6 @@ const CheckDropdownItem = React.forwardRef(
   const dateFormatter = (params) => {
     return new Date(params.value).toLocaleString();
   };
-
-  const nameFormatter = (params) => {
-    return ecoToName[params.value];
-  }
 
   const GenericTetTableModal = ({ title, body, show, onHide }) => {
     return (

--- a/src/components/biblio/topic_entity_tag/TopicEntityTable.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityTable.js
@@ -125,7 +125,9 @@ const TopicEntityTable = () => {
     { headerName: "Source Description", field: "topic_entity_tag_source.description" , id: 23, checked: false},
     { headerName: "Source Created By", field: "topic_entity_tag_source.created_by", id: 24, checked: false },
     { headerName: "Source Date Updated", field: "topic_entity_tag_source.date_updated" , id: 25, checked: false },
-    { headerName: "Source Date Created", field: "topic_entity_tag_source.date_created", id: 26, checked: false }
+    { headerName: "Source Date Created", field: "topic_entity_tag_source.date_created", id: 26, checked: false },
+    { headerName: "Topic Entity Tag Id", field: "topic_entity_tag_id" , id: 27, checked: false },
+    { headerName: "Topic Entity Tag Source Id", field: "topic_entity_tag_source.topic_entity_tag_source_id" , id: 28, checked: false }
     ];
 
   let itemsInitSGD=[
@@ -154,7 +156,9 @@ const TopicEntityTable = () => {
     { headerName: "Source Description", field: "topic_entity_tag_source.description" , id: 23, checked: false},
     { headerName: "Source Created By", field: "topic_entity_tag_source.created_by", id: 24, checked: false },
     { headerName: "Source Date Updated", field: "topic_entity_tag_source.date_updated" , id: 25, checked: false },
-    { headerName: "Source Date Created", field: "topic_entity_tag_source.date_created", id: 26, checked: false }
+    { headerName: "Source Date Created", field: "topic_entity_tag_source.date_created", id: 26, checked: false },
+    { headerName: "Topic Entity Tag Id", field: "topic_entity_tag_id" , id: 27, checked: false },
+    { headerName: "Topic Entity Tag Source Id", field: "topic_entity_tag_source.topic_entity_tag_source_id" , id: 28, checked: false }
     ];
 
     // Function to get a cookie value by name
@@ -253,12 +257,12 @@ const CheckDropdownItem = React.forwardRef(
      const newItems = [...items];
      let item=newItems.find(i => i.id === key);
      item.checked = event.target.checked;
-     if (item && item.checked == true){
+     if (item && item.checked === true){
         gridRef.current.api.applyColumnState({
                  state: [{ colId: item.field, hide: false },],
                 });
      }
-     else if (item && item.checked == false) {
+     else if (item && item.checked === false) {
          gridRef.current.api.applyColumnState({
                   state: [{ colId: item.field, hide: true },],
                  });
@@ -357,13 +361,13 @@ const CheckDropdownItem = React.forwardRef(
   };
 
   const caseInsensitiveComparator = (valueA, valueB) => {
-    if (valueA == null && valueB == null) {
+    if (valueA === null && valueB === null) {
       return 0;
     }
-    if (valueA == null) {
+    if (valueA === null) {
       return -1;
     }
-    if (valueB == null) {
+    if (valueB === null) {
       return 1;
     }
     return valueA.toLowerCase().localeCompare(valueB.toLowerCase());
@@ -396,7 +400,9 @@ const CheckDropdownItem = React.forwardRef(
     { headerName: "Source Description", field: "topic_entity_tag_source.description" },
     { headerName: "Source Created By", field: "topic_entity_tag_source.created_by" },
     { headerName: "Source Date Updated", field: "topic_entity_tag_source.date_updated" , valueFormatter: dateFormatter },
-    { headerName: "Source Date Created", field: "topic_entity_tag_source.date_created" , valueFormatter: dateFormatter }
+    { headerName: "Source Date Created", field: "topic_entity_tag_source.date_created" , valueFormatter: dateFormatter },
+    { headerName: "Topic Entity Tag Id", field: "topic_entity_tag_id" },
+    { headerName: "Topic Entity Tag Source Id", field: "topic_entity_tag_source.topic_entity_tag_source_id" }
   ];
 
   const gridOptions = {

--- a/src/components/biblio/topic_entity_tag/TopicEntityTable.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityTable.js
@@ -48,7 +48,7 @@ const TopicEntityTable = () => {
       dispatch(setCurieToNameTaxon(taxonData));
     };
     fetchData();
-  }, [accessToken]);
+  }, [accessToken, dispatch]);
 
   const fetchTableData = async () => {
     let url = process.env.REACT_APP_RESTAPI + '/topic_entity_tag/by_reference/' + referenceCurie + "?page=" + 1 + "&page_size=" + 8000;
@@ -76,7 +76,7 @@ const TopicEntityTable = () => {
 
   useEffect(() => {
     fetchTableData();
-  }, [topicEntityTags,biblioUpdatingEntityAdd]);
+  }, [topicEntityTags, biblioUpdatingEntityAdd, fetchTableData]);
 
 
   const handleNoteClick = (fullNote) => {


### PR DESCRIPTION
@sweng66 @pjhale There's some warnings, and I fixed a few that seemed obvious.  There's still a few more though

  Line 51:6:    React Hook useEffect has a missing dependency: 'dispatch'. Either include it or remove the dependency array        react-hooks/exhaustive-deps
  Line 79:6:    React Hook useEffect has a missing dependency: 'fetchTableData'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
  Line 348:9:   'nameFormatter' is assigned a value but never used                                                                 no-unused-vars
  Line 425:19:  'setColDefs' is assigned a value but never used   

348 ->  can we just get rid of that ?  It doesn't seem to be used anywhere
425 ->   const [colDefs, setColDefs] = useState(cols);
   colDefs is only used in one place
            columnDefs={colDefs}
   can we just use cols there ?  Because we never use setColDefs anywhere.

51 and 79 I'm not sure about.  I feel like we've run against that before, but I don't recall what we decided for those cases.  Maybe we add them to the array, or we add an es-lint comment to prevent the warning ?