### PR TITLE
refactor: track API rename of primary/order author/editor/email/name …

### DIFF
--- a/src/components/Merge.js
+++ b/src/components/Merge.js
@@ -760,25 +760,25 @@ const MergeSubmitDataTransferUpdateButton = () => {
     if ('authors' in referenceMeta1['referenceJson'] && referenceMeta1['referenceJson']['authors'] !== null) {
       const orderedAuthors = [];
       for (const value of referenceMeta1['referenceJson']['authors'].values()) {
-        let index = value['order'] - 1;
-        if (index < 0) { index = 0 }      // temporary fix for fake authors have an 'order' field value of 0
+        let index = value['author_order'] - 1;
+        if (index < 0) { index = 0 }      // temporary fix for fake authors have an 'author_order' field value of 0
         orderedAuthors[index] = value; }
       for (const [index, authDict] of orderedAuthors.entries()) {
-        // console.log( authDict['first_name'] + ' ' + authDict['author_id'] + ' index ' + index + ' order ' + authDict['order']);
+        // console.log( authDict['first_name'] + ' ' + authDict['author_id'] + ' index ' + index + ' author_order ' + authDict['author_order']);
         let swap = false;
         if (authDict['toggle']) { swap = !swap; }
         if (pmidKeepReference === 2) { swap = !swap; }
         if (swap) {
-          // console.log('remove ' + authDict['author_id'] + ' ' + authDict['order']);
+          // console.log('remove ' + authDict['author_id'] + ' ' + authDict['author_order']);
           let subPath = 'author/' + authDict['author_id'];
           let array = [ subPath, null, 'DELETE', 0, null, null];
-          forApiArray.push( array ); } 
-        else { 
+          forApiArray.push( array ); }
+        else {
           authorOrder++;
           // console.log('no swap raise authorOrder to ' + authorOrder);
           if (authorOrder-1 !== index) {
             // console.log('reorder ' + authDict['author_id'] + ' to authorOrder ' + authorOrder);
-            const updateJsonAuth1 = { 'order': authorOrder }
+            const updateJsonAuth1 = { 'author_order': authorOrder }
             let subPath = 'author/' + authDict['author_id'];
             let array = [ subPath, updateJsonAuth1, 'PATCH', 0, null, null];
             forApiArray.push( array );
@@ -786,20 +786,20 @@ const MergeSubmitDataTransferUpdateButton = () => {
     if ('authors' in referenceMeta2['referenceJson'] && referenceMeta2['referenceJson']['authors'] !== null) {
       const orderedAuthors = [];
       for (const value of referenceMeta2['referenceJson']['authors'].values()) {
-        let index = value['order'] - 1;
-        if (index < 0) { index = 0 }      // temporary fix for fake authors have an 'order' field value of 0
+        let index = value['author_order'] - 1;
+        if (index < 0) { index = 0 }      // temporary fix for fake authors have an 'author_order' field value of 0
         orderedAuthors[index] = value; }
       for (const authDict of orderedAuthors.values()) {
       // for (const [index, authDict] of orderedAuthors.entries())
-        // console.log( authDict['first_name'] + ' ' + authDict['author_id'] + ' index ' + index + ' order ' + authDict['order']);
+        // console.log( authDict['first_name'] + ' ' + authDict['author_id'] + ' index ' + index + ' author_order ' + authDict['author_order']);
         let swap = false;
         if (authDict['toggle']) { swap = !swap; }
         if (pmidKeepReference === 2) { swap = !swap; }
         if (swap) {
           authorOrder++;
-          // console.log('transfer ' + authDict['author_id'] + ' ' + authDict['order'] + ' to ' + authorOrder);
+          // console.log('transfer ' + authDict['author_id'] + ' ' + authDict['author_order'] + ' to ' + authorOrder);
           const referenceCurie = referenceMeta1.curie;
-          const updateJsonAuth2 = { 'reference_curie': referenceCurie, 'order': authorOrder }
+          const updateJsonAuth2 = { 'reference_curie': referenceCurie, 'author_order': authorOrder }
           let subPath = 'author/' + authDict['author_id'];
           let array = [ subPath, updateJsonAuth2, 'PATCH', 0, null, null];
           forApiArray.push( array ); } 
@@ -1383,7 +1383,7 @@ const RowDisplayPairAuthors = ({fieldName, referenceMeta1, referenceMeta2, refer
     maxLength = referenceMeta1['referenceJson'][fieldName].length; }
   if (referenceMeta2['referenceJson'][fieldName] !== null && referenceMeta2['referenceJson'][fieldName].length > maxLength) {
     maxLength = referenceMeta2['referenceJson'][fieldName].length; }
-  const autFields = ['first_name', 'last_name', 'name', 'order', 'corresponding_author', 'first_author', 'toggle'];
+  const autFields = ['first_name', 'last_name', 'name', 'author_order', 'corresponding_author', 'first_author', 'toggle'];
   let maxOrder = 0;
   const isLocked = GenerateIsLocked(fieldName, hasPmid);
   const element0 = GenerateFieldLabel(fieldName, isLocked);
@@ -1408,15 +1408,15 @@ const RowDisplayPairAuthors = ({fieldName, referenceMeta1, referenceMeta2, refer
         aut1Data['name'] = aut1Data['first_name'] + ' ' + aut1Data['last_name'] }
       else if ( aut1Data['first_name'] !== '') { aut1Data['name'] = aut1Data['first_name'] }
       else if ( aut1Data['last_name'] !== '') { aut1Data['name'] = aut1Data['last_name'] }
-      string1 = aut1Data['order'] + ' - ' + aut1Data['name'];
-      if (aut1Data['order'] > maxOrder) { maxOrder = aut1Data['order']; }
+      string1 = aut1Data['author_order'] + ' - ' + aut1Data['name'];
+      if (aut1Data['author_order'] > maxOrder) { maxOrder = aut1Data['author_order']; }
       if ( aut1Data['orcid'] !== '') { string1 += ' - ' + aut1Data['orcid']; }
 //       if ( aut1Data['corresponding_author'] !== true) { string1 += " <Badge>corresponding</Badge>"; }
       element1 = (<div className={`div-merge ${keepClass1}`} onClick={() => dispatch(mergeToggleIndependent(fieldName, 1, i, null))} >{string1}
         { (aut1Data['first_author'] === true) && <> <Badge variant="secondary">first</Badge></> }
         { (aut1Data['corresponding_author'] === true) && <> <Badge variant="secondary">corresponding</Badge></> }
         </div>);
-      author1Elements[aut1Data['order'] - 1] = element1; }
+      author1Elements[aut1Data['author_order'] - 1] = element1; }
     if (referenceMeta2['referenceJson'][fieldName] !== null &&
         referenceMeta2['referenceJson'][fieldName][i] !== null && referenceMeta2['referenceJson'][fieldName][i] !== undefined) {
       let aut2 = referenceMeta2['referenceJson'][fieldName][i];
@@ -1430,14 +1430,14 @@ const RowDisplayPairAuthors = ({fieldName, referenceMeta1, referenceMeta2, refer
         aut2Data['name'] = aut2Data['first_name'] + ' ' + aut2Data['last_name'] }
       else if ( aut2Data['first_name'] !== '') { aut2Data['name'] = aut2Data['first_name'] }
       else if ( aut2Data['last_name'] !== '') { aut2Data['name'] = aut2Data['last_name'] }
-      string2 = aut2Data['order'] + ' - ' + aut2Data['name'];
-      if (aut2Data['order'] > maxOrder) { maxOrder = aut2Data['order']; }
+      string2 = aut2Data['author_order'] + ' - ' + aut2Data['name'];
+      if (aut2Data['author_order'] > maxOrder) { maxOrder = aut2Data['author_order']; }
       if ( aut2Data['orcid'] !== '') { string2 += ' - ' + aut2Data['orcid']; }
       element2 = (<div className={`div-merge ${keepClass2}`} onClick={() => dispatch(mergeToggleIndependent(fieldName, 2, i, null))} >{string2}
         { (aut2Data['first_author'] === true) && <> <Badge variant="secondary">first</Badge></> }
         { (aut2Data['corresponding_author'] === true) && <> <Badge variant="secondary">corresponding</Badge></> }
         </div>);
-      author2Elements[aut2Data['order'] - 1] = element2; }
+      author2Elements[aut2Data['author_order'] - 1] = element2; }
   }
   for (let i = 0; i < maxOrder; i++) {
     const element1 = (author1Elements[i] !== undefined) ? author1Elements[i] : '';

--- a/src/components/ReferencesToSort.js
+++ b/src/components/ReferencesToSort.js
@@ -174,8 +174,8 @@ const ReferencesToSort = ({
 
   const orderedAuthorsLive = [];
   for (const value of reference['authors'].values()) {
-    let idx = value['order'] - 1;
-    if (idx < 0) { idx = 0; }      // temporary fix for fake authors have an 'order' field value of 0
+    let idx = value['author_order'] - 1;
+    if (idx < 0) { idx = 0; }      // temporary fix for fake authors have an 'author_order' field value of 0
     orderedAuthorsLive[idx] = value;
   }
 

--- a/src/components/biblio/BiblioDisplay.js
+++ b/src/components/biblio/BiblioDisplay.js
@@ -365,14 +365,14 @@ const RowDisplayAuthors = ({ fieldIndex, fieldName, referenceJsonLive, reference
   const orderedAuthorsDb = [];
 
   for (const value of referenceJsonLive['authors'].values()) {
-    let idx = (value?.order ?? 1) - 1;
+    let idx = (value?.author_order ?? 1) - 1;
     if (idx < 0) idx = 0; // temporary fix for fake authors have an 'order' field value of 0
     orderedAuthorsLive[idx] = value;
   }
 
   if (referenceJsonDb?.authors) {
     for (const value of referenceJsonDb['authors'].values()) {
-      let idx = (value?.order ?? 1) - 1;
+      let idx = (value?.author_order ?? 1) - 1;
       if (idx < 0) idx = 0; // temporary fix for fake authors have an 'order' field value of 0
       orderedAuthorsDb[idx] = value;
     }
@@ -474,7 +474,7 @@ const RowDisplayAuthors = ({ fieldIndex, fieldName, referenceJsonLive, reference
 
       rowAuthorElements.push(
         <Row key={`author ${index}`} className="Row-general" xs={2} md={4} lg={6}>
-          <Col className="Col-general Col-display Col-display-left">author {value['order']}</Col>
+          <Col className="Col-general Col-display Col-display-left">author {value['author_order']}</Col>
           <Col className={`Col-general Col-display ${updatedFlagAuthor} `} lg={{ span: 10 }}>
             <div key={`author ${index}`}>
               <span dangerouslySetInnerHTML={{ __html: value['name'] }} />

--- a/src/components/biblio/BiblioEditor.js
+++ b/src/components/biblio/BiblioEditor.js
@@ -362,7 +362,7 @@ const BiblioSubmitUpdateButton = () => {
 
 
     if ('authors' in referenceJsonLive && referenceJsonLive['authors'] !== null) {
-      const authorFields = [ 'order', 'name', 'first_name', 'last_name', 'orcid', 'first_author', 'corresponding_author', 'affiliations' ];
+      const authorFields = [ 'author_order', 'name', 'first_name', 'last_name', 'orcid', 'first_author', 'corresponding_author', 'affiliations' ];
 
       // 1. Delete authors marked for deletion
       for (const [index, authorDict] of referenceJsonLive['authors'].entries()) {
@@ -379,7 +379,7 @@ const BiblioSubmitUpdateButton = () => {
         .filter(authorDict => !(authorDict.deleteMe === true))
         .map(authorDict => ({
           authorDict,
-          originalOrder: authorDict.order
+          originalOrder: authorDict.author_order
         }));
       // Sort by original order
       survivingAuthors.sort((a, b) => a.originalOrder - b.originalOrder);
@@ -388,7 +388,7 @@ const BiblioSubmitUpdateButton = () => {
       for (let i = 0; i < survivingAuthors.length; i++) {
         let { authorDict, originalOrder } = survivingAuthors[i];
         let newOrder = i + 1;
-        authorDict.order = newOrder;  // update local order
+        authorDict.author_order = newOrder;  // update local order
         survivingAuthors[i].orderChanged = (originalOrder !== newOrder);
       }
 
@@ -1121,19 +1121,19 @@ const RowEditorAuthors = ({fieldIndex, fieldName, referenceJsonLive, referenceJs
   const hasPmid = useSelector(state => state.biblio.hasPmid);
   const authorExpand = useSelector(state => state.biblio.authorExpand);
 //   const revertDictFields = 'order, name, first_name, last_name, orcid, first_author, corresponding_author, affiliations'
-  const updatableFields = ['order', 'name', 'first_name', 'last_name', 'orcid', 'first_author', 'corresponding_author', 'affiliations']
+  const updatableFields = ['author_order', 'name', 'first_name', 'last_name', 'orcid', 'first_author', 'corresponding_author', 'affiliations']
   let authorOrder = 1;
   if ('authors' in referenceJsonLive && referenceJsonLive['authors'] !== null) { authorOrder = referenceJsonLive['authors'].length + 1; }
-  const initializeDict = {'order': authorOrder, 'name': '', 'first_name': '', 'last_name': '', orcid: null, first_author: false, corresponding_author: false, affiliations: [], 'author_id': 'new'}
+  const initializeDict = {'author_order': authorOrder, 'name': '', 'first_name': '', 'last_name': '', orcid: null, first_author: false, corresponding_author: false, affiliations: [], 'author_id': 'new'}
   let disabled = ''
   if (hasPmid && (fieldsPubmed.includes(fieldName))) { disabled = 'disabled'; }
   if (fieldsDisplayOnly.includes(fieldName)) { disabled = 'disabled'; }
 
   function getStoreAuthorIndexFromDomIndex(indexDomAuthorInfo, newAuthorInfoChange) {
     if (!(indexDomAuthorInfo in newAuthorInfoChange)) { return 0; }
-    let indexAuthorInfo = newAuthorInfoChange[indexDomAuthorInfo]['order']        // replace placeholder with index from store order value matches dom
+    let indexAuthorInfo = newAuthorInfoChange[indexDomAuthorInfo]['author_order']        // replace placeholder with index from store order value matches dom
     for (let authorReorderIndexDictIndex in newAuthorInfoChange) {
-      if (newAuthorInfoChange[authorReorderIndexDictIndex]['order'] - 1 === indexDomAuthorInfo) {
+      if (newAuthorInfoChange[authorReorderIndexDictIndex]['author_order'] - 1 === indexDomAuthorInfo) {
         indexAuthorInfo = authorReorderIndexDictIndex
         break } }
     return indexAuthorInfo }
@@ -1144,8 +1144,8 @@ const RowEditorAuthors = ({fieldIndex, fieldName, referenceJsonLive, referenceJs
   if ('authors' in referenceJsonLive && referenceJsonLive['authors'] !== null) {
     let highestAuthorOrder = 0;		// previously was using referenceJsonLive['authors'].length, but there could be a gap in the order from db
     for (const value  of referenceJsonLive['authors'].values()) {
-      if (value['order'] > highestAuthorOrder) { highestAuthorOrder = value['order']; }
-      let index = value['order'] - 1;
+      if (value['author_order'] > highestAuthorOrder) { highestAuthorOrder = value['author_order']; }
+      let index = value['author_order'] - 1;
       if (index < 0) { index = 0 }	// temporary fix for fake authors have an 'order' field value of 0
       orderedAuthors[index] = value; }
 
@@ -1272,7 +1272,7 @@ const RowEditorAuthors = ({fieldIndex, fieldName, referenceJsonLive, referenceJs
           rowAuthorsElements.push(
             <Form.Group as={Row} key={`${fieldName} ${index}`}>
               <Col className="Col-general form-label col-form-label" sm="2" >{fieldName} </Col>
-              <Col className="Col-general form-label col-form-label updated" sm={2 + otherColSizeName} ><span style={{color: 'red'}}>Deleted</span>&nbsp; {authorDict['order']} - {authorDict['name']}</Col>
+              <Col className="Col-general form-label col-form-label updated" sm={2 + otherColSizeName} ><span style={{color: 'red'}}>Deleted</span>&nbsp; {authorDict['author_order']} - {authorDict['name']}</Col>
               {buttonsElement}
             </Form.Group>);
 }
@@ -1282,7 +1282,7 @@ const RowEditorAuthors = ({fieldIndex, fieldName, referenceJsonLive, referenceJs
               <Col className="Col-general form-label col-form-label" sm="2" >{fieldName} {index + 1}</Col>
               <ColEditorSimple key={`colElement ${fieldName} ${index} name`} fieldType="input" fieldName={fieldName} colSize={otherColSizeName} value={authorDict['name']} updatedFlag={updatedDict['name']} placeholder="name" disabled={disabledName} fieldKey={`${fieldName} ${index} name`} dispatchAction={changeFieldAuthorsReferenceJson} />
               <Col className="Col-general form-label col-form-label" sm="1" >order </Col>
-              <ColEditorSelectNumeric key={`colElement ${fieldName} ${index} order`} fieldType="select" fieldName={fieldName} colSize="1" value={authorDict['order']} updatedFlag={updatedDict['order']} placeholder="order" disabled={disabled} fieldKey={`${fieldName} ${index} order`} minNumber="1"
+              <ColEditorSelectNumeric key={`colElement ${fieldName} ${index} order`} fieldType="select" fieldName={fieldName} colSize="1" value={authorDict['author_order']} updatedFlag={updatedDict['author_order']} placeholder="order" disabled={disabled} fieldKey={`${fieldName} ${index} author_order`} minNumber="1"
  maxNumber={highestAuthorOrder} dispatchAction={changeFieldAuthorsReferenceJson} />
               {buttonsElement}
             </Form.Group>);

--- a/src/components/person/PersonCcDisplay.js
+++ b/src/components/person/PersonCcDisplay.js
@@ -31,8 +31,8 @@ const NamesCard = ({ names }) => {
           <ul style={{ listStyle: 'none', paddingLeft: 0, marginBottom: 0 }}>
             {list.map((n, i) => (
               <li key={n.person_name_id ?? i} style={{ padding: '2px 0' }}>
-                {n.primary && <span title="primary" style={{ color: '#e7a700' }}>★ </span>}
-                <span style={{ fontWeight: n.primary ? 600 : 400 }}>
+                {n.is_primary && <span title="primary" style={{ color: '#e7a700' }}>★ </span>}
+                <span style={{ fontWeight: n.is_primary ? 600 : 400 }}>
                   {fullName(n) || <span style={muted}>(blank)</span>}
                 </span>
               </li>
@@ -58,10 +58,10 @@ const EmailsCard = ({ emails }) => {
               const invalid = !!e.date_invalidated;
               return (
                 <li key={e.email_id ?? i} style={{ padding: '2px 0' }}>
-                  {e.primary && <span title="primary" style={{ color: '#e7a700' }}>★ </span>}
+                  {e.is_primary && <span title="primary" style={{ color: '#e7a700' }}>★ </span>}
                   <span
                     style={{
-                      fontWeight: e.primary ? 600 : 400,
+                      fontWeight: e.is_primary ? 600 : 400,
                       textDecoration: invalid ? 'line-through' : 'none',
                       color: invalid ? '#888' : 'inherit',
                     }}

--- a/src/components/person/PersonCompact.js
+++ b/src/components/person/PersonCompact.js
@@ -16,8 +16,8 @@ const PersonCompact = ({ person }) => {
   const notes = person.notes ?? [];
   const roles = person.mod_roles ?? [];
 
-  const primaryEmail = emails.find(e => e.primary)?.email_address || emails[0]?.email_address || null;
-  const primaryNameRow = names.find(n => n.primary) || names[0];
+  const primaryEmail = emails.find(e => e.is_primary)?.email_address || emails[0]?.email_address || null;
+  const primaryNameRow = names.find(n => n.is_primary) || names[0];
   const primaryName = primaryNameRow ? fullName(primaryNameRow) : null;
   const status = person.active_status || 'unknown';
   const statusVariant = status === 'active' ? 'success' : 'secondary';

--- a/src/components/person/PersonEditor.js
+++ b/src/components/person/PersonEditor.js
@@ -121,7 +121,7 @@ const PersonEditor = ({ person }) => {
             <Form.Control placeholder="First" defaultValue={n.first_name ?? ''} />
             <Form.Control placeholder="Middle" defaultValue={n.middle_name ?? ''} />
             <Form.Control placeholder="Last" defaultValue={n.last_name ?? ''} />
-            <Form.Check type="checkbox" label="primary" defaultChecked={!!n.primary} style={{ whiteSpace: 'nowrap' }} />
+            <Form.Check type="checkbox" label="primary" defaultChecked={!!n.is_primary} style={{ whiteSpace: 'nowrap' }} />
             {trashBtn}
           </div>
         )}
@@ -134,7 +134,7 @@ const PersonEditor = ({ person }) => {
         renderRow={(e) => (
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             <Form.Control type="email" defaultValue={e.email_address ?? ''} />
-            <Form.Check type="checkbox" label="primary" defaultChecked={!!e.primary} style={{ whiteSpace: 'nowrap' }} />
+            <Form.Check type="checkbox" label="primary" defaultChecked={!!e.is_primary} style={{ whiteSpace: 'nowrap' }} />
             {trashBtn}
           </div>
         )}

--- a/src/components/person/PersonWbDisplay.js
+++ b/src/components/person/PersonWbDisplay.js
@@ -120,7 +120,7 @@ const PersonWbDisplay = ({ person }) => {
           names.map((n, i) => (
             <FieldRow
               key={n.person_name_id ?? i}
-              label={n.primary ? 'name (primary)' : 'name'}
+              label={n.is_primary ? 'name (primary)' : 'name'}
               ts={tsLabel(n.updated_by, n.date_updated)}
             >
               {fullName(n) || <span style={muted}>(blank)</span>}
@@ -138,7 +138,7 @@ const PersonWbDisplay = ({ person }) => {
             {activeEmails.map((e, i) => (
               <FieldRow
                 key={e.email_id ?? i}
-                label={e.primary ? 'email (primary)' : 'email'}
+                label={e.is_primary ? 'email (primary)' : 'email'}
                 ts={tsLabel(e.updated_by, e.date_updated)}
               >
                 {e.email_address}

--- a/src/components/person/PersonWbEditor.js
+++ b/src/components/person/PersonWbEditor.js
@@ -144,7 +144,7 @@ const PersonWbEditor = ({ person }) => {
     first_name: '',
     middle_name: '',
     last_name: '',
-    primary: false,
+    is_primary: false,
     _ts: null,
     _by: null,
   });
@@ -153,7 +153,7 @@ const PersonWbEditor = ({ person }) => {
     first_name: n.first_name ?? '',
     middle_name: n.middle_name ?? '',
     last_name: n.last_name ?? '',
-    primary: !!n.primary,
+    is_primary: !!n.is_primary,
     _ts: n.date_updated ?? null,
     _by: n.updated_by ?? null,
   }));
@@ -166,7 +166,7 @@ const PersonWbEditor = ({ person }) => {
   // Emails
   const emptyEmail = () => ({
     email_address: '',
-    primary: false,
+    is_primary: false,
     invalidated: false,
     _origInvalidatedDate: null,
     _ts: null,
@@ -175,7 +175,7 @@ const PersonWbEditor = ({ person }) => {
   const emailIsEmpty = (e) => !e.email_address;
   const initialEmails = (p.emails ?? []).map((e) => ({
     email_address: e.email_address ?? '',
-    primary: !!e.primary,
+    is_primary: !!e.is_primary,
     invalidated: !!e.date_invalidated,
     _origInvalidatedDate: e.date_invalidated ?? null,
     _ts: e.date_updated ?? null,
@@ -222,18 +222,18 @@ const PersonWbEditor = ({ person }) => {
   const [notes, updateNote, removeNote] = useAutoGrowList(initialNotes, emptyNote, noteIsEmpty);
 
   const setNamePrimary = (idx) =>
-    setNames((prev) => prev.map((row, i) => ({ ...row, primary: i === idx })));
+    setNames((prev) => prev.map((row, i) => ({ ...row, is_primary: i === idx })));
   const setEmailPrimary = (idx) =>
-    setEmails((prev) => prev.map((row, i) => ({ ...row, primary: i === idx })));
+    setEmails((prev) => prev.map((row, i) => ({ ...row, is_primary: i === idx })));
 
   const labelForName = (n, i) => {
     if (i === names.length - 1 && nameIsEmpty(n)) return 'name (new)';
-    return n.primary ? 'name (primary)' : 'name';
+    return n.is_primary ? 'name (primary)' : 'name';
   };
   const labelForEmail = (e, i) => {
     if (i === emails.length - 1 && emailIsEmpty(e)) return 'email (new)';
     if (e.invalidated) return 'old_email';
-    return e.primary ? 'email (primary)' : 'email';
+    return e.is_primary ? 'email (primary)' : 'email';
   };
   const labelForUrl = (u, i) =>
     i === urls.length - 1 && urlIsEmpty(u) ? 'webpage (new)' : 'webpage';
@@ -305,7 +305,7 @@ const PersonWbEditor = ({ person }) => {
                   id={`wb-name-primary-${i}`}
                   name="wb-name-primary"
                   label="primary"
-                  checked={n.primary}
+                  checked={n.is_primary}
                   onChange={(e) => {
                     if (e.target.checked) setNamePrimary(i);
                   }}
@@ -348,7 +348,7 @@ const PersonWbEditor = ({ person }) => {
                     id={`wb-email-primary-${i}`}
                     name="wb-email-primary"
                     label="primary"
-                    checked={e.primary}
+                    checked={e.is_primary}
                     onChange={(ev) => {
                       if (ev.target.checked) setEmailPrimary(i);
                     }}

--- a/src/reducers/biblioReducer.js
+++ b/src/reducers/biblioReducer.js
@@ -117,10 +117,10 @@ export const checkHasPmid = (referenceJsonLive) => {
 const getStoreAuthorIndexFromDomIndex = (indexDomAuthorInfo, newAuthorInfoChange) => {
   // indexDomAuthorInfo is the index of the author info in the DOM
   // indexAuthorInfo is the index of the author info in the redux store, for updating non-order info
-  let indexAuthorInfo = newAuthorInfoChange[indexDomAuthorInfo]['order']	// replace placeholder with index from store order value matches dom
+  let indexAuthorInfo = newAuthorInfoChange[indexDomAuthorInfo]['author_order']	// replace placeholder with index from store order value matches dom
   for (let authorReorderIndexDictIndex in newAuthorInfoChange) {
 // console.log('loop index ' + authorReorderIndexDictIndex + ' for ' + indexDomAuthorInfo);
-    if (newAuthorInfoChange[authorReorderIndexDictIndex]['order'] - 1 === indexDomAuthorInfo) {
+    if (newAuthorInfoChange[authorReorderIndexDictIndex]['author_order'] - 1 === indexDomAuthorInfo) {
 // console.log('loop index match ' + authorReorderIndexDictIndex + ' to ' + indexDomAuthorInfo);
       indexAuthorInfo = authorReorderIndexDictIndex
       break } }
@@ -588,7 +588,7 @@ export default function(state = initialState, action) {
       else if (subfieldAuthorInfo === 'affiliations') {
 //         let subindexDomAuthorInfo = parseInt(authorInfoArray[3])
         newAuthorInfoChange[indexAuthorInfo][subfieldAuthorInfo][subindexDomAuthorInfo] = authorInfoNewValue; }
-      else if (subfieldAuthorInfo === 'order') {
+      else if (subfieldAuthorInfo === 'author_order') {
         let oldAuthorOrder = indexDomAuthorInfo + 1
         let newAuthorOrder = parseInt(authorInfoNewValue)
         // console.log('reorder ' + oldAuthorOrder + " into " + newAuthorOrder)
@@ -596,19 +596,19 @@ export default function(state = initialState, action) {
         for (let authorReorderDict of newAuthorInfoChange) {
           // console.log({ authorReorderDict, newAuthorInfoChange, oldAuthorOrder });
           if (newAuthorOrder < oldAuthorOrder) {
-            if (authorReorderDict['order'] === oldAuthorOrder) {
+            if (authorReorderDict['author_order'] === oldAuthorOrder) {
               authorReorderDict['needsChange'] = true;
-              authorReorderDict['order'] = newAuthorOrder }
-            else if ( (authorReorderDict['order'] >= newAuthorOrder) && (authorReorderDict['order'] < oldAuthorOrder) ) {
+              authorReorderDict['author_order'] = newAuthorOrder }
+            else if ( (authorReorderDict['author_order'] >= newAuthorOrder) && (authorReorderDict['author_order'] < oldAuthorOrder) ) {
               authorReorderDict['needsChange'] = true;
-              authorReorderDict['order'] += 1 } }
+              authorReorderDict['author_order'] += 1 } }
           else if (newAuthorOrder > oldAuthorOrder) {
-            if (authorReorderDict['order'] === oldAuthorOrder) {
+            if (authorReorderDict['author_order'] === oldAuthorOrder) {
               authorReorderDict['needsChange'] = true;
-              authorReorderDict['order'] = newAuthorOrder }
-            else if ( (authorReorderDict['order'] <= newAuthorOrder) && (authorReorderDict['order'] > oldAuthorOrder) ) {
+              authorReorderDict['author_order'] = newAuthorOrder }
+            else if ( (authorReorderDict['author_order'] <= newAuthorOrder) && (authorReorderDict['author_order'] > oldAuthorOrder) ) {
               authorReorderDict['needsChange'] = true;
-              authorReorderDict['order'] -= 1 } } } }
+              authorReorderDict['author_order'] -= 1 } } } }
       else {
         newAuthorInfoChange[indexAuthorInfo][subfieldAuthorInfo] = authorInfoNewValue; }
       // console.log(newAuthorInfoChange)
@@ -795,8 +795,8 @@ export default function(state = initialState, action) {
         if (revertAuthorId === 'new') {
 //           console.log('reset to initialize dict indexDomAuthorRevert ' + indexDomAuthorRevert)
           const revertNewAuthorDict = JSON.parse(JSON.stringify(action.payload.initializeDict))
-          revertNewAuthorDict['order'] = state.referenceJsonLive[fieldStringArrayRevert][indexStoreAuthorRevert]['order']
-//           console.log('reset to initialize dict set order to ' + state.referenceJsonLive[fieldStringArrayRevert][indexStoreAuthorRevert]['order'])
+          revertNewAuthorDict['author_order'] = state.referenceJsonLive[fieldStringArrayRevert][indexStoreAuthorRevert]['author_order']
+//           console.log('reset to initialize dict set order to ' + state.referenceJsonLive[fieldStringArrayRevert][indexStoreAuthorRevert]['author_order'])
 // console.log(revertNewAuthorDict)
           revertValue[indexStoreAuthorRevert] = revertNewAuthorDict }
         else {
@@ -806,8 +806,8 @@ export default function(state = initialState, action) {
             if (dbRevertAuthorDict['author_id'] === revertAuthorId) {
 // console.log('loop match ' + dbRevertAuthorDict['author_id'] + ' to ' + revertAuthorId);
               const revertNewAuthorDict = JSON.parse(JSON.stringify(dbRevertAuthorDict))
-              revertNewAuthorDict['order'] = state.referenceJsonLive[fieldStringArrayRevert][indexStoreAuthorRevert]['order']
-//               console.log('reset to initialize dict set order to ' + state.referenceJsonLive[fieldStringArrayRevert][indexStoreAuthorRevert]['order'])
+              revertNewAuthorDict['author_order'] = state.referenceJsonLive[fieldStringArrayRevert][indexStoreAuthorRevert]['author_order']
+//               console.log('reset to initialize dict set order to ' + state.referenceJsonLive[fieldStringArrayRevert][indexStoreAuthorRevert]['author_order'])
 // console.log(revertNewAuthorDict)
               revertValue[indexStoreAuthorRevert] = revertNewAuthorDict
               break } } } }


### PR DESCRIPTION
…fields

The API at github.com/alliance-genome/agr_literature_service renamed four PG-reserved-word columns end-to-end on branch SCRUM-5994:

- email.primary       -> is_primary
- person_name.primary -> is_primary
- author.order        -> author_order
- editor.order        -> editor_order

The API uses Pydantic extra="forbid", so any UI request still sending the old keys gets a 422; reads of old keys silently return undefined. Rename the JSON property names everywhere they cross the API boundary and in the local Redux/component state that mirrors the API JSON shape.

Person primary handling (display + WB editor mockup):
- PersonCompact, PersonEditor, PersonCcDisplay, PersonWbDisplay, PersonWbEditor.

Author order handling (display, biblio editor, merge, sort, reducer):
- BiblioDisplay, BiblioEditor (authorFields list, reorder logic, initializeDict, ColEditorSelectNumeric fieldKey/value/updatedFlag), Merge (PATCH payloads + display dict), ReferencesToSort, biblioReducer (subfieldAuthorInfo === 'author_order' branch and all dict['author_order'] accesses).

editor_order has no UI consumer in this repo (Resources view reads only name/first_name/last_name on editors), so no changes there.

Cosmetic UI strings deliberately kept as 'order'/'primary': Bootstrap variant, JSX label/header text, placeholder, name= radio-group identity, code comments.