### PR TITLE
add retraction status facet under bibliographic data

### DIFF
--- a/src/components/Reports.js
+++ b/src/components/Reports.js
@@ -699,7 +699,7 @@ const QCReportObsoleteEntities = ({modSection}) => {
                 </div>
               ) : (
                 <div className="ag-theme-quartz" onCopy={handleGridCopy} style={{ width: '100%' }}>
-                 {( qcReportObsoleteEntities["'date-produced'"] !== null) &&
+                 {( qcReportObsoleteEntities['date-produced'] !== null) &&
                   (<div style={{ textAlign: 'left' }}>Date Produced: {convertDate(qcReportObsoleteEntities['date-produced'])}<br /><br /></div>) }
                  {( ( qcReportObsoleteEntities["obsolete_entities"] !== null) && ( modSection in qcReportObsoleteEntities["obsolete_entities"] ) ) ? (
                   <AgGridReact
@@ -802,7 +802,7 @@ const QCReportRetractedPapers = ({modSection}) => {
                             </div>
                         ) : (
                             <div className="ag-theme-quartz" onCopy={handleGridCopy} style={{ width: '100%' }}>
-                                {( qcReportRedactedPapers["'date-produced'"] !== null) &&
+                                {( qcReportRedactedPapers['date-produced'] !== null) &&
                                     (<div style={{ textAlign: 'left' }}>Date Produced: {convertDate(qcReportRedactedPapers['date-produced'])}<br /><br /></div>) }
                                 {( ( qcReportRedactedPapers["redacted-references"] !== null) && ( modSection in qcReportRedactedPapers["redacted-references"] ) ) ? (
                                     <AgGridReact
@@ -984,7 +984,7 @@ const QCReportDuplicateOrcids = ({ modSection }) => {
                 </div>
               ) : (
                 <div className="ag-theme-quartz" onCopy={handleGridCopy} style={{ width: '100%' }}>
-                 {( qcReportDuplicateOrcids["'date-produced'"] !== null) &&
+                 {( qcReportDuplicateOrcids['date-produced'] !== null) &&
                   (<div style={{ textAlign: 'left' }}>Date Produced: {convertDate(qcReportDuplicateOrcids['date-produced'])}<br /><br /></div>) }
                  {( ( qcReportDuplicateOrcids["duplicate_orcids"] !== null) && ( modSection in qcReportDuplicateOrcids["duplicate_orcids"] ) ) ? (
                   <AgGridReact

--- a/src/components/search/BreadCrumbs.js
+++ b/src/components/search/BreadCrumbs.js
@@ -40,27 +40,30 @@ const BreadCrumbs = () => {
     const isExceptionFacet = (facet) => {
 	// Match either:
 	// 1. language.keyword (Bibliographic Data's language)
-	// 2. Any Alliance Metadata facets
-       return facet === 'language.keyword' || facet.startsWith('mods_');
+	// 2. retraction_status.keyword (Bibliographic Data's retraction status)
+	// 3. Any Alliance Metadata facets
+       return facet === 'language.keyword' || facet === 'retraction_status.keyword' || facet.startsWith('mods_');
     };
     
     const getFacetLabel = (facet, value) => {
         const displayValue = getDisplayName(facet, value);
-        const categoryName = RENAME_FACETS[facet]?.label || 
+        const renameFacet = RENAME_FACETS[facet];
+        const categoryName = (typeof renameFacet === 'string' ? renameFacet : renameFacet?.label) ||
                             facet.replace('.keyword', '')
                                  .replaceAll('_', ' ');
-        
+
         return isExceptionFacet(facet) ? `${categoryName}: ${displayValue}` : displayValue;
     };
 
     const getExcludedFacetLabel = (facet, value) => {
         const displayValue = getDisplayName(facet, value);
-        const categoryName = RENAME_FACETS[facet]?.label || 
+        const renameFacet = RENAME_FACETS[facet];
+        const categoryName = (typeof renameFacet === 'string' ? renameFacet : renameFacet?.label) ||
                             facet.replace('.keyword', '')
                                  .replaceAll('_', ' ');
-        
-        return isExceptionFacet(facet) ? 
-            `Exclude ${categoryName}: ${displayValue}` : 
+
+        return isExceptionFacet(facet) ?
+            `Exclude ${categoryName}: ${displayValue}` :
             `Exclude ${displayValue}`;
     };
 

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -103,7 +103,7 @@ export const RENAME_FACETS = {
 export const FACETS_CATEGORIES_WITH_FACETS = {
     "Alliance Metadata": ["mods in corpus", "mods needs review", "mods in corpus or needs review"],
     "Workflow Tags": ["file_workflow", "reference_classification", "entity_extraction", "manual_indexing", "curation_classification", "community_curation"], 
-    "Bibliographic Data": ["mod reference types", "pubmed types", "category", "pubmed publication status", "retraction_status", "authors.name", "language"],
+    "Bibliographic Data": ["mod reference types", "pubmed types", "category", "pubmed publication status", "retraction status", "authors.name", "language"],
     "Topics and Entities": ["topics", "confidence_levels", "confidence_scores", "source_methods", "source_evidence_assertions", "data_novelty"],
     "Date Range": ["Date Modified in Pubmed", "Date Added To Pubmed", "Date Published", "Date Added to ABC"]
 }
@@ -217,7 +217,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
     const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
     const searchExcludedFacetsValues = useSelector(state => state.search.searchExcludedFacetsValues);
     const dispatch = useDispatch();
-    const negatedFacetCategories = ["pubmed publication status", "mod reference types", "category", "pubmed types", "confidence_levels", "retraction_status"];
+    const negatedFacetCategories = ["pubmed publication status", "mod reference types", "category", "pubmed types", "confidence_levels", "retraction status"];
     const [openSubFacets, setOpenSubFacets] = useState(new Set());
 
     const [sourceMethodDescriptions, setSourceMethodDescriptions] = useState({});

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -64,6 +64,7 @@ export const RENAME_FACETS = {
     "mods_in_corpus_or_needs_review.keyword": "corpus - in corpus or needs review",
     "authors.name.keyword": "Authors",
     "mod_reference_types.keyword": "MOD reference type",
+    "retraction_status.keyword": "Retraction Status",
     "topics": "Topic",
     "confidence_levels": "Confidence level",
     "source_methods": "Source method",
@@ -102,7 +103,7 @@ export const RENAME_FACETS = {
 export const FACETS_CATEGORIES_WITH_FACETS = {
     "Alliance Metadata": ["mods in corpus", "mods needs review", "mods in corpus or needs review"],
     "Workflow Tags": ["file_workflow", "reference_classification", "entity_extraction", "manual_indexing", "curation_classification", "community_curation"], 
-    "Bibliographic Data": ["mod reference types", "pubmed types", "category", "pubmed publication status", "authors.name","language"],
+    "Bibliographic Data": ["mod reference types", "pubmed types", "category", "pubmed publication status", "retraction_status", "authors.name", "language"],
     "Topics and Entities": ["topics", "confidence_levels", "confidence_scores", "source_methods", "source_evidence_assertions", "data_novelty"],
     "Date Range": ["Date Modified in Pubmed", "Date Added To Pubmed", "Date Published", "Date Added to ABC"]
 }
@@ -216,7 +217,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
     const searchFacetsValues = useSelector(state => state.search.searchFacetsValues);
     const searchExcludedFacetsValues = useSelector(state => state.search.searchExcludedFacetsValues);
     const dispatch = useDispatch();
-    const negatedFacetCategories = ["pubmed publication status", "mod reference types", "category", "pubmed types", "confidence_levels"];
+    const negatedFacetCategories = ["pubmed publication status", "mod reference types", "category", "pubmed types", "confidence_levels", "retraction_status"];
     const [openSubFacets, setOpenSubFacets] = useState(new Set());
 
     const [sourceMethodDescriptions, setSourceMethodDescriptions] = useState({});
@@ -461,10 +462,10 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                                                                     : sourceEvidenceAssertionDescriptions[bucket.key]) || 'No description available.'}
                                                             </Tooltip>
                                                         }
-                                                    >                                                                                                                 
-                                                        <span dangerouslySetInnerHTML={{ __html: bucket.name || bucket.key }} />                                      
-                                                    </OverlayTrigger>                                                                                                 
-                                                ) : (                                                                                                                 
+                                                    >
+                                                        <span dangerouslySetInnerHTML={{ __html: bucket.name || bucket.key }} />
+                                                    </OverlayTrigger>
+                                                ) : (
                                                     <span dangerouslySetInnerHTML={{ __html: bucket.name || bucket.key }} />
                                                 )}                                                                                                                                                {isModRefTypeFacet && renderModIcons(bucket.key)}
                                             </Col>                                                                                                                    

--- a/src/components/search/settings/SearchPreferencesControls.js
+++ b/src/components/search/settings/SearchPreferencesControls.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import PersonSettingsControls from '../../settings/PersonSettingsControls';
 import {
   buildSearchSettingsState,
   applySearchSettingsFromJson,
 } from './SearchPreferencesUtils';
+import { api } from '../../../api';
 
 /**
  * SearchPreferencesControls:
@@ -13,6 +14,30 @@ import {
  * search - specific state builder + apply function.
  */
 const SearchPreferencesControls = () => {
+  const [retractionStatusCuries, setRetractionStatusCuries] = useState([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Fetch retraction status CURIEs on mount to use in default exclusions
+  useEffect(() => {
+    const fetchRetractionStatuses = async () => {
+      try {
+        const result = await api.get('/ontology/search_descendants/ATP:0000346/true/true/true');
+        const curies = (result.data || []).map(entity => entity.curie);
+        setRetractionStatusCuries(curies);
+      } catch (error) {
+        console.error('Error fetching retraction status CURIEs:', error);
+      } finally {
+        setIsLoaded(true);
+      }
+    };
+    fetchRetractionStatuses();
+  }, []);
+
+  // Wait for retraction status CURIEs to be fetched before rendering
+  if (!isLoaded) {
+    return null;
+  }
+
   return (
     <PersonSettingsControls
       componentName="reference_search"
@@ -22,7 +47,7 @@ const SearchPreferencesControls = () => {
       gearButtonTitle="Manage saved searches and defaults"
       dropdownPlaceholder="Load setting..."
       rowSaveLabel="Save Current Search"
-      // Build name like "SGD Default Search" or "Default Search"	
+      // Build name like "SGD Default Search" or "Default Search"
       defaultSettingNameBuilder={({ accessLevel }) =>
         accessLevel ? `${accessLevel} Default Search` : 'Default Search'
       }
@@ -30,13 +55,14 @@ const SearchPreferencesControls = () => {
       buildSettingsState={(reduxState) =>
         buildSearchSettingsState(reduxState)
       }
-      
+
       applySettingsFromJson={(json_settings, dispatch, options) =>
         applySearchSettingsFromJson(json_settings, dispatch, options)
       }
       // Inject defaults when seeding the very first setting
       seedStateTransform={(statePayload, { accessLevel }) => {
         const facetsValues = { ...(statePayload.facetsValues || {}) };
+        const excludedFacetsValues = { ...(statePayload.excludedFacetsValues || {}) };
 
         if (
           accessLevel &&
@@ -54,7 +80,16 @@ const SearchPreferencesControls = () => {
           facetsValues['language.keyword'] = ['English'];
         }
 
-        return { ...statePayload, facetsValues };
+        // Exclude all retraction statuses by default (retracted, partially retracted, fully retracted)
+        if (
+          retractionStatusCuries.length > 0 &&
+          (!Array.isArray(excludedFacetsValues['retraction_status.keyword']) ||
+            excludedFacetsValues['retraction_status.keyword'].length === 0)
+        ) {
+          excludedFacetsValues['retraction_status.keyword'] = retractionStatusCuries;
+        }
+
+        return { ...statePayload, facetsValues, excludedFacetsValues };
       }}
     />
   );

--- a/src/reducers/searchReducer.js
+++ b/src/reducers/searchReducer.js
@@ -42,6 +42,7 @@ const initialState = {
     'mod_reference_types.keyword': INITIAL_FACETS_LIMIT,
     'category.keyword': INITIAL_FACETS_LIMIT,
     'pubmed_publication_status.keyword': INITIAL_FACETS_LIMIT,
+    'retraction_status.keyword': INITIAL_FACETS_LIMIT,
     'authors.name.keyword': INITIAL_FACETS_LIMIT,
     'topics': INITIAL_FACETS_LIMIT,
     'confidence_levels': INITIAL_FACETS_LIMIT,


### PR DESCRIPTION
- Add retraction_status facet above authors in Bibliographic Data category
- Support include/exclude checkboxes for filtering retracted papers
- Exclude all retraction statuses by default for new users
- Display human-readable names from retraction_status_name field
- Update breadcrumbs to show "Retraction Status: value" format