### PR TITLE
Fixing Initial State for TET Variables

### DIFF
--- a/src/components/biblio/topic_entity_tag/TopicEntityTable.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityTable.js
@@ -1,7 +1,7 @@
 import { Spinner } from 'react-bootstrap';
 import {useSelector, useDispatch} from "react-redux";
 import {useEffect, useState, useMemo, useCallback, useRef} from "react";
-import { setCurieToNameTaxon,setAllSpecies, setAllEntities, setAllTopics, setAllEntityTypes} from "../../../actions/biblioActions";
+import {setCurieToNameTaxon,setAllSpecies, setAllEntities, setAllTopics, setAllEntityTypes} from "../../../actions/biblioActions";
 import axios from "axios";
 import {getCurieToNameTaxon} from "./TaxonUtils";
 import Modal from 'react-bootstrap/Modal';

--- a/src/reducers/biblioReducer.js
+++ b/src/reducers/biblioReducer.js
@@ -964,6 +964,8 @@ export default function(state = initialState, action) {
         curieToNameTaxon: {},
         allSpecies: [],
         allEntities: [],
+        filteredTags: null,
+        editTag: null,
         getReferenceCurieFlag: true
       }
     case 'SET_GET_REFERENCE_CURIE_FLAG':


### PR DESCRIPTION
In the reducer we are setting filteredTags and editTag to null so that when a new page is opened the TET table has no variables/filters set.