### PR TITLE
feat(SCRUM-5819): show person<->lab connections in the Person UI

### DIFF
--- a/src/components/person/PersonCcDisplay.js
+++ b/src/components/person/PersonCcDisplay.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import Card from 'react-bootstrap/Card';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
@@ -231,7 +232,64 @@ const NotesCard = ({ notes }) => {
   );
 };
 
+const labRoles = (lp) => {
+  const roles = [];
+  if (lp.lab_position) roles.push(lp.lab_position);
+  if (lp.is_pi) roles.push(`PI since ${formatDate(lp.is_pi)}`);
+  if (lp.former_pi) roles.push(`former PI since ${formatDate(lp.former_pi)}`);
+  if (lp.alum) roles.push(`alum since ${formatDate(lp.alum)}`);
+  if (lp.is_lab_contact) roles.push('lab contact');
+  if (lp.can_edit_lab) roles.push('can edit');
+  return roles;
+};
+
+const LaboratoriesCard = ({ labs, effectiveMod }) => {
+  const list = labs ?? [];
+  const labHref = (curie) =>
+    '/lab?q=' + encodeURIComponent(curie) + (effectiveMod === 'WB' ? '&tab=wbdisplay' : '');
+  return (
+    <Card className="mb-3">
+      <Card.Header>Laboratories</Card.Header>
+      <Card.Body>
+        {list.length === 0 ? (
+          <span style={muted}>—</span>
+        ) : (
+          <ul style={{ listStyle: 'none', paddingLeft: 0, marginBottom: 0 }}>
+            {list.map((lp, i) => {
+              const label =
+                [lp.laboratory_name, lp.laboratory_strain_designation].filter(Boolean).join(' · ') ||
+                lp.laboratory_curie ||
+                '(unknown lab)';
+              const roles = labRoles(lp);
+              return (
+                <li key={lp.laboratory_person_id ?? i} style={{ padding: '2px 0' }}>
+                  {lp.laboratory_curie ? (
+                    <a href={labHref(lp.laboratory_curie)}>{label}</a>
+                  ) : (
+                    <span>{label}</span>
+                  )}
+                  {roles.length > 0 && (
+                    <span style={{ marginLeft: 8 }}>
+                      {roles.map((r, j) => (
+                        <Badge key={j} variant="info" style={{ marginRight: 4 }}>{r}</Badge>
+                      ))}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Card.Body>
+    </Card>
+  );
+};
+
 const PersonCcDisplay = ({ person }) => {
+  const cognitoMod = useSelector((s) => s.isLogged.cognitoMod);
+  const testerMod = useSelector((s) => s.isLogged.testerMod);
+  const effectiveMod = testerMod !== 'No' ? testerMod : cognitoMod;
+
   if (!person) return null;
   const status = person.active_status || 'unknown';
   const statusVariant = status === 'active' ? 'success' : 'secondary';
@@ -277,6 +335,7 @@ const PersonCcDisplay = ({ person }) => {
         <Col md={6}>
           <BiographyCard bio={person.biography_research_interest} />
           <InstitutionsCard list={person.institution} />
+          <LaboratoriesCard labs={person.lab_persons} effectiveMod={effectiveMod} />
           <AddressCard person={person} />
           <WebpagesCard pages={person.webpage} />
           <NotesCard notes={person.notes} />

--- a/src/components/person/PersonWbDisplay.js
+++ b/src/components/person/PersonWbDisplay.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import Card from 'react-bootstrap/Card';
 import Badge from 'react-bootstrap/Badge';
 
@@ -75,7 +76,24 @@ const xrefHref = (x) => {
   return null;
 };
 
+const labRoles = (lp) => {
+  const roles = [];
+  if (lp.lab_position) roles.push(lp.lab_position);
+  if (lp.is_pi) roles.push(`PI since ${formatTimestamp(lp.is_pi)}`);
+  if (lp.former_pi) roles.push(`former PI since ${formatTimestamp(lp.former_pi)}`);
+  if (lp.alum) roles.push(`alum since ${formatTimestamp(lp.alum)}`);
+  if (lp.is_lab_contact) roles.push('lab contact');
+  if (lp.can_edit_lab) roles.push('can edit');
+  return roles;
+};
+
 const PersonWbDisplay = ({ person }) => {
+  const cognitoMod = useSelector((s) => s.isLogged.cognitoMod);
+  const testerMod = useSelector((s) => s.isLogged.testerMod);
+  const effectiveMod = testerMod !== 'No' ? testerMod : cognitoMod;
+  const labHref = (curie) =>
+    '/lab?q=' + encodeURIComponent(curie) + (effectiveMod === 'WB' ? '&tab=wbdisplay' : '');
+
   if (!person) return null;
 
   const status = person.active_status || 'unknown';
@@ -89,6 +107,7 @@ const PersonWbDisplay = ({ person }) => {
   const webpages = person.webpage ?? [];
   const institutions = person.institution ?? [];
   const notes = person.notes ?? [];
+  const labPersons = person.lab_persons ?? [];
 
   const recordTs = tsLabel(person.updated_by, person.date_updated);
 
@@ -235,6 +254,40 @@ const PersonWbDisplay = ({ person }) => {
                   </a>
                 ) : (
                   <span style={valStyle}>{value}</span>
+                )}
+              </FieldRow>
+            );
+          })
+        )}
+      </Section>
+
+      <Section title="Laboratories">
+        {labPersons.length === 0 ? (
+          <FieldRow label="laboratory" />
+        ) : (
+          labPersons.map((lp, i) => {
+            const label =
+              [lp.laboratory_name, lp.laboratory_strain_designation].filter(Boolean).join(' · ') ||
+              lp.laboratory_curie ||
+              '(unknown lab)';
+            const roles = labRoles(lp);
+            return (
+              <FieldRow
+                key={lp.laboratory_person_id ?? i}
+                label="laboratory"
+                ts={tsLabel(lp.updated_by, lp.date_updated)}
+              >
+                {lp.laboratory_curie ? (
+                  <a href={labHref(lp.laboratory_curie)}>{label}</a>
+                ) : (
+                  <span>{label}</span>
+                )}
+                {roles.length > 0 && (
+                  <span style={{ marginLeft: 8 }}>
+                    {roles.map((r, j) => (
+                      <Badge key={j} variant="info" style={{ marginRight: 4 }}>{r}</Badge>
+                    ))}
+                  </span>
                 )}
               </FieldRow>
             );

--- a/src/components/person/PersonWbEditor.js
+++ b/src/components/person/PersonWbEditor.js
@@ -227,6 +227,34 @@ const PersonWbEditor = ({ person }) => {
   }));
   const [notes, updateNote, removeNote] = useAutoGrowList(initialNotes, emptyNote, noteIsEmpty);
 
+  // Laboratory connections — editable, auto-growing like the other lists. The
+  // alum / is_pi / former_pi DateTime fields are shown as checkboxes; the stored
+  // timestamp (when set in the database) is displayed beside the box. Mockup-only.
+  const emptyLab = () => ({
+    lab: '',
+    alum: false,
+    is_pi: false,
+    former_pi: false,
+    _alum_ts: null,
+    _is_pi_ts: null,
+    _former_pi_ts: null,
+    _ts: null,
+    _by: null,
+  });
+  const labIsEmpty = (l) => !l.lab;
+  const initialLabs = (p.lab_persons ?? []).map((lp) => ({
+    lab: lp.laboratory_strain_designation || lp.laboratory_curie || '',
+    alum: !!lp.alum,
+    is_pi: !!lp.is_pi,
+    former_pi: !!lp.former_pi,
+    _alum_ts: lp.alum ?? null,
+    _is_pi_ts: lp.is_pi ?? null,
+    _former_pi_ts: lp.former_pi ?? null,
+    _ts: lp.date_updated ?? null,
+    _by: lp.updated_by ?? null,
+  }));
+  const [labs, updateLab, removeLab] = useAutoGrowList(initialLabs, emptyLab, labIsEmpty);
+
   const setNamePrimary = (idx) =>
     setNames((prev) => prev.map((row, i) => ({ ...row, is_primary: i === idx })));
 
@@ -247,6 +275,8 @@ const PersonWbEditor = ({ person }) => {
     i === xrefs.length - 1 && xrefIsEmpty(x) ? 'xref (new)' : x.curie_prefix || 'xref';
   const labelForNote = (n, i) =>
     i === notes.length - 1 && noteIsEmpty(n) ? 'comment (new)' : 'comment';
+  const labelForLab = (l, i) =>
+    i === labs.length - 1 && labIsEmpty(l) ? 'laboratory (new)' : 'laboratory';
 
   const recordTs = tsLabel(p.updated_by, p.date_updated);
 
@@ -442,6 +472,67 @@ const PersonWbEditor = ({ person }) => {
               />
             </FieldLine>
           ))}
+        </Card.Body>
+      </Card>
+
+      <Card className="mb-3">
+        <Card.Header>Laboratories</Card.Header>
+        <Card.Body>
+          {labs.map((lab, i) => {
+            const isNew = i === labs.length - 1 && labIsEmpty(lab);
+            const ts = isNew ? 'new' : tsLabel(lab._by, lab._ts);
+            const flags = [
+              { key: 'alum', tsKey: '_alum_ts' },
+              { key: 'is_pi', tsKey: '_is_pi_ts' },
+              { key: 'former_pi', tsKey: '_former_pi_ts' },
+            ];
+            return (
+              <FieldLine
+                key={i}
+                label={labelForLab(lab, i)}
+                ts={ts}
+                trail={<RemoveBtn onClick={() => removeLab(i)} />}
+              >
+                <div style={inlineRow}>
+                  <Form.Control
+                    placeholder="strain_designation (or lab curie)"
+                    value={lab.lab}
+                    onChange={(ev) => updateLab(i, { lab: ev.target.value })}
+                    style={{ width: 300, flexShrink: 0 }}
+                  />
+                  {flags.map(({ key, tsKey }) => {
+                    const stamp = lab[key] && lab[tsKey] ? formatTimestamp(lab[tsKey]) : null;
+                    return (
+                      <div
+                        key={key}
+                        style={{
+                          width: 230,
+                          flexShrink: 0,
+                          boxSizing: 'border-box',
+                          paddingLeft: 12,
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 6,
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                        }}
+                      >
+                        <Form.Check
+                          type="checkbox"
+                          id={`wb-labperson-${i}-${key}`}
+                          label={key}
+                          checked={lab[key]}
+                          onChange={(ev) => updateLab(i, { [key]: ev.target.checked })}
+                          style={{ whiteSpace: 'nowrap' }}
+                        />
+                        {stamp && <span style={tsStyle}>{stamp}</span>}
+                      </div>
+                    );
+                  })}
+                </div>
+              </FieldLine>
+            );
+          })}
         </Card.Body>
       </Card>
 


### PR DESCRIPTION
- PersonCcDisplay: new Laboratories card listing each lab the person is in (name · strain_designation or curie), linked to the Lab page, with roles (lab_position, PI/former-PI/alum dates, lab contact, can edit).
- PersonWbDisplay: matching Laboratories section in the field-row layout.
- PersonWbEditor (mockup): editable, auto-growing Laboratories list — a fixed-width strain_designation (or lab curie) input with alum/is_pi/former_pi checkboxes aligned in fixed columns; each shows its stored DB timestamp when set. New trailing row + delete button, same as the other fields.
- Lab links honor the user's MOD (WB -> WB display, else CC), symmetric with the Lab page's links to people.