### PR TITLE
fix(SCRUM-523): make GEO and PDB datasets non-editable in biblio editor

### DIFF
--- a/src/components/biblio/BiblioEditor.js
+++ b/src/components/biblio/BiblioEditor.js
@@ -1099,11 +1099,7 @@ const RowEditorCrossReferences = ({fieldIndex, fieldName, referenceJsonLive, ref
 
 const RowEditorDatasets = ({fieldIndex, fieldName, referenceJsonLive, referenceJsonDb}) => {
   const dispatch = useDispatch();
-  const hasPmid = useSelector(state => state.biblio.hasPmid);
-  const initializeDict = {'curie': 'PDB:', 'url': null, 'is_obsolete': false, 'cross_reference_id': 'new'}
-  let disabled = ''
-  if (hasPmid && (fieldsPubmed.includes('cross_references'))) { disabled = 'disabled'; }
-  if (fieldsDisplayOnly.includes('cross_references')) { disabled = 'disabled'; }
+  const disabled = 'disabled';
   const rowDatasetsElements = []
 
   const xrefPatterns = useSelector(state => state.biblio.xrefPatterns);
@@ -1179,13 +1175,6 @@ const RowEditorDatasets = ({fieldIndex, fieldName, referenceJsonLive, referenceJ
             <ColEditorCheckbox key={`colElement cross_references ${index} is_obsolete`} colSize="1" label="obsolete" updatedFlag={updatedFlagIsObsolete} disabled={disabled} fieldKey={`cross_references ${index} is_obsolete`} checked={obsoleteChecked} dispatchAction={changeFieldCrossReferencesReferenceJson} />
             {buttonsElement}
           </Form.Group>); } } }
-  if (disabled === '') {
-    rowDatasetsElements.push(
-      <Row className="form-group row" key="datasets" >
-        <Col className="Col-general form-label col-form-label" sm="2" >datasets</Col>
-        <Col sm="10" ><div id="cross_references" className="form-control biblio-button" onClick={(e) => dispatch(biblioAddNewRowDict(e, initializeDict))} >add datasets</div></Col>
-      </Row>);
-  }
   return (<>{rowDatasetsElements}</>); }
 
 


### PR DESCRIPTION
## Summary
- `RowEditorDatasets` now renders with `disabled = 'disabled'` unconditionally, so the prefix dropdown, curie ID input, and obsolete checkbox are all locked for GEO and PDB entries
- Existing disable paths in the component hide the per-row revert/delete buttons and suppress the "add datasets" affordance (the now-unreachable add-row block was removed to keep the build clean)
- Regular `cross_references` (DOI, PMID, MGI, etc.) and the Display view are unchanged

## Test plan
- [ ] Open a reference with one or more PDB/GEO cross-references in the biblio editor
- [ ] Confirm prefix dropdown, ID input, and obsolete checkbox are all greyed out
- [ ] Confirm no revert/delete buttons appear next to dataset rows
- [ ] Confirm no "add datasets" button at the bottom of the datasets section
- [ ] Confirm regular cross_references (DOI, PMID, etc.) remain fully editable
- [ ] Confirm Display view still shows datasets as hyperlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)