### PR TITLE
feat(biblio): recognize _nxml and _tei suffixes on converted files

### DIFF
--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -759,8 +759,11 @@ const FileEditor = ({ onFileStatusChange }) => {
     }
   };
 
-  // Method suffixes used in converted file display names
-  const METHOD_SUFFIXES = ['_grobid', '_docling', '_marker', '_merged'];
+  // Method suffixes used in converted file display names.
+  // PDFX outputs use _grobid/_docling/_marker/_merged; XML-derived outputs use
+  // _nxml (from nXML sources) and _tei (from TEI sources). Stripping any of
+  // these yields the source display_name used as the grouping key.
+  const METHOD_SUFFIXES = ['_grobid', '_docling', '_marker', '_merged', '_nxml', '_tei'];
 
   // Create a mapping of base display_name to converted files (markdown and TEI)
   // Converted files have names like "PMC123_grobid" but we need to map to "PMC123"


### PR DESCRIPTION
## Summary

Adds `_nxml` and `_tei` to the `METHOD_SUFFIXES` list in `BiblioFileManagement.js`, so XML-derived markdown conversions (produced by the updated `nxml2md.py` oneoff and by `pdf2md.py`'s nXML path) group under the source file's card alongside the existing PDFX outputs (`_grobid`, `_docling`, `_marker`, `_merged`).

Without this change, converted files named e.g. `PMC11490078.1_nxml` would not strip to the source `display_name` and would never surface under the source file in the UI.

Companion to the backend changes in [agr_literature_service PR #1131](https://github.com/alliance-genome/agr_literature_service/pull/1131), where the new pdf2md pipeline emits `_nxml` and the oneoff `nxml2md.py` / backfill script tag existing rows with `_nxml` or `_tei`.

## Test plan

- [ ] Load a reference in the Biblio file management view that has a `converted_merged_main` row with `_nxml` suffix (e.g. AGRKB:101000001813672 on dev) and confirm it appears as a "merged" link under the source PDF/nXML card.
- [ ] Confirm the same for a `_tei`-suffixed row on dev (e.g. a FlyBase `FBrf*` reference).
- [ ] Sanity-check that existing PDFX-method conversions (`_grobid` / `_docling` / `_marker` / `_merged`) still group correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)