### PR TITLE
updating sort page to work for single reference

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -100,7 +100,7 @@ const getSearchParams = (state) => {
     query_fields: state.search.query_fields,
     sort_by_published_date_order: state.search.sortByPublishedDate,
     partial_match: state.search.partialMatch,
-    mod_abbreviation: state.isLogged.oktaMod
+    mod_abbreviation: state.isLogged.testerMod !== 'No' ? state.isLogged.testerMod : state.isLogged.oktaMod
   }
 
   const data = state.search.searchFacetsValues;
@@ -158,7 +158,7 @@ export const searchReferences = () => {
           const xrefCurieValues = res.data.hits.filter(hit => hit.cross_references !== null).flatMap(hit =>
               hit.cross_references.map(cross_reference => cross_reference.curie)
           );
-          const curies = res.data.hits.map(hit => hit.curie);
+          const curies = res.data.hits.map(hit => hit.curie);	    
           axios.post(restUrl + '/cross_reference/show_all', xrefCurieValues)
               .then(resXref => {
                 let curieToCrossRefMap = resXref.data.reduce((accumulatedHashTable, currentObject) => {

--- a/src/actions/sortActions.js
+++ b/src/actions/sortActions.js
@@ -163,6 +163,15 @@ export const sortButtonSetRadiosAll = (payload) => {
   };
 };
 
+// New action creator: removeReferenceFromSortLive
+export const removeReferenceFromSortLive = (index) => {
+  console.log("action removeReferenceFromSortLive");
+  return {
+    type: 'REMOVE_REFERENCE_FROM_SORT_LIVE',
+    payload: index
+  };
+};
+
 // // replaced by biblioActions : setReferenceCurie + setGetReferenceCurieFlag
 // // export const resetQueryState = () => {
 // //   return {

--- a/src/components/Sort.js
+++ b/src/components/Sort.js
@@ -367,7 +367,7 @@ const Sort = () => {
           <Row>
             <Col lg={12} className="text-center">
               <SortSubmitUpdateRouter />
-              <Button as="input" type="button" disabled={buttonUpdateDisabled} value="Update Sorting" onClick={() => updateSorting()} />{' '}
+              <Button as="input" style={{ backgroundColor: '#6b9ef3', color: 'white', border: 'none' }} type="button" disabled={buttonUpdateDisabled} value="Update Sorting" onClick={() => updateSorting()} />{' '}
             </Col>
           </Row>
         } 
@@ -520,10 +520,10 @@ const Sort = () => {
                   />
                   { (activeMod === 'WB') && <div><br/><NewTaxonModal/></div> }
 	          <br />
-                  <Button variant="primary" size="sm" onClick={() => handleInsideOrOpen(reference, index, true)}>
+                  <Button variant="outline-primary" size="sm" onClick={() => handleInsideOrOpen(reference, index, true)}>
                       Inside & Open
                   </Button>{' '}
-                  <Button variant="secondary" size="sm" onClick={() => handleInsideOrOpen(reference, index, false)}>
+                  <Button variant="outline-primary" size="sm" onClick={() => handleInsideOrOpen(reference, index, false)}>
                       Inside
                   </Button>
                 </Col>
@@ -542,7 +542,9 @@ const Sort = () => {
 		    <br /><br /><br /><br />
                     {/* New Outside Button */}
 		    <div style={{ marginTop: '10px' }}>
-                      <Button variant="danger" size="sm" onClick={() => handleOutside(reference, index)}>
+		      {/* <Button variant="danger" size="sm" onClick={() => handleOutside(reference, index)}> */}
+		      {/* <Button className="outside-button" size="sm" onClick={() => handleOutside(reference, index)}> */}
+		      <Button variant="outline-secondary" size="sm" onClick={() => handleOutside(reference, index)}>			    
                         Outside
                       </Button>
 	            </div>
@@ -557,7 +559,7 @@ const Sort = () => {
           <RowDivider />
           <Row><Col>
             <SortSubmitUpdateRouter />
-            <Button as="input" type="button" disabled={buttonUpdateDisabled} value="Update Sorting" onClick={() => updateSorting()} />{' '}
+            <Button as="input" style={{ backgroundColor: '#6b9ef3', color: 'white', border: 'none' }} type="button" disabled={buttonUpdateDisabled} value="Update Sorting" onClick={() => updateSorting()} />{' '}
           </Col></Row>
         </Container>
       }
@@ -598,7 +600,7 @@ const NewTaxonModal = () => {
 
   return (
     <>
-      <Button style={{width: "12em"}} onClick={handleShow}>Create New Taxon</Button>
+      <Button variant="outline-primary" size="sm" onClick={handleShow}>Create New Taxon</Button>
       <Modal show={show} onHide={handleClose}>
         <Modal.Header closeButton>
           <Modal.Title>New Taxon</Modal.Title>

--- a/src/components/Sort.js
+++ b/src/components/Sort.js
@@ -1,5 +1,4 @@
 import { Link } from 'react-router-dom'
-// import { useHistory } from "react-router-dom";
 import { useSelector, useDispatch } from 'react-redux';
 
 import Form from 'react-bootstrap/Form';
@@ -29,15 +28,6 @@ import React, {useEffect, useRef, useState} from "react";
 import axios from "axios";
 import { AsyncTypeahead } from "react-bootstrap-typeahead";
 import {AlertAteamApiDown} from "./ATeamAlert";
-
-// DONE
-// Find Papers to Sort will need to query data once there's an API
-// radio buttons need something in the referencesToSort store to update for what type of value to set it to
-// changeSortCorpusToggler should use a button to update the state of that radio
-// Update Sorting will need to update something once there's an API
-// Better styling for the reference display once we know what data we want to show
-// TODO
-// Toggle All buttons need to also access the store for those radio states
 
 
 const RowDivider = () => { return (<Row><Col>&nbsp;</Col></Row>); }
@@ -255,6 +245,19 @@ const Sort = () => {
             <Col lg={4} ></Col>
           </Row>
         }
+
+        {/* Added space between "Find Papers to Sort" button and "Update Sorting" button */}
+        <RowDivider />
+
+        { referencesToSortLive && referencesToSortLive.length > 0 &&
+          <Row>
+            <Col lg={12} className="text-center">
+              <SortSubmitUpdateRouter />
+              <Button as="input" type="button" disabled={buttonUpdateDisabled} value="Update Sorting" onClick={() => updateSorting()} />{' '}
+            </Col>
+          </Row>
+        } 
+	  
       </Container>
       <AlertAteamApiDown />
       {
@@ -266,7 +269,7 @@ const Sort = () => {
             : null
       }
       { referencesToSortLive && referencesToSortLive.length > 0 &&
-        <Container fluid>
+        <Container fluid>	    
           <RowDivider />
           <RowDivider />
           <Row>
@@ -522,6 +525,7 @@ const SortSubmitUpdating = () => {
   );
 }
 
+
 const AlertDismissibleSortUpdate = () => {
   const dispatch = useDispatch();
   const updateAlert = useSelector(state => state.sort.updateAlert);
@@ -535,6 +539,16 @@ const AlertDismissibleSortUpdate = () => {
   else {
     header = 'Update Failure';
     variant = 'danger'; }
+
+  useEffect(() => {
+    if (updateAlert && updateFailure === 0) {
+      const timer = setTimeout(() => {
+        dispatch(closeSortUpdateAlert());
+      }, 2000); // dismiss after 2 seconds
+      return () => clearTimeout(timer);
+    }
+  }, [updateAlert, updateFailure, dispatch]);
+
   if (updateAlert) {
     return (
       <Alert variant={variant} onClose={() => dispatch(closeSortUpdateAlert())} dismissible>
@@ -546,7 +560,6 @@ const AlertDismissibleSortUpdate = () => {
     );
   } else { return null; }
 }
-
 
 export default Sort
 

--- a/src/components/Sort.js
+++ b/src/components/Sort.js
@@ -23,7 +23,6 @@ import { changeSortWorkflowToggler } from '../actions/sortActions';
 import { updateButtonSort } from '../actions/sortActions';
 import { closeSortUpdateAlert } from '../actions/sortActions';
 import { setSortUpdating } from '../actions/sortActions';
-import { sortButtonSetRadiosAll } from '../actions/sortActions';
 import {Spinner} from "react-bootstrap";
 import React, {useEffect, useRef, useState} from "react";
 import axios from "axios";
@@ -35,7 +34,6 @@ const RowDivider = () => { return (<Row><Col>&nbsp;</Col></Row>); }
 const Sort = () => {
   const modsField = useSelector(state => state.sort.modsField);
   const referencesToSortLive = useSelector(state => state.sort.referencesToSortLive);
-  const referencesToSortDb = useSelector(state => state.sort.referencesToSortDb);
   const accessToken = useSelector(state => state.isLogged.accessToken);
   const sortType = useSelector(state => state.sort.sortType);
   const sortUpdating = useSelector(state => state.sort.sortUpdating);
@@ -55,9 +53,11 @@ const Sort = () => {
   let accessLevel = oktaMod;
   let activeMod = oktaMod;
   if (testerMod !== 'No') {
-    activeMod = testerMod;
-    accessLevel = testerMod; }
-  else if (oktaDeveloper) { accessLevel = 'developer'; }
+      activeMod = testerMod;
+      accessLevel = testerMod;
+  } else if (oktaDeveloper) {
+      accessLevel = 'developer';
+  }
 
   const tetAccessLevel = (testerMod !== 'No') ? testerMod : oktaMod;
     
@@ -71,10 +71,14 @@ const Sort = () => {
   }, [tetAccessLevel, accessToken]);
 
   let buttonFindDisabled = 'disabled'
-  if (modsField) { buttonFindDisabled = ''; }
+  if (modsField) {
+      buttonFindDisabled = '';
+  }
 
   let buttonUpdateDisabled = ''
-  if (sortUpdating > 0) { buttonUpdateDisabled = 'disabled'; }
+  if (sortUpdating > 0) {
+      buttonUpdateDisabled = 'disabled';
+  }
 
   const mods = ['FB', 'MGI', 'RGD', 'SGD', 'WB', 'XB', 'ZFIN']
 
@@ -89,13 +93,13 @@ const Sort = () => {
     const rowReferencefileElements = [];
 
     for (const[index, reference] of referencesToSortLive.entries()) {
-     if (referenceCurie  !== reference['curie']) {continue; }
-     const copyrightLicenseOpenAccess =  (reference['copyright_license_open_access'] !==null && reference['copyright_license_open_access'] === 'True') ? true : false;
-     let is_ok = false;
-     let allowed_mods = [];
+       if (referenceCurie  !== reference['curie']) {continue; }
+       const copyrightLicenseOpenAccess =  (reference['copyright_license_open_access'] !==null && reference['copyright_license_open_access'] === 'True') ? true : false;
+       let is_ok = false;
+       let allowed_mods = [];
 
-     if ( 'referencefiles' in reference && reference['referencefiles'].length > 0) {
-         for (const referencefile of reference['referencefiles'].values()) {
+       if ( 'referencefiles' in reference && reference['referencefiles'].length > 0) {
+          for (const referencefile of reference['referencefiles'].values()) {
              let filename=null;
              let fileclass=null;
              let referencefile_id=null;
@@ -140,21 +144,18 @@ const Sort = () => {
                      {referencefileValue}
                  </div>);
              rowReferencefileElements.push( referencefileRow );
-         }
-      }
+          }
+       }
     }
     return (<>{rowReferencefileElements}</>);
   }
 
-
-
-
-  // Function to handle "Inside & Open" button click
+  // function to handle "Inside & Open" button click
   const handleInsideAndOpen = (reference, index) => {
-    // Array to hold API calls
+
     const forApiArray = [];
 
-    // Update mod_corpus_association to set 'corpus' to true
+    // update mod_corpus_association to set 'corpus' to true
     let updateJson = { 'corpus': true, 'mod_corpus_sort_source': 'manual_creation' };
     let subPath = 'reference/mod_corpus_association/' + reference['mod_corpus_association_id'];
     let method = 'PATCH';
@@ -163,7 +164,7 @@ const Sort = () => {
     let array = [subPath, updateJson, method, index, field, subField];
     forApiArray.push(array);
 
-    // If activeMod === 'WB', handle setting 'reference_type' via 'mod_reference_type'
+    // if activeMod === 'WB', handle setting 'reference_type' via 'mod_reference_type'
     if (activeMod === "WB") {
       let reference_type = null;
       if (reference['workflow'] === 'experimental') {
@@ -181,7 +182,7 @@ const Sort = () => {
         forApiArray.push(array);
       }
 
-      // Handle species selection
+      // handle species selection
       if (speciesSelect && speciesSelect[index]) {
         for (const item of speciesSelect[index].values()) {
           const taxArray = item.split(" ");
@@ -201,7 +202,7 @@ const Sort = () => {
       }
     }
 
-    // Dispatch the updates
+    // dispatch the updates
     let dispatchCount = forApiArray.length;
     dispatch(setSortUpdating(dispatchCount));
     for (const arrayData of forApiArray.values()) {
@@ -209,34 +210,31 @@ const Sort = () => {
       dispatch(updateButtonSort(arrayData));
     }
 
-    // Remove the paper from the page
+    // remove the paper from the page
     dispatch(removeReferenceFromSortLive(index));
 
-    // Update speciesSelect state
+    // update speciesSelect state
     setSpeciesSelect(prevSpeciesSelect => {
       const newSpeciesSelect = [...prevSpeciesSelect];
       newSpeciesSelect.splice(index, 1);
       return newSpeciesSelect;
     });
 
-    // Update speciesSelectLoading state
+    // update speciesSelectLoading state
     setSpeciesSelectLoading(prevSpeciesSelectLoading => {
       const newSpeciesSelectLoading = [...prevSpeciesSelectLoading];
       newSpeciesSelectLoading.splice(index, 1);
       return newSpeciesSelectLoading;
     });
 
-    // Open TET editor in new tab/window
-    const tetEditorUrl = `/TET?action=display&referenceCurie=${reference['curie']}`;
+    // open TET editor in new tab/window
+    const tetEditorUrl = `/Biblio/?action=entity&referenceCurie=${reference['curie']}`;
     window.open(tetEditorUrl, '_blank');
   };
 
-
-
-
-  // Function to handle "Inside" button click
+  // function to handle "Inside" button click
   const handleInside = (reference, index) => {
-    // Array to hold API calls
+    
     const forApiArray = [];
 
     // Update mod_corpus_association to set 'corpus' to true
@@ -346,7 +344,6 @@ const Sort = () => {
       if (reference['mod_corpus_association_corpus'] !== null) {
         // console.log(reference['mod_corpus_association_id']);
         // console.log(reference['corpus']);
-        // console.log(referencesToSortDb[index]['corpus']);
         let updateJson = { 'corpus': reference['mod_corpus_association_corpus'], 'mod_corpus_sort_source': 'manual_creation' }
         let subPath = 'reference/mod_corpus_association/' + reference['mod_corpus_association_id'];
         const field = null;
@@ -469,7 +466,7 @@ const Sort = () => {
             return (
             <div key={`reference div ${index}`} >
               <Row key={`reference ${index}`} >	    
-              <Col lg={3} className="Col-general Col-display" style={{display: 'flex', flexDirection: 'column', justifyContent: 'center', backgroundColor: backgroundColor}} >
+              <Col lg={2} className="Col-general Col-display" style={{display: 'flex', flexDirection: 'column', backgroundColor: backgroundColor}} >
                  <div style={{alignSelf: 'flex-start'}} ><b>Title: </b>
                    <span dangerouslySetInnerHTML={{__html: reference['title']}} /></div>
                  <Link to={{pathname: "/Biblio", search: "?action=display&referenceCurie=" + reference['curie']}}
@@ -481,15 +478,29 @@ const Sort = () => {
                  ))}
                  <div style={{alignSelf: 'flex-start'}} ><b>Journal:</b> {
                    (reference['resource_title']) ? <span dangerouslySetInnerHTML={{__html: reference['resource_title']}} /> : 'N/A' }</div>
-                <div style={{alignSelf: 'flex-start'}} ><FileElement  referenceCurie={reference['curie']}/></div>
+                 <div style={{alignSelf: 'flex-start'}} ><FileElement  referenceCurie={reference['curie']}/></div>
               </Col>
               <Col lg={5} className="Col-general Col-display" style={{backgroundColor: backgroundColor}}><span dangerouslySetInnerHTML={{__html: reference['abstract']}} /></Col>
 
-              <Col lg={2} className="Col-general Col-display" style={{display: 'block', backgroundColor: backgroundColor}}>
-		  <br></br><br></br>
+
+	      {/* Needs Review Column */}  	  
+	      <Col lg={1} className="Col-general Col-display" style={{ display: 'block', backgroundColor: backgroundColor }}>
+		  <br /><br />    
                   <Form.Check
                       inline
                       checked={ (reference['mod_corpus_association_corpus'] === null) ? 'checked' : '' }
+                      type='radio'
+                      label='needs review'
+                      id={`needs_review_toggle ${index}`}
+                      onChange={(e) => dispatch(changeSortCorpusToggler(e))}
+                  />
+              </Col>
+
+	      <Col lg={2} className="Col-general Col-display" style={{ display: 'block', backgroundColor: backgroundColor }}>
+		  <br /><br />
+                  <Form.Check
+                      inline
+                      checked={ (reference['mod_corpus_association_corpus'] === true) ? 'checked' : '' }
                       type='radio'
                       label='inside corpus'
                       id={`inside_corpus_toggle ${index}`}
@@ -597,7 +608,7 @@ const Sort = () => {
                     <br /><br />
                     <Form.Check
                       inline
-                      checked={(reference['mod_corpus_association_corpus'] === false) ? 'checked' : ''}
+                      checked={ (reference['mod_corpus_association_corpus'] === false) ? 'checked' : '' }
                       type='radio'
                       label='outside corpus'
                       id={`outside_corpus_toggle ${index}`}
@@ -611,6 +622,8 @@ const Sort = () => {
                       </Button>
 	            </div>
                 </Col>
+
+		  
 		  
             </Row>
 

--- a/src/components/Sort.js
+++ b/src/components/Sort.js
@@ -30,9 +30,7 @@ import axios from "axios";
 import { AsyncTypeahead } from "react-bootstrap-typeahead";
 import {AlertAteamApiDown} from "./ATeamAlert";
 
-
 const RowDivider = () => { return (<Row><Col>&nbsp;</Col></Row>); }
-
 
 const Sort = () => {
   const modsField = useSelector(state => state.sort.modsField);
@@ -315,7 +313,31 @@ const Sort = () => {
   };
 
     
+  // Function to handle "Outside" button click
+  const handleOutside = (reference, index) => {
+    // Array to hold API calls
+    const forApiArray = [];
 
+    // Update mod_corpus_association to set 'corpus' to false
+    let updateJson = { 'corpus': false, 'mod_corpus_sort_source': 'manual_creation' };
+    let subPath = 'reference/mod_corpus_association/' + reference['mod_corpus_association_id'];
+    let method = 'PATCH';
+    let field = null;
+    let subField = null;
+    let array = [subPath, updateJson, method, index, field, subField];
+    forApiArray.push(array);
+
+    // Dispatch the updates
+    let dispatchCount = forApiArray.length;
+    dispatch(setSortUpdating(dispatchCount));
+    for (const arrayData of forApiArray.values()) {
+      arrayData.unshift(accessToken);
+      dispatch(updateButtonSort(arrayData));
+    }
+
+    // Remove the paper from the page
+    dispatch(removeReferenceFromSortLive(index));
+  };
     
     
   function updateSorting() {
@@ -464,7 +486,7 @@ const Sort = () => {
               <Col lg={5} className="Col-general Col-display" style={{backgroundColor: backgroundColor}}><span dangerouslySetInnerHTML={{__html: reference['abstract']}} /></Col>
 
               <Col lg={2} className="Col-general Col-display" style={{display: 'block', backgroundColor: backgroundColor}}>
-                  <br/><br/>
+		  <br></br><br></br>
                   <Form.Check
                       inline
                       checked={ (reference['mod_corpus_association_corpus'] === null) ? 'checked' : '' }
@@ -473,7 +495,7 @@ const Sort = () => {
                       id={`inside_corpus_toggle ${index}`}
                       onChange={(e) => dispatch(changeSortCorpusToggler(e))}
                   />
-                  <br/><br/>
+		  <br /> 
                   { (activeMod === 'WB') &&
                     <>
                       <Form.Check
@@ -568,8 +590,28 @@ const Sort = () => {
                   <Button variant="secondary" size="sm" onClick={() => handleInside(reference, index)}>
                       Inside
                   </Button>
+                </Col>
 
-              </Col>
+                {/* Outside Corpus Column */}
+                <Col lg={2} className="Col-general Col-display" style={{ display: 'block', backgroundColor: backgroundColor }}>
+                    <br /><br />
+                    <Form.Check
+                      inline
+                      checked={(reference['mod_corpus_association_corpus'] === false) ? 'checked' : ''}
+                      type='radio'
+                      label='outside corpus'
+                      id={`outside_corpus_toggle ${index}`}
+                      onChange={(e) => dispatch(changeSortCorpusToggler(e))}
+                    />
+		    <br /><br /><br /><br />
+                    {/* New Outside Button */}
+		    <div style={{ marginTop: '10px' }}>
+                      <Button variant="danger" size="sm" onClick={() => handleOutside(reference, index)}>
+                        Outside
+                      </Button>
+	            </div>
+                </Col>
+		  
             </Row>
 
             </div>

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -363,6 +363,8 @@ const Facets = () => {
     const datePublished= useSelector(state => state.search.datePublished);
     const dateCreated = useSelector(state => state.search.dateCreated);
     const oktaMod = useSelector(state => state.isLogged.oktaMod);
+    const testerMod = useSelector(state => state.isLogged.testerMod);
+    const accessLevel = testerMod !== "No" ? testerMod : oktaMod;
     const modPreferencesLoaded = useSelector(state => state.search.modPreferencesLoaded);
     const applyToSingleTag = useSelector(state => state.search.applyToSingleTag);
     // const [showWarning, setShowWarning] = useState(false);
@@ -410,15 +412,15 @@ const Facets = () => {
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(()=> {
-        if(modPreferencesLoaded === 'false' && oktaMod !== 'No'){
+        if(modPreferencesLoaded === 'false' && accessLevel !== 'No'){
             dispatch(setModPreferencesLoaded(true));
             if(searchFacetsValues["mods_in_corpus_or_needs_review.keyword"]){
-                if(!searchFacetsValues["mods_in_corpus_or_needs_review.keyword"].includes(oktaMod)) {
-                    dispatch(addFacetValue("mods_in_corpus_or_needs_review.keyword", oktaMod));
+                if(!searchFacetsValues["mods_in_corpus_or_needs_review.keyword"].includes(accessLevel)) {
+                    dispatch(addFacetValue("mods_in_corpus_or_needs_review.keyword", accessLevel));
                 }
             }
             else {
-                dispatch(addFacetValue("mods_in_corpus_or_needs_review.keyword", oktaMod));
+                dispatch(addFacetValue("mods_in_corpus_or_needs_review.keyword", accessLevel));
             }
             if(searchFacetsValues["language.keyword"]){
                 if(!searchFacetsValues["language.keyword"].includes('English')) {
@@ -431,7 +433,7 @@ const Facets = () => {
             dispatch(searchReferences());
 
         }
-    }, [oktaMod]) // eslint-disable-line react-hooks/exhaustive-deps
+    }, [accessLevel]) // eslint-disable-line react-hooks/exhaustive-deps
 
 
     /*

--- a/src/reducers/sortReducer.js
+++ b/src/reducers/sortReducer.js
@@ -136,6 +136,13 @@ export default function(state = initialState, action) {
         referencesToSortLive: sortToggleWorkflowReferencesToSortLive
       }
 
+      
+      case 'REMOVE_REFERENCE_FROM_SORT_LIVE':
+        return {
+          ...state,
+          referencesToSortLive: state.referencesToSortLive.filter((_, idx) => idx !== action.payload)
+        };
+      
     case 'UPDATE_BUTTON_SORT':
       // console.log('reducer UPDATE_BUTTON_SORT ' + action.payload.responseMessage);
       // console.log('action.payload'); console.log(action.payload);
@@ -175,4 +182,4 @@ export default function(state = initialState, action) {
       return state;
   }
 }
-  
+


### PR DESCRIPTION
* adding paper into log-in user's mod corpus
* adding paper into log-in user's mod corpus plus directing curators to TET page
* discarding paper from log-in user's mod
* adding "Update Sorting" button on the top (along with the one at the bottom) to discard/add multiple papers at the same time
* also fixed the search code to handle tester properly (for missing PDF icon issue in search result page)