### PR TITLE
only show Alliance-Granted Permission label when images can be displayed

### DIFF
--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -430,8 +430,9 @@ const OpenAccess = () => {
 
   const permissionText = formatPermissionText(permissionTextRaw);
 
-  // Check if this is an Alliance-granted permission (has permission name from resource_image_permission)
-  const hasAlliancePermission = imagePermissionName && (
+  // Check if this is an Alliance-granted permission that allows image display
+  // Only show green label when can_display_images is true (not for subset permissions)
+  const hasAlliancePermission = imagePermission["can_display_images"] && imagePermissionName && (
     imagePermissionName.toLowerCase().includes('permission granted') ||
     imagePermissionName.toLowerCase().includes('blanket permission') ||
     imagePermissionName.toLowerCase().includes('contract') ||


### PR DESCRIPTION


Don't show the green "Alliance-Granted Permission" label for subset permissions where can_display_images is false. This avoids the confusing UX of showing a positive permission label when images cannot be displayed.