### PR TITLE
feat(taxon-import): route NCBI taxon creation through backend proxy (SCRUM-5679)

### DIFF
--- a/src/components/SortHelper.js
+++ b/src/components/SortHelper.js
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
 import { Button, Modal, InputGroup, Form, Alert, Spinner } from 'react-bootstrap';
-import axios from 'axios';
 import { api } from '../api';
 import PropTypes from 'prop-types';
 
@@ -9,7 +7,6 @@ import PropTypes from 'prop-types';
  * NewTaxonModal Component
  */
 export const NewTaxonModal = () => {
-  const accessToken = useSelector(state => state.isLogged.accessToken);
   const [show, setShow] = useState(false);
   const [taxonId, setTaxonId] = useState('');
   const [ateamResponse, setAteamResponse] = useState('');
@@ -19,17 +16,10 @@ export const NewTaxonModal = () => {
   const defaultBodyText = "Import NCBI Taxon into A-team system for autocomplete here.\nOnly put in the digits part of the NCBI Taxon ID.\n\n";
 
   const importTaxon = (taxonId) => {
-    axios.get(`${process.env.REACT_APP_ATEAM_API_BASE_URL}api/ncbitaxonterm/NCBITaxon:${taxonId}`, {
-      headers: {
-        'content-type': 'application/json',
-        'authorization': `Bearer ${accessToken}`
-      }
-    })
+    api.get(`/ontology/get_or_create_species/${encodeURIComponent(taxonId)}`)
     .then(res => {
-      let success = false;
-      if (res.data.entity && res.data.entity.curie) { success = true; }
-      if (success) {
-        setAteamResponse(`${res.data.entity.curie} created in A-team system`);
+      if (res.data && res.data.curie) {
+        setAteamResponse(`${res.data.curie} created in A-team system`);
         setAteamSuccess(true);
       } else {
         setAteamResponse('Unknown failure to create in A-team system');


### PR DESCRIPTION
## Summary
- Migrates the **Create New Taxon** modal to call the literature-service endpoint `/ontology/get_or_create_species/{taxon_id}` instead of hitting the A-Team API directly.
- Authentication is now enforced server-side (via the literature-service session) rather than by forwarding the user's access token to the A-Team.
- Drops the now-unused `axios` and `useSelector` imports from `SortHelper.js`.

## Related
- Backend PR: https://github.com/alliance-genome/agr_literature_service/pull/1129
- Jira: [SCRUM-5679](https://agr-jira.atlassian.net/browse/SCRUM-5679)

## Test plan
- [ ] `npm start` against a literature-service pointing at a matching curation env (`ATEAM_API_URL` + `PERSISTENT_STORE_DB_HOST` aligned).
- [ ] Open the sort workflow with `activeMod === "WB"` and click **Create New Taxon**.
- [ ] Enter a numeric NCBI Taxon ID (e.g., `272634`) and submit.
- [ ] Confirm the green success message shows the created CURIE (e.g., `NCBITaxon:272634 created in A-team system`).
- [ ] Verify the row is present in the target curation DB (`SELECT curie, name FROM ontologyterm WHERE curie = 'NCBITaxon:272634'`).
- [ ] Verify the species typeahead can then find it by partial name.

[SCRUM-5679]: https://agr-jira.atlassian.net/browse/SCRUM-5679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ