### PR TITLE
fix(SCRUM-6071): mount banner directory and serve via nginx alias for…

### DIFF
--- a/banner/README.md
+++ b/banner/README.md
@@ -11,6 +11,14 @@ focus, and every 5 minutes). The banner is shown only while that file contains a
 non-empty `message`. The file is **not** part of the build — it is supplied at
 run time as a mounted volume — so updating it requires **no rebuild or redeploy**.
 
+`docker-compose.yml` mounts a *directory* of banner content read-only into nginx
+at `/var/www/banner-config`, and nginx serves `/banner.json` from
+`banner-config/banner.json` via `alias`. A directory (rather than a single file)
+is mounted so that host edits — including `vim`/`sed` save-by-rename — are picked
+up live, with no container restart. The mounted directory is the `BANNER_DIR`
+variable from the env file (the one passed via `ENV_FILE=`), falling back to
+`./banner` when unset.
+
 File format:
 
 ```json
@@ -23,24 +31,40 @@ File format:
 
 ## Per-server setup (once)
 
-On each deployed server, in the directory where `docker-compose` runs:
+On deployed servers the docker-compose working directory is a **disposable
+Jenkins workspace**, so the banner content must live outside it — in a stable,
+server-managed directory (alongside how `.env` is handled). Set it up once per
+server:
 
 ```bash
-cp banner/banner.json.example banner/banner.json
+# 1. Create the banner directory + file in a stable location (survives redeploys):
+mkdir -p /usr/share/agr_ui_files
+echo '{ "message": "", "severity": "info" }' > /usr/share/agr_ui_files/banner.json
+
+# 2. Point the mount at that DIRECTORY via BANNER_DIR in the server's env file
+#    (e.g. /usr/share/agr_env_files/.env.dev_3001):
+BANNER_DIR=/usr/share/agr_ui_files
+
+# 3. Redeploy so the container binds the directory:
+make restart-ui ENV_FILE=/usr/share/agr_env_files/.env.dev_3001
 ```
 
-`docker-compose.yml` mounts `banner/banner.json` read-only into nginx at
-`/var/www/banner.json`. The file **must exist before `docker-compose up`**,
-otherwise Docker creates a directory at that path. The example starts with an
-empty `message`, so nothing shows until you set one.
+The directory must exist before `docker-compose up`. `banner.json` need not
+exist yet — if it's absent nginx returns 404 and the UI simply shows no banner;
+create it whenever you want a banner. Leaving `BANNER_DIR` unset falls back to
+`./banner` (only suitable for local Docker use, not a deployed server).
+
+To let anyone on the server edit the banner, make the directory and file
+writable as needed (e.g. `chmod 777 /usr/share/agr_ui_files` and `chmod 666
+/usr/share/agr_ui_files/banner.json`).
 
 ## Updating the banner
 
-Edit `banner/banner.json` on the server (this file is gitignored, so deploys
-never clobber it). Open browser tabs pick up the change on their next
-poll/tab-focus/refresh — no rebuild, redeploy, or container restart.
-
-To clear the banner, set `message` to `""`.
+Edit `banner.json` in the `BANNER_DIR` (e.g. `/usr/share/agr_ui_files/banner.json`)
+on the server — including with `vim`. Because a *directory* is mounted, the edit
+is picked up live; open browser tabs reflect it on their next poll/tab-focus/refresh,
+with no rebuild, redeploy, or container restart. To clear the banner, set
+`message` to `""` (or remove the file).
 
 ## Local development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,11 @@ services:
     ports:
       - "${LIT_UI_PORT}:80"
     volumes:
-      # Externally-editable system-status banner content, served at /banner.json.
-      # The source file lives on the server (per-environment config, like .env);
-      # copy banner/banner.json.example to banner/banner.json once per server.
-      # Editing it updates the banner with no rebuild/redeploy. The file MUST
-      # exist before `up`, otherwise Docker creates a directory at this path.
-      - ./banner/banner.json:/var/www/banner.json:ro
+      # Externally-editable system-status banner content (served at /banner.json
+      # via nginx alias to banner-config/banner.json). A DIRECTORY is mounted (not
+      # the single file) so host edits -- including vim/sed save-by-rename -- are
+      # picked up live without a container restart. Source dir is set per-server
+      # via BANNER_DIR in the env file (a stable, server-managed location like
+      # /usr/share/agr_ui_files) so it survives the disposable Jenkins workspace;
+      # falls back to ./banner for local use.
+      - ${BANNER_DIR:-./banner}:/var/www/banner-config:ro

--- a/nginx.conf
+++ b/nginx.conf
@@ -47,14 +47,16 @@ http {
             try_files $uri =404;
         }
 
-        # System-status banner content (runtime-mounted volume, not part of the
-        # build). Served uncached so edits appear on the next client poll. If
-        # the file is not mounted, return 404 so the UI simply shows no banner.
+        # System-status banner content. Served from a runtime-mounted directory
+        # (/var/www/banner-config, not part of the build) via alias, so the path
+        # is resolved fresh each request -- in-place AND save-by-rename edits
+        # (e.g. vim) on the host show up live without a container restart.
+        # Served uncached; a missing file returns 404 so the UI shows no banner.
         location = /banner.json {
             add_header Cache-Control "no-cache, no-store, must-revalidate";
             add_header Pragma "no-cache";
             add_header Expires "0";
-            try_files $uri =404;
+            alias /var/www/banner-config/banner.json;
         }
 
         location / {


### PR DESCRIPTION
… live edits

Mount a directory (BANNER_DIR, default ./banner) at /var/www/banner-config instead of bind-mounting the single banner.json file, and serve /banner.json via nginx alias. Because the path is resolved per request, host edits -- including vim/sed save-by-rename -- are picked up live with no container restart, matching the public/banner.json experience under npm start.

BANNER_DIR points at a stable, server-managed location (e.g. /usr/share/agr_ui_files) set in the env file, so the banner content survives the disposable Jenkins workspace across redeploys.