### PR TITLE
refactor(SCRUM-6084): align person email UI with new API contract

### DIFF
--- a/src/components/biblio/BiblioDisplay.js
+++ b/src/components/biblio/BiblioDisplay.js
@@ -513,8 +513,7 @@ export const RowDisplayExtractedEmails = ({ referenceJsonLive, displayOrEditor }
   const seen = new Set();
   for (const e of emailsRaw) {
     const addr = (e?.email_address || '').trim();
-    const invalidated = e?.date_invalidated !== null && typeof e?.date_invalidated !== 'undefined';
-    if (!addr || invalidated) continue;
+    if (!addr) continue;
     const key = addr.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);

--- a/src/components/person/PersonCcDisplay.js
+++ b/src/components/person/PersonCcDisplay.js
@@ -55,13 +55,11 @@ const EmailsCard = ({ emails }) => {
         ) : (
           <ul style={{ listStyle: 'none', paddingLeft: 0, marginBottom: 0 }}>
             {list.map((e, i) => {
-              const invalid = !!e.date_invalidated;
+              const invalid = !!e.date_made_old_email;
               return (
-                <li key={e.email_id ?? i} style={{ padding: '2px 0' }}>
-                  {e.is_primary && <span title="primary" style={{ color: '#e7a700' }}>★ </span>}
+                <li key={e.email_address ?? i} style={{ padding: '2px 0' }}>
                   <span
                     style={{
-                      fontWeight: e.is_primary ? 600 : 400,
                       textDecoration: invalid ? 'line-through' : 'none',
                       color: invalid ? '#888' : 'inherit',
                     }}
@@ -70,7 +68,7 @@ const EmailsCard = ({ emails }) => {
                   </span>
                   {invalid && (
                     <span style={{ ...muted, fontSize: '0.85em', marginLeft: 6 }}>
-                      (invalidated {formatDate(e.date_invalidated)})
+                      (old since {formatDate(e.date_made_old_email)})
                     </span>
                   )}
                 </li>
@@ -240,8 +238,11 @@ const PersonCcDisplay = ({ person }) => {
                 </div>
               )}
             </Col>
-            <Col xs="auto">
+            <Col xs="auto" style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
               <Badge variant={statusVariant} style={{ fontSize: '0.95em' }}>{status}</Badge>
+              {person.unsubscribe && (
+                <Badge variant="warning" style={{ fontSize: '0.95em' }}>unsubscribed</Badge>
+              )}
             </Col>
           </Row>
         </Card.Body>

--- a/src/components/person/PersonCompact.js
+++ b/src/components/person/PersonCompact.js
@@ -6,6 +6,20 @@ const muted = { color: '#888' };
 
 const fullName = (n) => [n.first_name, n.middle_name, n.last_name].filter(Boolean).join(' ');
 
+// Pick the most-recently-touched active email. Mirrors the server-side
+// get_most_current_email(person_id) function so display matches backend
+// behavior for users with multiple emails.
+const pickEmail = (emails) => {
+  const active = (emails ?? []).filter((e) => !e.date_made_old_email);
+  if (!active.length) return null;
+  const sorted = active.slice().sort((a, b) => {
+    const ta = a.date_updated ?? a.date_created ?? '';
+    const tb = b.date_updated ?? b.date_created ?? '';
+    return String(tb).localeCompare(String(ta));
+  });
+  return sorted[0]?.email_address ?? null;
+};
+
 const PersonCompact = ({ person }) => {
   if (!person) return null;
 
@@ -16,7 +30,10 @@ const PersonCompact = ({ person }) => {
   const notes = person.notes ?? [];
   const roles = person.mod_roles ?? [];
 
-  const primaryEmail = emails.find(e => e.is_primary)?.email_address || emails[0]?.email_address || null;
+  const currentEmail = pickEmail(emails);
+  const emailDisplay = currentEmail
+    ? (person.unsubscribe ? `${currentEmail} (unsubscribed)` : currentEmail)
+    : 'no email';
   const primaryNameRow = names.find(n => n.is_primary) || names[0];
   const primaryName = primaryNameRow ? fullName(primaryNameRow) : null;
   const status = person.active_status || 'unknown';
@@ -25,7 +42,7 @@ const PersonCompact = ({ person }) => {
   const parts = [
     person.display_name || '(no name)',
     person.curie || null,
-    primaryEmail || 'no email',
+    emailDisplay,
     primaryName || 'no name record',
     roles.length > 0 ? roles.join(', ') : 'no roles',
   ].filter(Boolean);

--- a/src/components/person/PersonEditor.js
+++ b/src/components/person/PersonEditor.js
@@ -66,6 +66,16 @@ const PersonEditor = ({ person }) => {
             </Col>
           </Row>
           <Row className="mb-2">
+            <Col md={6}>
+              <Form.Check
+                type="checkbox"
+                id="person-editor-unsubscribe"
+                label="Unsubscribed from email"
+                defaultChecked={!!p.unsubscribe}
+              />
+            </Col>
+          </Row>
+          <Row className="mb-2">
             <Col>
               <Form.Label>Biography / Research interest</Form.Label>
               <Form.Control as="textarea" rows={4} defaultValue={p.biography_research_interest ?? ''} />
@@ -134,7 +144,12 @@ const PersonEditor = ({ person }) => {
         renderRow={(e) => (
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             <Form.Control type="email" defaultValue={e.email_address ?? ''} />
-            <Form.Check type="checkbox" label="primary" defaultChecked={!!e.is_primary} style={{ whiteSpace: 'nowrap' }} />
+            <Form.Check
+              type="checkbox"
+              label="mark as old"
+              defaultChecked={!!e.date_made_old_email}
+              style={{ whiteSpace: 'nowrap' }}
+            />
             {trashBtn}
           </div>
         )}

--- a/src/components/person/PersonWbDisplay.js
+++ b/src/components/person/PersonWbDisplay.js
@@ -82,8 +82,8 @@ const PersonWbDisplay = ({ person }) => {
   const statusVariant = status === 'active' ? 'success' : 'secondary';
 
   const emails = person.emails ?? [];
-  const activeEmails = emails.filter((e) => !e.date_invalidated);
-  const oldEmails = emails.filter((e) => !!e.date_invalidated);
+  const activeEmails = emails.filter((e) => !e.date_made_old_email);
+  const oldEmails = emails.filter((e) => !!e.date_made_old_email);
   const names = person.names ?? [];
   const xrefs = person.cross_references ?? [];
   const webpages = person.webpage ?? [];
@@ -107,7 +107,12 @@ const PersonWbDisplay = ({ person }) => {
               </h4>
               <div style={{ ...muted, fontSize: '0.9em' }}>{person.curie}</div>
             </div>
-            <Badge variant={statusVariant} style={{ fontSize: '0.95em' }}>{status}</Badge>
+            <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+              <Badge variant={statusVariant} style={{ fontSize: '0.95em' }}>{status}</Badge>
+              {person.unsubscribe && (
+                <Badge variant="warning" style={{ fontSize: '0.95em' }}>unsubscribed</Badge>
+              )}
+            </div>
           </div>
         </Card.Body>
       </Card>
@@ -137,20 +142,20 @@ const PersonWbDisplay = ({ person }) => {
           <>
             {activeEmails.map((e, i) => (
               <FieldRow
-                key={e.email_id ?? i}
-                label={e.is_primary ? 'email (primary)' : 'email'}
+                key={e.email_address ?? i}
+                label="email"
                 ts={tsLabel(e.updated_by, e.date_updated)}
               >
                 {e.email_address}
               </FieldRow>
             ))}
             {oldEmails.map((e, i) => {
-              const invalidatedNote = `invalidated ${formatTimestamp(e.date_invalidated)}`;
+              const oldNote = `old since ${formatTimestamp(e.date_made_old_email)}`;
               const editTs = tsLabel(e.updated_by, e.date_updated);
-              const ts = editTs ? `${invalidatedNote} · ${editTs}` : invalidatedNote;
+              const ts = editTs ? `${oldNote} · ${editTs}` : oldNote;
               return (
                 <FieldRow
-                  key={`old-${e.email_id ?? i}`}
+                  key={`old-${e.email_address ?? i}`}
                   label="old_email"
                   ts={ts}
                 >

--- a/src/components/person/PersonWbEditor.js
+++ b/src/components/person/PersonWbEditor.js
@@ -166,26 +166,26 @@ const PersonWbEditor = ({ person }) => {
   // Emails
   const emptyEmail = () => ({
     email_address: '',
-    is_primary: false,
     invalidated: false,
-    _origInvalidatedDate: null,
+    _origOldDate: null,
     _ts: null,
     _by: null,
   });
   const emailIsEmpty = (e) => !e.email_address;
   const initialEmails = (p.emails ?? []).map((e) => ({
     email_address: e.email_address ?? '',
-    is_primary: !!e.is_primary,
-    invalidated: !!e.date_invalidated,
-    _origInvalidatedDate: e.date_invalidated ?? null,
+    invalidated: !!e.date_made_old_email,
+    _origOldDate: e.date_made_old_email ?? null,
     _ts: e.date_updated ?? null,
     _by: e.updated_by ?? null,
   }));
-  const [emails, updateEmail, removeEmail, setEmails] = useAutoGrowList(
+  const [emails, updateEmail, removeEmail] = useAutoGrowList(
     initialEmails,
     emptyEmail,
     emailIsEmpty,
   );
+
+  const [unsubscribe, setUnsubscribe] = React.useState(!!p.unsubscribe);
 
   // Webpages — strings, no per-row timestamp, no who/when shown
   const emptyUrl = () => ({ url: '' });
@@ -223,8 +223,6 @@ const PersonWbEditor = ({ person }) => {
 
   const setNamePrimary = (idx) =>
     setNames((prev) => prev.map((row, i) => ({ ...row, is_primary: i === idx })));
-  const setEmailPrimary = (idx) =>
-    setEmails((prev) => prev.map((row, i) => ({ ...row, is_primary: i === idx })));
 
   const labelForName = (n, i) => {
     if (i === names.length - 1 && nameIsEmpty(n)) return 'name (new)';
@@ -233,7 +231,7 @@ const PersonWbEditor = ({ person }) => {
   const labelForEmail = (e, i) => {
     if (i === emails.length - 1 && emailIsEmpty(e)) return 'email (new)';
     if (e.invalidated) return 'old_email';
-    return e.is_primary ? 'email (primary)' : 'email';
+    return 'email';
   };
   const labelForUrl = (u, i) =>
     i === urls.length - 1 && urlIsEmpty(u) ? 'webpage (new)' : 'webpage';
@@ -264,6 +262,19 @@ const PersonWbEditor = ({ person }) => {
                 <option key={s} value={s}>{s}</option>
               ))}
             </Form.Control>
+          </FieldLine>
+          <FieldLine label="unsubscribe" ts={recordTs}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-start', gap: 6 }}>
+              <input
+                type="checkbox"
+                id="wb-person-unsubscribe"
+                checked={unsubscribe}
+                onChange={(ev) => setUnsubscribe(ev.target.checked)}
+              />
+              <label htmlFor="wb-person-unsubscribe" style={{ marginBottom: 0 }}>
+                unsubscribed from email
+              </label>
+            </div>
           </FieldLine>
         </Card.Body>
       </Card>
@@ -324,10 +335,10 @@ const PersonWbEditor = ({ person }) => {
           {emails.map((e, i) => {
             const isNew = i === emails.length - 1 && emailIsEmpty(e);
             const editTs = tsLabel(e._by, e._ts);
-            const invalidatedNote = e._origInvalidatedDate
-              ? `invalidated ${formatTimestamp(e._origInvalidatedDate)}`
+            const oldNote = e._origOldDate
+              ? `old since ${formatTimestamp(e._origOldDate)}`
               : null;
-            const computed = [invalidatedNote, editTs].filter(Boolean).join(' · ') || null;
+            const computed = [oldNote, editTs].filter(Boolean).join(' · ') || null;
             const ts = isNew ? 'new' : computed;
             return (
               <FieldLine
@@ -344,20 +355,9 @@ const PersonWbEditor = ({ person }) => {
                     style={{ flex: '1 1 240px', minWidth: 200 }}
                   />
                   <Form.Check
-                    type="radio"
-                    id={`wb-email-primary-${i}`}
-                    name="wb-email-primary"
-                    label="primary"
-                    checked={e.is_primary}
-                    onChange={(ev) => {
-                      if (ev.target.checked) setEmailPrimary(i);
-                    }}
-                    style={{ whiteSpace: 'nowrap' }}
-                  />
-                  <Form.Check
                     type="checkbox"
-                    id={`wb-email-invalidated-${i}`}
-                    label="invalidated (old_email)"
+                    id={`wb-email-old-${i}`}
+                    label="mark as old"
                     checked={e.invalidated}
                     onChange={(ev) => updateEmail(i, { invalidated: ev.target.checked })}
                     style={{ whiteSpace: 'nowrap' }}


### PR DESCRIPTION
Backend dropped `is_primary` and renamed `date_invalidated` -> `date_made_old_email` on person_email payloads, and shrank the reference_email response to {reference_email_id, email_address}. UI components that read the old fields silently misbehaved.

- Replace `date_invalidated` reads with `date_made_old_email` across PersonWbDisplay, PersonCcDisplay, PersonWbEditor.
- Drop the "primary email" UX everywhere: remove the star badge and bold styling in PersonCcDisplay, the "(primary)" label suffix in PersonWbDisplay, the primary radio + setEmailPrimary helper in PersonWbEditor, and the "primary" checkbox in PersonEditor.
- PersonCompact now picks the displayed email via a `pickEmail` helper that filters active emails and sorts by date_updated DESC, mirroring the backend `get_most_current_email()` function.
- Use `email_address` (always present) in React `key` props instead of the now-absent `email_id`.
- Surface the new `person.unsubscribe` boolean: a warning badge next to the active_status badge in PersonWbDisplay and PersonCcDisplay, a "(unsubscribed)" suffix on PersonCompact's surfaced email, and a checkbox in both PersonWbEditor and PersonEditor (mockup-only editors -- not yet wired to the API). The editor checkbox uses a raw input + label with an explicit flex container so the global .App { text-align: center } rule doesn't visually center it.
- BiblioDisplay's extracted-emails filter drops the dead date_made_old_email predicate (that field isn't present on reference_email payloads); empty-address + case-insensitive dedup remain.