### PR TITLE
allow species-less topic tags and fix species addition in sort

### DIFF
--- a/src/components/Sort.js
+++ b/src/components/Sort.js
@@ -174,7 +174,9 @@ const Sort = () => {
                   'topic': "ATP:0000123",
                   'entity_type': "ATP:0000123",
                   'entity_id_validation': "alliance",
-                  'topic_entity_tag_source_id': topicEntitySourceId
+                  'topic_entity_tag_source_id': topicEntitySourceId,
+                  'data_novelty': "ATP:0000335",
+                  'negated': false
                 };
                 subPath = 'topic_entity_tag/';
                 const field = null;

--- a/src/components/biblio/topic_entity_tag/TopicEntityCreate.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityCreate.js
@@ -103,9 +103,9 @@ const TopicEntityCreate = () => {
 
   const taxonList = useMemo(() => {
     const unsortedTaxonList = Object.values(modToTaxon || {}).flat();
-    unsortedTaxonList.push("");
     unsortedTaxonList.push("use_wb");
     unsortedTaxonList.push("NCBITaxon:9606");
+    // Sort species by name, excluding empty string
     let sortedList = unsortedTaxonList.sort((a, b) => (curieToNameTaxon[a] > curieToNameTaxon[b] ? 1 : -1));
 
     // Reorder to put user's MOD species first
@@ -113,6 +113,9 @@ const TopicEntityCreate = () => {
       const filteredTaxonList = sortedList.filter((x) => !modToTaxon[accessLevel].includes(x));
       sortedList = modToTaxon[accessLevel].concat(filteredTaxonList);
     }
+
+    // Add "No species" option at the end
+    sortedList.push("");
 
     return sortedList;
   }, [modToTaxon, curieToNameTaxon, accessLevel]);
@@ -466,9 +469,9 @@ const TopicEntityCreate = () => {
       }
 
       // Calculate disabledAddButton for the current row
+      // Species is optional - tags can be created without species
       const disabledAddButton =
         (currentRow.topicSelect === speciesATP && !currentRow.isSpeciesSelected) ||
-        (currentRow.topicSelect !== speciesATP && (!currentRow.taxonSelect || currentRow.taxonSelect === "")) ||
         !topicEntitySourceId ||
         !currentRow.topicSelect;
 
@@ -630,12 +633,12 @@ const TopicEntityCreate = () => {
             forApiArray.push([null, subPath, updateJson, method]);
           }
         }
-      } else if (row.taxonSelect !== "" && row.taxonSelect !== undefined) {
-        //const updateJson = initializeUpdateJson(refCurie, row, null, "alliance");
+      } else {
+        // Allow tags without species (species is optional)
         const updateJson = initializeUpdateJson(refCurie, row, null, null, dataNoveltyAtp);
-        // console.log("updateJson = " + JSON.stringify(updateJson, null, 2));
         forApiArray.push([null, subPath, updateJson, method]);
-    } }
+      }
+    }
 
     if (forApiArray.length === 0) {
       console.error("No valid data to submit.");
@@ -986,7 +989,7 @@ const TopicEntityCreate = () => {
                 >
                   {taxonList.map((option, idx) => (
                     <option key={idx} value={option}>
-                      {curieToNameTaxon[option]}
+                      {option === "" ? "(No species)" : curieToNameTaxon[option]}
                     </option>
                   ))}
                 </Form.Control>

--- a/src/components/biblio/topic_entity_tag/TopicEntityCreate.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityCreate.js
@@ -484,7 +484,13 @@ const TopicEntityCreate = () => {
       if (field === 'selectedSpecies') {
         newRows[index].selectedSpecies = value; // store selected species
       }
-	
+
+      // Clear entity fields when species is set to empty (entities require species for validation)
+      if (field === 'taxonSelect' && (value === "" || value === undefined)) {
+        currentRow.entityText = "";
+        currentRow.entityResultList = [];
+      }
+
       // Validate the row when relevant fields change
       if (['entityText', 'taxonSelect', 'entityTypeSelect'].includes(field)) {
         handleEntityValidation(index, value);
@@ -1049,11 +1055,13 @@ const TopicEntityCreate = () => {
                     options={typeaheadOptions}
           	  selected={row.selectedSpecies || row.entityResultList.map(entity => `${entity.entityTypeSymbol} ${entity.curie}`)}
                   />
-                ) : ( 	
+                ) : (
                   <Form.Control
                     as="textarea"
                     id={`entitytextarea-${index}`}
                     value={row.entityText}
+                    disabled={!row.taxonSelect || row.taxonSelect === ""}
+                    placeholder={!row.taxonSelect || row.taxonSelect === "" ? "Select species to add entities" : ""}
                     onChange={(e) => handleRowChange(index, 'entityText', e.target.value)}
                   />
                 )}


### PR DESCRIPTION
  - Allow curators to add topic entity tags without selecting a species (e.g., "catalytic activity" with no data for a specific organism)                                               
  - Add "(No species)" option to the species dropdown                                           
  - Disable entity input when no species is selected (entities require species for validation)  
  - Clear entity fields when species is changed to empty  
  - Fix sort interface: add missing `data_novelty` and `negated` fields when adding species tags