### PR TITLE
Add Headers to the Manual Indexing and Community Curation AgGrid tabl…

### DIFF
--- a/src/components/biblio/BiblioWorkflow.js
+++ b/src/components/biblio/BiblioWorkflow.js
@@ -1013,15 +1013,15 @@ const BiblioWorkflow = () => {
               className="ag-theme-quartz"
               style={{
                 width: '80%',
-                height: `${indexingWorkflowData.length * 75}px`,
-                marginBottom: 10,
+                height: `${indexingWorkflowData.length * 45 + 60}px`,
+                marginBottom: 40,
               }}
             >
               <AgGridReact
                 rowData={indexingWorkflowData}
                 columnDefs={indexingWorkflowColumns}
                 singleClickEdit={true}
-                domLayout="autoHeight"
+                domLayout="normal"
                 rowHeight={43}
                 getRowClass={() => 'ag-row-striped-light'}
                 popupParent={document.body}

--- a/src/components/biblio/BiblioWorkflow.js
+++ b/src/components/biblio/BiblioWorkflow.js
@@ -720,7 +720,7 @@ const BiblioWorkflow = () => {
       filter: true,
     },
     {
-      headerName: 'Current Status',
+      headerName: 'Workflow Status',
       field: 'workflow_tag',
       flex: 1,
       cellStyle: { textAlign: 'left' },
@@ -748,7 +748,7 @@ const BiblioWorkflow = () => {
       filter: true,
     },
     {
-      headerName: 'Email',
+      headerName: 'Curator',
       field: 'email',
       flex: 1,
       cellStyle: { textAlign: 'left' },
@@ -757,7 +757,7 @@ const BiblioWorkflow = () => {
       filter: true,
     },
     {
-      headerName: 'Date Updated',
+      headerName: 'Workflow Updated',
       field: 'date_updated',
       flex: 1,
       cellStyle: { textAlign: 'left' },
@@ -1013,7 +1013,7 @@ const BiblioWorkflow = () => {
               className="ag-theme-quartz"
               style={{
                 width: '80%',
-                height: `${indexingWorkflowData.length * 45}px`,
+                height: `${indexingWorkflowData.length * 75}px`,
                 marginBottom: 10,
               }}
             >
@@ -1021,8 +1021,7 @@ const BiblioWorkflow = () => {
                 rowData={indexingWorkflowData}
                 columnDefs={indexingWorkflowColumns}
                 singleClickEdit={true}
-                domLayout="normal"
-                headerHeight={0}
+                domLayout="autoHeight"
                 rowHeight={43}
                 getRowClass={() => 'ag-row-striped-light'}
                 popupParent={document.body}


### PR DESCRIPTION
…e, and change the header names to match the story, but not changing the field names, since those better match where the data comes from the API.  Also setting height to autoHeight which fits, but doesn't look great