### PR TITLE
SCRUM-6018: Topic Entity Tag validation grid (topic grid view)

### DIFF
--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -132,7 +132,48 @@ function estimateIdsColumnWidth(rows, selectedPrefixes) {
   );
 }
 
-export default function TetValidationGrid({ referenceIds, topics, mod }) {
+// useState whose value is mirrored into an external store object so it survives
+// the component being unmounted/remounted. On (re)mount the initial value is
+// read back from the store; an effect keeps the store in sync on every change.
+// Returns the same [state, setState] tuple as useState (setState supports
+// functional updates). Falls back to plain state when no store is provided.
+function usePersistentState(store, key, initial) {
+  const [state, setState] = useState(() => {
+    if (store && key in store) return store[key];
+    return typeof initial === 'function' ? initial() : initial;
+  });
+  useEffect(() => {
+    if (store) store[key] = state;
+  }, [store, key, state]);
+  return [state, setState];
+}
+
+// Ref counterpart of usePersistentState for imperative, render-free flags whose
+// value must also survive remounts (e.g. "user has touched the topic filter").
+// The returned handle reads/writes straight through to the store.
+function usePersistentRef(store, key, initialValue) {
+  const handleRef = useRef(null);
+  if (handleRef.current === null) {
+    handleRef.current = store
+      ? {
+          get current() {
+            return key in store ? store[key] : initialValue;
+          },
+          set current(value) {
+            store[key] = value;
+          },
+        }
+      : { current: initialValue };
+  }
+  return handleRef.current;
+}
+
+export default function TetValidationGrid({ referenceIds, topics, mod, persistRef }) {
+  // Optional external store (a plain object held in a parent ref) used to
+  // persist toolbar/filter state across the grid being unmounted and remounted
+  // on every search. When absent (standalone use) the persistence hooks fall
+  // back to ordinary component state/refs and behaviour is unchanged.
+  const persistStore = persistRef?.current;
   const dispatch = useDispatch();
   const cognitoMod = useSelector((s) => s.isLogged.cognitoMod);
   const testerMod = useSelector((s) => s.isLogged.testerMod);
@@ -299,17 +340,37 @@ export default function TetValidationGrid({ referenceIds, topics, mod }) {
     return [...s].sort();
   }, [rows]);
 
-  const [displayOptions, setDisplayOptions] = useState({
-    inlineNote: false,
-    showLevel: false,
-    showScore: false,
-    showAuthors: false,
-  });
-  const [hiddenTopicCuries, setHiddenTopicCuries] = useState(new Set());
-  const [sourceFilterModel, setSourceFilterModel] = useState(null);
+  // Toolbar/filter state persisted across searches via the parent store (see
+  // usePersistentState). Topic/source multiselects, the display checkboxes and
+  // the ID-prefix filter all survive the grid's unmount/remount on pagination
+  // and filter changes; they reset only on a topic-facet change or a refresh.
+  const [displayOptions, setDisplayOptions] = usePersistentState(
+    persistStore,
+    'displayOptions',
+    {
+      inlineNote: false,
+      showLevel: false,
+      showScore: false,
+      showAuthors: false,
+    }
+  );
+  const [hiddenTopicCuries, setHiddenTopicCuries] = usePersistentState(
+    persistStore,
+    'hiddenTopicCuries',
+    () => new Set()
+  );
+  const [sourceFilterModel, setSourceFilterModel] = usePersistentState(
+    persistStore,
+    'sourceFilterModel',
+    null
+  );
   // Mirrors the IdPrefixFilter's column model so IdsCell can hide the
   // corresponding curie/xref lines inside each cell as well as filtering rows.
-  const [selectedIdPrefixes, setSelectedIdPrefixes] = useState(null);
+  const [selectedIdPrefixes, setSelectedIdPrefixes] = usePersistentState(
+    persistStore,
+    'selectedIdPrefixes',
+    null
+  );
   // True while the autosize/fill-extra passes are running. Used to render a
   // light overlay so the curator knows the layout is still adjusting and
   // mid-resize column widths aren't a bug.
@@ -321,8 +382,21 @@ export default function TetValidationGrid({ referenceIds, topics, mod }) {
   const [selectedRefCuries, setSelectedRefCuries] = useState(() => new Set());
   const [bulkTopicCurie, setBulkTopicCurie] = useState(null);
   const [bulkPending, setBulkPending] = useState(null);
-  const userTouchedHiddenRef = useRef(false);
-  const idsFilterDefaultAppliedRef = useRef(false);
+  // Persisted across remounts: "did the curator touch the topic filter" and
+  // "have we already applied the one-time AGRKB id-prefix default this session".
+  const userTouchedHiddenRef = usePersistentRef(
+    persistStore,
+    'userTouchedHidden',
+    false
+  );
+  const idsFilterDefaultAppliedRef = usePersistentRef(
+    persistStore,
+    'idsFilterDefaultApplied',
+    false
+  );
+  // Per-mount guard: restore the persisted id-prefix filter onto the freshly
+  // created AgGrid instance exactly once after data has loaded.
+  const idsFilterRestoredRef = useRef(false);
 
   // Esc closes fullscreen. Listener is attached only while fullscreen is
   // active so we don't intercept Esc anywhere else in the app.
@@ -653,7 +727,9 @@ export default function TetValidationGrid({ referenceIds, topics, mod }) {
   //   their choice — UNTIL the facet selection itself changes, at which point
   //   we re-apply the default so the new facet topic(s) become the only
   //   visible columns again.
-  const lastTopicsKeyRef = useRef('');
+  // Persisted so a remount mid-session doesn't look like a facet change and
+  // wrongly re-apply the defaults over the curator's preserved selection.
+  const lastTopicsKeyRef = usePersistentRef(persistStore, 'lastTopicsKey', '');
   useEffect(() => {
     const key = JSON.stringify(
       (topics || [])
@@ -674,12 +750,12 @@ export default function TetValidationGrid({ referenceIds, topics, mod }) {
         .filter((c) => !requested.has(c))
     );
     setHiddenTopicCuries(next);
-  }, [topics, topicColumns]);
+  }, [topics, topicColumns, lastTopicsKeyRef, setHiddenTopicCuries, userTouchedHiddenRef]);
 
   const handleSetHiddenTopicCuries = useCallback((next) => {
     userTouchedHiddenRef.current = true;
     setHiddenTopicCuries(next);
-  }, []);
+  }, [setHiddenTopicCuries, userTouchedHiddenRef]);
 
   const visibleTopicColumns = useMemo(
     () => topicColumns.filter((t) => !hiddenTopicCuries.has(t.curie)),
@@ -790,19 +866,31 @@ export default function TetValidationGrid({ referenceIds, topics, mod }) {
     );
   }, [gridApi, idsColumnWidth]);
 
-  // Default the ID-prefix filter to AGRKB-only on first load — applied once
-  // per mount and only when AGRKB is actually present in the loaded data.
+  // Restore the ID-prefix filter onto the freshly created AgGrid instance after
+  // data has loaded. On the very first load of the session there is no persisted
+  // selection yet, so we default to AGRKB-only when present. On later remounts
+  // (pagination/filter changes) we re-apply the curator's persisted selection
+  // verbatim — including prefixes absent from the current page — so the choice
+  // is retained and re-appears selected when those prefixes come back. Runs once
+  // per mount via idsFilterRestoredRef; setFilterModel triggers handleFilterChanged
+  // which keeps selectedIdPrefixes (and therefore the persisted value) in sync.
   useEffect(() => {
-    if (!gridApi || idsFilterDefaultAppliedRef.current) return;
-    if (!allIdPrefixes.includes('AGRKB')) return;
+    if (!gridApi || idsFilterRestoredRef.current) return;
+    if (allIdPrefixes.length === 0) return; // wait until data has loaded
     const currentModel = gridApi.getFilterModel?.() || {};
-    if (currentModel.__ids !== undefined) {
-      idsFilterDefaultAppliedRef.current = true;
-      return;
+
+    let desired = selectedIdPrefixes; // persisted across remounts; null === all
+    if (desired === null && !idsFilterDefaultAppliedRef.current) {
+      // First load this session: seed the AGRKB-only default when available.
+      if (allIdPrefixes.includes('AGRKB')) desired = ['AGRKB'];
     }
-    gridApi.setFilterModel({ ...currentModel, __ids: ['AGRKB'] });
     idsFilterDefaultAppliedRef.current = true;
-  }, [gridApi, allIdPrefixes]);
+    idsFilterRestoredRef.current = true;
+
+    if (currentModel.__ids !== undefined) return; // grid already has a filter
+    if (desired === null) return; // null === all selected → leave unfiltered
+    gridApi.setFilterModel({ ...currentModel, __ids: desired });
+  }, [gridApi, allIdPrefixes, selectedIdPrefixes, idsFilterDefaultAppliedRef]);
 
   const syncSingleInnerColumnState = useCallback(
     (preferredInnerColId, apiOverride = null) => {
@@ -946,7 +1034,7 @@ export default function TetValidationGrid({ referenceIds, topics, mod }) {
       prevFilterModelRef.current = apiInstance.getFilterModel?.() || {};
       prevSortModelRef.current = apiInstance.getSortModel?.() || [];
     },
-    [gridApi, allowedInnerColumnIds, syncSingleInnerColumnState]
+    [gridApi, allowedInnerColumnIds, syncSingleInnerColumnState, setSelectedIdPrefixes]
   );
 
   const handleSortChanged = useCallback(

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -34,6 +34,15 @@ const SearchLayout = () => {
     const [view, setView] = useState('list'); // 'list' | 'grid'
     const [hasOpenedTopicGrid, setHasOpenedTopicGrid] = useState(false);
 
+    // Persisted topic-grid UI state — topic/source multiselects, the display
+    // checkboxes and the ID-prefix filter. The grid is torn down on every
+    // search (results are cleared while loading), which would otherwise reset
+    // every toolbar choice on each pagination/filter change. Holding the state
+    // in a ref here keeps it across searches without re-rendering SearchLayout;
+    // it resets only when the topic facet changes (handled inside the grid via
+    // the topics-prop key) or on a page refresh (this component remounts).
+    const gridStateRef = useRef({});
+
     const searchResults = useSelector((s) => s.search.searchResults);
     const searchFacetsValues = useSelector((s) => s.search.searchFacetsValues);
     const searchLoading = useSelector((s) => s.search.searchLoading);
@@ -272,6 +281,7 @@ const SearchLayout = () => {
                                         <TetValidationGrid
                                             referenceIds={referenceIds}
                                             topics={topicsForGrid}
+                                            persistRef={gridStateRef}
                                         />
                                     </div>
                                 )}

--- a/src/components/search/__tests__/SearchLayout.test.js
+++ b/src/components/search/__tests__/SearchLayout.test.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchLayout from '../SearchLayout';
+
+// Mutable redux state read through the mocked useSelector. Tests mutate this
+// then re-render to simulate search-loading transitions.
+const mockState = {
+  search: {
+    searchResults: [],
+    searchFacetsValues: {},
+    searchLoading: false,
+  },
+};
+
+jest.mock('react-redux', () => ({
+  useSelector: (fn) => fn(mockState),
+}));
+
+// The grid unmounts on every search (results are cleared while loading). This
+// mock records how the persistRef store behaves across that remount: it writes
+// a marker on first mount and reads it back on the next mount. If SearchLayout
+// holds the store in a stable ref, the marker survives the remount.
+const mockGrid = { mounts: 0, unmounts: 0, sawOnRemount: undefined };
+
+jest.mock('../../refs_tet_validation/TetValidationGrid', () => {
+  const ReactLib = require('react');
+  return function MockTetValidationGrid(props) {
+    ReactLib.useEffect(() => {
+      mockGrid.mounts += 1;
+      const store = props.persistRef.current;
+      if (mockGrid.mounts === 1) {
+        store.marker = 'kept-selection';
+      } else {
+        mockGrid.sawOnRemount = store.marker;
+      }
+      return () => {
+        mockGrid.unmounts += 1;
+      };
+    }, [props.persistRef]);
+    return ReactLib.createElement('div', { 'data-testid': 'tet-grid' }, 'grid');
+  };
+});
+
+// Heavy children that pull in API calls / redux dispatch — stub them out.
+jest.mock('../SearchBar', () => () => null);
+jest.mock('../SearchResults', () => () => null);
+jest.mock('../SearchOptions', () => () => null);
+jest.mock('../BreadCrumbs', () => () => null);
+jest.mock('../SearchPagination', () => () => null);
+jest.mock('../Facets', () => () => null);
+
+function setSearchState(next) {
+  mockState.search = { ...mockState.search, ...next };
+}
+
+beforeEach(() => {
+  mockGrid.mounts = 0;
+  mockGrid.unmounts = 0;
+  mockGrid.sawOnRemount = undefined;
+  setSearchState({
+    searchResults: [{ curie: 'AGRKB:101000000000001' }],
+    searchFacetsValues: {},
+    searchLoading: false,
+  });
+});
+
+test('grid persistence store survives the unmount/remount of a new search', () => {
+  const { rerender } = render(<SearchLayout />);
+
+  // Switch to the topic grid view; this mounts the grid once.
+  fireEvent.click(screen.getByText(/Topic grid/i));
+  expect(screen.getByTestId('tet-grid')).toBeInTheDocument();
+  expect(mockGrid.mounts).toBe(1);
+
+  // A new search (pagination/filter change) clears results while loading —
+  // referenceIds becomes empty so the grid unmounts.
+  setSearchState({ searchResults: [], searchLoading: true });
+  rerender(<SearchLayout />);
+  expect(screen.queryByTestId('tet-grid')).not.toBeInTheDocument();
+  expect(mockGrid.unmounts).toBe(1);
+
+  // Results return — the grid remounts and must read back the marker it stored
+  // before the unmount, proving the persistence container is stable.
+  setSearchState({
+    searchResults: [{ curie: 'AGRKB:101000000000002' }],
+    searchLoading: false,
+  });
+  rerender(<SearchLayout />);
+  expect(screen.getByTestId('tet-grid')).toBeInTheDocument();
+  expect(mockGrid.mounts).toBe(2);
+  expect(mockGrid.sawOnRemount).toBe('kept-selection');
+});


### PR DESCRIPTION
## Summary

Delivers the **SCRUM-6018 Topic Entity Tag (TET) validation grid** — a "Topic grid" view on the search page that lets curators review and validate topic/entity tags across many references at once. This branch was developed off the `SCRUM-6018` feature branch (never pushed separately), so this PR to `main` contains the **full feature** plus the latest fix below.

### Core feature
- New `TetValidationGrid` (AgGrid-based) wired into `SearchLayout` via a List/Topic-grid toggle.
- Per-topic columns with validation strips, sources, tags, notes, confidence level/score, species picker.
- Bulk validation, reference action icons, fullscreen, sticky scroll sync, ID-prefix and inner-column filters/sorting.
- `useReferenceTets` data hook (mixed-id resolution + TET fetch with retry/backoff).

### Latest fix — persistent toolbar selections (most recent commit)
The grid is unmounted on every search (`searchResults` is cleared while loading → `referenceIds` drops to 0), which reset every toolbar choice on each pagination/filter change.

- Toolbar/filter state is now lifted into a `SearchLayout`-held ref (`usePersistentState` / `usePersistentRef`) so it survives the unmount/remount.
- Persists the **topics** & **sources** multiselects, the **display checkboxes**, and the **ID-prefix filter**.
- Selected options are **retained even when absent from the current page** and re-appear selected when the data returns.
- Resets only on a **topic-facet change** (topics-prop key) or a **page refresh**.

## Testing
- Added `SearchLayout` regression test covering persistence across the grid's remount.
- `eslint` clean; jest suites for `search` + `refs_tet_validation` pass (32 tests).
- `main` merged into the branch; no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)