### PR TITLE
SCRUM-5277 Automatic removal of NOT selections in confidence level.

### DIFF
--- a/src/components/search/BreadCrumbs.js
+++ b/src/components/search/BreadCrumbs.js
@@ -69,8 +69,14 @@ const BreadCrumbs = () => {
     };
 
     const handleRemoveFacet = (facet, value) => {
+
+        //Remove NOT Confidence Levels if no topic is selected.
+        if(facet === 'topics' && searchExcludedFacetsValues.confidence_levels){
+            searchExcludedFacetsValues.confidence_levels.forEach(confidence_level => {
+                dispatch(removeExcludedFacetValue('confidence_levels', confidence_level))
+            })
+        }
         dispatch(removeFacetValue(facet, value));
-        dispatch(searchReferences());
     };
 
     const handleClearAll = () => {

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -231,7 +231,6 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                 <Form.Check inline type="checkbox"
                     checked={searchFacetsValues.hasOwnProperty(facet) && searchFacetsValues[facet].includes(value)}
                     onChange={(evt) => {
-                        console.log(facet,value);
                         if (evt.target.checked) {
                             dispatch(addFacetValue(facet, value));
                             if(facet === 'topics'  && !searchExcludedFacetsValues.confidence_levels  && !searchFacetsValues.confidence_levels) {

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -231,13 +231,20 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                 <Form.Check inline type="checkbox"
                     checked={searchFacetsValues.hasOwnProperty(facet) && searchFacetsValues[facet].includes(value)}
                     onChange={(evt) => {
-
+                        console.log(facet,value);
                         if (evt.target.checked) {
                             dispatch(addFacetValue(facet, value));
                             if(facet === 'topics'  && !searchExcludedFacetsValues.confidence_levels  && !searchFacetsValues.confidence_levels) {
                                 dispatch(addExcludedFacetValue('confidence_levels', 'NEG'));
                             }
                         } else {
+                            //Remove NOT Confidence Levels if no topic is selected.
+                            if(facet === 'topics' && searchExcludedFacetsValues.confidence_levels){
+                                console.log(searchFacetsValues.topics);
+                                searchExcludedFacetsValues.confidence_levels.forEach(confidence_level => {
+                                    dispatch(removeExcludedFacetValue('confidence_levels', confidence_level))
+                                })
+                            }
                             dispatch(removeFacetValue(facet, value));
                         }
                 }}/>


### PR DESCRIPTION
When there are no topics selected the UI should automatically remove any NOT selections in confidence level as they do not make sense.  This checks in the facet and breadcrumbs every time a user removes all topics and then removes all NOT confidence level selections.  This does not remove positive selections in this facet.

Also removed a searchReferences() call that appears redundant.  These are in other functions here but I didn't touch them.