### PR TITLE
left-align facet category headers to fix indentation

### DIFF
--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -668,7 +668,7 @@ const Facets = () => {
             {
                 Object.entries(FACETS_CATEGORIES_WITH_FACETS).map(([facetCategory, facetsInCategory]) =>
                     <div key={facetCategory} style={{textAlign: "left"}}>
-                        <Button variant="light" size="lg" eventkey="0" onClick={() => toggleFacetGroup(facetCategory)}>
+                        <Button variant="light" size="lg" eventkey="0" style={{textAlign: "left"}} onClick={() => toggleFacetGroup(facetCategory)}>
                             {openFacets.has(facetCategory) ? <IoIosArrowDropdownCircle/> : <IoIosArrowDroprightCircle/>} {facetCategory}
                         </Button>
 			<Collapse in={openFacets.has(facetCategory)}>


### PR DESCRIPTION
The "Curation Classification Tags" category title wrapped to two lines and appeared indented because Bootstrap's default centered button text pushed the arrow icon and wrapped text inward. Left-aligning the category button text keeps all category headers flush-left.