### PR TITLE
feat(tet): drop entity_published_as column from TET views (SCRUM-4218)

### DIFF
--- a/src/components/biblio/BiblioRawTetData.js
+++ b/src/components/biblio/BiblioRawTetData.js
@@ -40,7 +40,7 @@ const RawDataEntityTable = () => {
   }, [referenceCurie, biblioUpdatingEntityAdd, topicEntityTags]);
 
   // use the following code for the editor view table
-  // let headers = ['topic', 'entity_type', 'species', 'entity', 'entity_published_as', 'negated', 'confidence_level', 'created_by', 'note', 'entity_source', 'date_created', 'updated_by', 'date_updated', 'validation_value_author', 'validation_value_curator', 'validation_value_curation_tools', 'display_tag'];
+  // let headers = ['topic', 'entity_type', 'species', 'entity', 'negated', 'confidence_level', 'created_by', 'note', 'entity_source', 'date_created', 'updated_by', 'date_updated', 'validation_value_author', 'validation_value_curator', 'validation_value_curation_tools', 'display_tag'];
   // let source_headers = ['mod_id', 'source_method', 'evidence', 'validation_type', 'source_type', 'description', 'created_by', 'date_updated', 'date_created'];
   // const headersWithSortability = new Set(['entity_type']);
   // const headersToEntityMap = new Set(['topic', 'entity_type', 'entity', 'display_tag']);

--- a/src/components/biblio/topic_entity_tag/TopicEntityTable.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityTable.js
@@ -409,7 +409,6 @@ const TopicEntityTable = () => {
       { headerName: 'Entity Type', field: 'entity_type_name', id: 2, checked: true },
       { headerName: 'Species', field: 'species_name', id: 3, checked: true },
       { headerName: 'Entity', field: 'entity_name', id: 4, checked: true },
-      { headerName: 'Entity Published As', field: 'entity_published_as', id: 5, checked: false },
       { headerName: 'No Data', field: 'no_data', id: 6, checked: true },
       { headerName: 'Data', field: 'has_data', id: 32, checked: true },
       { headerName: 'Data Novelty', field: 'data_novelty', id: 7, checked: false },
@@ -447,7 +446,6 @@ const TopicEntityTable = () => {
       { headerName: 'Entity Type', field: 'entity_type_name', id: 2, checked: true },
       { headerName: 'Species', field: 'species_name', id: 3, checked: true },
       { headerName: 'Entity', field: 'entity_name', id: 4, checked: true },
-      { headerName: 'Entity Published As', field: 'entity_published_as', id: 5, checked: false },
       { headerName: 'No Data', field: 'no_data', id: 6, checked: false },
       { headerName: 'Data', field: 'has_data', id: 32, checked: false },
       { headerName: 'Data Novelty', field: 'data_novelty', id: 7, checked: false },
@@ -536,7 +534,6 @@ const TopicEntityTable = () => {
         filter: EntityFilter,
         onCellClicked: (p) => handleCurieClick(`${p.value}:${p.data.entity}`)
       },
-      { headerName: 'Entity Published As', field: 'entity_published_as', comparator: caseInsensitiveComparator, filter: true },
       {
         headerName: 'No Data',
         field: 'no_data',

--- a/src/components/refs_tet_validation/cellRenderers/NoteCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/NoteCell.jsx
@@ -50,7 +50,7 @@ export default function NoteCell(params) {
         // entity-collapsed: list notes (one per entity that has one)
         const noted = e.tets
           .map((t) => ({
-            entity: t.entity_published_as || t.entity_name || t.entity,
+            entity: t.entity_name || t.entity,
             note: t.note,
           }))
           .filter((x) => x.note);

--- a/src/components/refs_tet_validation/cellRenderers/TagsCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/TagsCell.jsx
@@ -28,7 +28,7 @@ function PillEntityCount({ count, negated, entitiesText }) {
 }
 
 function entityLabel(t) {
-  return t.entity_published_as || t.entity_name || t.entity || '';
+  return t.entity_name || t.entity || '';
 }
 
 export default function TagsCell(params) {


### PR DESCRIPTION
## Summary

Companion UI change for [SCRUM-4218](https://agr-jira.atlassian.net/browse/SCRUM-4218). The backend is removing the `entity_published_as` field from `topic_entity_tag` (it will live in the A-team DB), so this removes the now-dead column from the TET views.

## Changes
- **`TopicEntityTable.js`** — removed the three "Entity Published As" column entries (`itemsInit`, `itemsInitSGD`, and the ag-grid `cols` definition).
- **`NoteCell.jsx`, `TagsCell.jsx`** — dropped the dead `t.entity_published_as ||` prefix from the entity-label fallback chains (kept `entity_name || entity`).
- **`BiblioRawTetData.js`** — removed it from the commented-out header list.

## Verification
- ESLint on the four changed files: 0 errors (one pre-existing, unrelated warning).
- The TET reads already degraded gracefully via `entity_name`/`entity` fallbacks, so rendering is unaffected once the field disappears from API responses.

## Companion PR
Backend: `agr_literature_service` PR for SCRUM-4218 (stacked on the SCRUM-6090 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-4218]: https://agr-jira.atlassian.net/browse/SCRUM-4218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ