### PR TITLE
Fix for Long Notes

### DIFF
--- a/src/components/biblio/topic_entity_tag/TopicEntityTable.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityTable.js
@@ -614,6 +614,21 @@ const CheckboxDropdown =  ({ items }) => {
       }
     }
   },[]);
+
+  const onColumnResize = useCallback((params)=>{
+      let colState = gridRef.current.api.getColumnState();
+      //Only Trigger on autoresize
+      if(params.source === 'autosizeColumns') {
+          colState.forEach((element) => {
+              if (element.colId === 'note' && element.width > 300){
+                  gridRef.current.api.applyColumnState({
+                      state: [{ colId: 'note', width: 300 },],
+                  });
+              }
+          })
+      }
+  },[])
+
   const getRowId = useMemo(() => {
     return (params) => String(params.data.topic_entity_tag_id);
   }, []);
@@ -665,6 +680,7 @@ const CheckboxDropdown =  ({ items }) => {
                   reactiveCustomComponents
                   rowData={topicEntityTags}
                   onGridReady={onGridReady}
+                  onColumnResized={onColumnResize}
                   getRowId={getRowId}
                   columnDefs={colDefs}
                   onColumnMoved={columnMoved}


### PR DESCRIPTION
We use auto column widths for this table.  But some notes are super long.  This change adds a listener to column resized.  We look for events that are auto and if the notes field width is more than 300 wide.