### PR TITLE
Use centralized Claude review thresholds from .github repo

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,8 +26,7 @@ jobs:
       review_focus: "critical bugs, security vulnerabilities, and UX issues in the React frontend application. Focus on: component rendering errors, Redux state management bugs, memory leaks, XSS vulnerabilities, improper API error handling, missing loading states, race conditions in async operations, and accessibility violations"
       trigger_phrase: "@claude"
       use_zen_tools: true
-      pr_size_threshold: "300"
-      skip_threshold: "25"
+      # Use centralized thresholds from .github repo (skip_threshold: 3, pr_size_threshold: 40)
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
- Remove hardcoded pr_size_threshold and skip_threshold
- Let workflow inherit defaults from alliance-genome/.github
- Centralized thresholds: skip ≤3 lines, zen >40 lines
- Supports Skip 10%, Zen 50% strategy across all repos