### PR TITLE
new WorkflowTagService to delete a workflow_tag.  GeneralizedDropdown…

### DIFF
--- a/src/components/biblio/WorkflowTagService.js
+++ b/src/components/biblio/WorkflowTagService.js
@@ -39,3 +39,22 @@ export async function patchWorkflowTag(id, data, accessToken) {
   }
   return res.data;
 }
+
+/**
+ * Delete an existing workflow tag.
+ * @param {string|number} id  the reference_workflow_tag_id
+ * @param {string} accessToken
+ */
+export async function deleteWorkflowTag(id, accessToken) {
+  const url = `${process.env.REACT_APP_RESTAPI}/workflow_tag/${id}`;
+  const res = await axios.delete(url, {
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (res.status !== 204) {
+    throw new Error(`DELETE /workflow_tag/${id} failed with status ${res.status}`);
+  }
+  return res.data;
+}


### PR DESCRIPTION
…Renderer allows a blank option when workflow_tag as well as previous curation_status.  when clearing a workflow_tag from an existing value to no value, delete the workflow_tag