### PR TITLE
fix(SCRUM-6135): poll version.json periodically so banner appears in Firefox

### DIFF
--- a/src/hooks/useVersionCheck.js
+++ b/src/hooks/useVersionCheck.js
@@ -2,10 +2,12 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 
 /**
  * Hook that checks for new application versions by polling /version.json.
- * Checks on initial mount and whenever the tab becomes visible.
- * Returns { updateAvailable: boolean } when a newer build is detected.
+ * Checks on initial mount, on a periodic interval, and whenever the tab
+ * becomes visible. Returns { updateAvailable: boolean } when a newer build
+ * is detected.
  */
 const MIN_CHECK_INTERVAL_MS = 60_000; // Don't check more than once per minute
+const POLL_INTERVAL_MS = 5 * 60_000; // Periodic poll cadence (5 minutes)
 
 export const useVersionCheck = () => {
     const initialBuildId = useRef(null);
@@ -56,6 +58,17 @@ export const useVersionCheck = () => {
         document.addEventListener('visibilitychange', handleVisibilityChange);
         return () => {
             document.removeEventListener('visibilitychange', handleVisibilityChange);
+        };
+    }, [checkVersion]);
+
+    // Poll periodically so the banner appears even if the user never switches
+    // tabs. Firefox does not fire visibilitychange on its own while a tab
+    // remains in the foreground, so without this interval the check would
+    // only run on mount.
+    useEffect(() => {
+        const intervalId = setInterval(checkVersion, POLL_INTERVAL_MS);
+        return () => {
+            clearInterval(intervalId);
         };
     }, [checkVersion]);
 


### PR DESCRIPTION
## Summary
- `useVersionCheck` only ran on mount and on `visibilitychange`. Firefox doesn't fire `visibilitychange` while a tab stays in the foreground, so the "new version available" banner never appeared unless the user switched tabs. Chrome was masking the bug by firing visibility events more aggressively.
- Added a 5-minute `setInterval` inside `useVersionCheck` (same pattern as `DebeziumStatusAlert.js:36`) so the check runs even when the tab stays focused.
- The existing `MIN_CHECK_INTERVAL_MS` (1 min) throttle and the `updateAvailableRef` short-circuit keep request volume bounded and stop polling once an update is detected.

Jira: [SCRUM-6135](https://agr-jira.atlassian.net/browse/SCRUM-6135)

## Test plan
- [ ] Load the UI in Firefox, leave the tab focused, deploy a new build (or manually change `/version.json`'s `buildId`), and confirm the banner appears within ~5 minutes without any tab switch.
- [ ] Confirm Chrome behavior is unchanged (banner still appears).
- [ ] Confirm only one `/version.json` request fires per minute even with focus/visibility churn (throttle still effective).
- [ ] Confirm no further requests fire after the banner appears (short-circuit still effective).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6135]: https://agr-jira.atlassian.net/browse/SCRUM-6135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ