### PR TITLE
honor Exclude NEG / confidence in Topic grid + speed it up

### DIFF
--- a/src/actions/searchActions.js
+++ b/src/actions/searchActions.js
@@ -160,7 +160,10 @@ const getSearchParams = (state) => {
 
   // Negated TET facets. Source method / source evidence assertion exclusions use whole-reference
   // semantics (drop a reference if ANY of its tags matches) and apply in both single- and
-  // multi-tag modes. Confidence level negation keeps its existing single-tag-only behavior.
+  // multi-tag modes. Confidence level negation applies in both modes too: the backend attaches
+  // it as a must_not inside each positive nested tag query (add_nested_query), so it correctly
+  // excludes NEG tags per-tag whether one or many TET facets are selected (it just needs at
+  // least one positive TET facet, e.g. a chosen topic, for the exclusion to be consumed).
   // All negated TET keys are carried in ONE merged object: the backend reads only
   // tet_facets_negative_values[0] and turns each source/SEA key into its own independent
   // must_not nested clause, so splitting them into separate array entries would silently drop
@@ -172,7 +175,7 @@ const getSearchParams = (state) => {
   if (negated_facets.source_evidence_assertions && negated_facets.source_evidence_assertions.length > 0) {
       negatedTetEntry["topic_entity_tags.source_evidence_assertion.keyword"] = negated_facets.source_evidence_assertions;
   }
-  if (state.search.applyToSingleTag && negated_facets.confidence_levels && negated_facets.confidence_levels.length > 0) {
+  if (negated_facets.confidence_levels && negated_facets.confidence_levels.length > 0) {
       negatedTetEntry["topic_entity_tags.confidence_level.keyword"] = negated_facets.confidence_levels;
   }
   if (Object.keys(negatedTetEntry).length > 0) {

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -173,6 +173,8 @@ export default function TetValidationGrid({
   topics,
   mod,
   excludedConfidenceLevels,
+  confidenceScore,
+  biblioByCurie,
   persistRef,
 }) {
   // Optional external store (a plain object held in a parent ref) used to
@@ -230,14 +232,20 @@ export default function TetValidationGrid({
   const effectiveMod = mod || accessLevel;
 
   const { rows: rawRows, unresolved, loading, refetchRow } = useReferenceTets(
-    referenceIds
+    referenceIds,
+    biblioByCurie
   );
 
-  // Honor the search's "Exclude NEG" filter in the grid. The grid fetches TETs
+  // Honor the search's confidence filters in the grid. The grid fetches TETs
   // independently of the search query (useReferenceTets), so without this it
-  // would still render negative data the search excluded. We drop any TET whose
-  // confidence_level matches an excluded level (e.g. 'NEG' = confidence <= 0.5),
-  // matching the backend search filter (confidence_level keyword must_not).
+  // would still render data the search excluded. Two filters apply:
+  //  - "Exclude NEG": drop any TET whose confidence_level matches an excluded
+  //    level (e.g. 'NEG' = confidence <= 0.5), matching the backend search
+  //    filter (confidence_level keyword must_not).
+  //  - confidence-score slider: drop any TET whose numeric confidence_score
+  //    falls outside the selected [min, max] range, matching the backend nested
+  //    range query. TETs without a numeric score (e.g. curator/author tags) are
+  //    kept, since the slider targets scored ML/automated predictions.
   // Filtering once here keeps every per-topic column (Sources / Data / Conf /
   // Note) consistent, since they all iterate row.tets.
   const excludedConfLevelSet = useMemo(
@@ -247,16 +255,34 @@ export default function TetValidationGrid({
       ),
     [excludedConfidenceLevels]
   );
+  const confMin = Array.isArray(confidenceScore) ? confidenceScore[0] : undefined;
+  const confMax = Array.isArray(confidenceScore) ? confidenceScore[1] : undefined;
+  // The default [0, 1] range means "no filter" — skip it (mirrors searchActions).
+  const confRangeActive =
+    typeof confMin === 'number' &&
+    typeof confMax === 'number' &&
+    !(confMin === 0 && confMax === 1);
   const rows = useMemo(() => {
-    if (excludedConfLevelSet.size === 0) return rawRows;
+    if (excludedConfLevelSet.size === 0 && !confRangeActive) return rawRows;
     return rawRows.map((r) => ({
       ...r,
-      tets: (r.tets || []).filter(
-        (t) =>
-          !excludedConfLevelSet.has(String(t.confidence_level || '').toUpperCase())
-      ),
+      tets: (r.tets || []).filter((t) => {
+        if (
+          excludedConfLevelSet.has(String(t.confidence_level || '').toUpperCase())
+        ) {
+          return false;
+        }
+        if (confRangeActive) {
+          const sc =
+            t.confidence_score == null ? null : Number(t.confidence_score);
+          if (sc != null && !Number.isNaN(sc) && (sc < confMin || sc > confMax)) {
+            return false;
+          }
+        }
+        return true;
+      }),
     }));
-  }, [rawRows, excludedConfLevelSet]);
+  }, [rawRows, excludedConfLevelSet, confRangeActive, confMin, confMax]);
 
   // Ensure curator source id is loaded so the validation strip can submit
   useEffect(() => {

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -168,7 +168,13 @@ function usePersistentRef(store, key, initialValue) {
   return handleRef.current;
 }
 
-export default function TetValidationGrid({ referenceIds, topics, mod, persistRef }) {
+export default function TetValidationGrid({
+  referenceIds,
+  topics,
+  mod,
+  excludedConfidenceLevels,
+  persistRef,
+}) {
   // Optional external store (a plain object held in a parent ref) used to
   // persist toolbar/filter state across the grid being unmounted and remounted
   // on every search. When absent (standalone use) the persistence hooks fall
@@ -223,9 +229,34 @@ export default function TetValidationGrid({ referenceIds, topics, mod, persistRe
   );
   const effectiveMod = mod || accessLevel;
 
-  const { rows, unresolved, loading, refetchRow } = useReferenceTets(
+  const { rows: rawRows, unresolved, loading, refetchRow } = useReferenceTets(
     referenceIds
   );
+
+  // Honor the search's "Exclude NEG" filter in the grid. The grid fetches TETs
+  // independently of the search query (useReferenceTets), so without this it
+  // would still render negative data the search excluded. We drop any TET whose
+  // confidence_level matches an excluded level (e.g. 'NEG' = confidence <= 0.5),
+  // matching the backend search filter (confidence_level keyword must_not).
+  // Filtering once here keeps every per-topic column (Sources / Data / Conf /
+  // Note) consistent, since they all iterate row.tets.
+  const excludedConfLevelSet = useMemo(
+    () =>
+      new Set(
+        (excludedConfidenceLevels || []).map((v) => String(v).toUpperCase())
+      ),
+    [excludedConfidenceLevels]
+  );
+  const rows = useMemo(() => {
+    if (excludedConfLevelSet.size === 0) return rawRows;
+    return rawRows.map((r) => ({
+      ...r,
+      tets: (r.tets || []).filter(
+        (t) =>
+          !excludedConfLevelSet.has(String(t.confidence_level || '').toUpperCase())
+      ),
+    }));
+  }, [rawRows, excludedConfLevelSet]);
 
   // Ensure curator source id is loaded so the validation strip can submit
   useEffect(() => {

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -175,6 +175,7 @@ export default function TetValidationGrid({
   excludedConfidenceLevels,
   confidenceScore,
   biblioByCurie,
+  active = true,
   persistRef,
 }) {
   // Optional external store (a plain object held in a parent ref) used to
@@ -233,7 +234,8 @@ export default function TetValidationGrid({
 
   const { rows: rawRows, unresolved, loading, refetchRow } = useReferenceTets(
     referenceIds,
-    biblioByCurie
+    biblioByCurie,
+    active
   );
 
   // Honor the search's confidence filters in the grid. The grid fetches TETs

--- a/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
+++ b/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
@@ -1,12 +1,13 @@
-import { resolveOne, fetchTets } from '../useReferenceTets';
+import { resolveOne, fetchTets, fetchTetsBatch } from '../useReferenceTets';
 import { api } from '../../../../api';
 
 jest.mock('../../../../api', () => ({
-  api: { get: jest.fn() },
+  api: { get: jest.fn(), post: jest.fn() },
 }));
 
 beforeEach(() => {
   api.get.mockReset();
+  api.post.mockReset();
   // Make backoff sleeps no-ops in tests so retries run back-to-back.
   jest.spyOn(global, 'setTimeout').mockImplementation((fn) => {
     fn();
@@ -91,5 +92,53 @@ describe('fetchTets', () => {
     expect(tets).toEqual([]);
     // 1 initial + 5 backoff retries
     expect(api.get).toHaveBeenCalledTimes(6);
+  });
+});
+
+describe('fetchTetsBatch', () => {
+  test('no curies → no request, empty map', async () => {
+    const out = await fetchTetsBatch([]);
+    expect(out).toEqual({});
+    expect(api.post).not.toHaveBeenCalled();
+  });
+
+  test('posts curies to /by_references and returns the map', async () => {
+    api.post.mockResolvedValueOnce({
+      data: {
+        'AGRKB:1': [{ topic_entity_tag_id: 1 }],
+        'AGRKB:2': [],
+      },
+    });
+    const out = await fetchTetsBatch(['AGRKB:1', 'AGRKB:2']);
+    expect(api.post).toHaveBeenCalledWith(
+      '/topic_entity_tag/by_references',
+      ['AGRKB:1', 'AGRKB:2']
+    );
+    expect(out['AGRKB:1']).toHaveLength(1);
+    expect(out['AGRKB:2']).toEqual([]);
+  });
+
+  test('dedupes curies and defaults missing keys to empty arrays', async () => {
+    api.post.mockResolvedValueOnce({ data: { 'AGRKB:1': [{ x: 1 }] } });
+    const out = await fetchTetsBatch(['AGRKB:1', 'AGRKB:1', 'AGRKB:3']);
+    expect(api.post).toHaveBeenCalledWith(
+      '/topic_entity_tag/by_references',
+      ['AGRKB:1', 'AGRKB:3']
+    );
+    expect(out['AGRKB:1']).toEqual([{ x: 1 }]);
+    expect(out['AGRKB:3']).toEqual([]); // present in request, absent in response
+  });
+
+  test('falls back to per-reference GET when batch endpoint fails', async () => {
+    api.post.mockRejectedValue({ response: { status: 404 } });
+    api.get
+      .mockResolvedValueOnce({ data: [{ topic_entity_tag_id: 11 }] })
+      .mockResolvedValueOnce({ data: [{ topic_entity_tag_id: 22 }] });
+    const out = await fetchTetsBatch(['AGRKB:1', 'AGRKB:2']);
+    expect(out['AGRKB:1']).toEqual([{ topic_entity_tag_id: 11 }]);
+    expect(out['AGRKB:2']).toEqual([{ topic_entity_tag_id: 22 }]);
+    expect(api.get).toHaveBeenCalledWith(
+      '/topic_entity_tag/by_reference/AGRKB:1?page=1&page_size=8000'
+    );
   });
 });

--- a/src/components/refs_tet_validation/hooks/useReferenceTets.js
+++ b/src/components/refs_tet_validation/hooks/useReferenceTets.js
@@ -102,8 +102,13 @@ export async function fetchTetsBatch(curies) {
   await Promise.all(
     chunk(unique, TETS_BATCH_SIZE).map(async (group) => {
       try {
-        const r = await withBackoff(() =>
-          api.post('/topic_entity_tag/by_references', group)
+        // Fail fast (one short retry) before falling back to per-reference
+        // GETs: a 4xx (older backend without this endpoint) isn't retried at
+        // all, and on persistent 5xx/timeout we'd rather fall back quickly than
+        // burn the full ~60s backoff. The fallback path keeps its own retries.
+        const r = await withBackoff(
+          () => api.post('/topic_entity_tag/by_references', group),
+          { delays: [500] }
         );
         const data = r.data && typeof r.data === 'object' ? r.data : {};
         for (const c of group) result[c] = data[c] || [];
@@ -124,7 +129,7 @@ export async function fetchTetsBatch(curies) {
   return result;
 }
 
-export function useReferenceTets(referenceIds, biblioByCurie) {
+export function useReferenceTets(referenceIds, biblioByCurie, active = true) {
   const [rows, setRows] = useState([]);
   const [unresolved, setUnresolved] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -155,6 +160,10 @@ export function useReferenceTets(referenceIds, biblioByCurie) {
   }, []);
 
   useEffect(() => {
+    // Skip fetching while the grid is hidden (e.g. the user is in List view
+    // but the grid stays mounted to preserve state). Otherwise every later
+    // search would trigger a batch fetch for a grid nobody is looking at.
+    if (!active) return undefined;
     const reqId = ++reqIdRef.current;
     let cancelled = false;
     setLoading(true);
@@ -205,7 +214,7 @@ export function useReferenceTets(referenceIds, biblioByCurie) {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(referenceIds || []), resolveBiblio]);
+  }, [JSON.stringify(referenceIds || []), resolveBiblio, active]);
 
   const refetchRow = useCallback(async (curie) => {
     const tets = await fetchTets(curie);

--- a/src/components/refs_tet_validation/hooks/useReferenceTets.js
+++ b/src/components/refs_tet_validation/hooks/useReferenceTets.js
@@ -20,6 +20,15 @@ const DEFAULT_BACKOFF_DELAYS = [500, 1500, 4500, 13500, 40500];
 const TETS_PAGE_SIZE = 8000;
 // How many references to resolve/fetch in parallel.
 const FETCH_CONCURRENCY = 10;
+// How many references' TETs to request per batch call. A search page is usually
+// tens of references, so this typically collapses to a single request.
+const TETS_BATCH_SIZE = 50;
+
+function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
 
 /**
  * Retry an axios call on 5xx / network errors with exponential backoff.
@@ -79,31 +88,70 @@ export async function fetchTets(curie) {
   }
 }
 
-export function useReferenceTets(referenceIds) {
+/**
+ * Fetch TETs for many references in one round-trip via POST
+ * /topic_entity_tag/by_references, which returns a { curie: tets[] } map.
+ * Chunked so a very large page doesn't become one huge request. Falls back to
+ * per-reference GETs if the batch endpoint is unavailable (e.g. older backend),
+ * so the grid keeps working either way.
+ */
+export async function fetchTetsBatch(curies) {
+  const result = {};
+  const unique = Array.from(new Set((curies || []).filter(Boolean)));
+  if (unique.length === 0) return result;
+  await Promise.all(
+    chunk(unique, TETS_BATCH_SIZE).map(async (group) => {
+      try {
+        const r = await withBackoff(() =>
+          api.post('/topic_entity_tag/by_references', group)
+        );
+        const data = r.data && typeof r.data === 'object' ? r.data : {};
+        for (const c of group) result[c] = data[c] || [];
+      } catch (e) {
+        debug.warn(
+          '[TetValidationGrid] batch fetchTets failed; falling back per-reference:',
+          e?.response?.status,
+          e?.response?.data?.detail || e?.message
+        );
+        await Promise.all(
+          group.map(async (c) => {
+            result[c] = await fetchTets(c);
+          })
+        );
+      }
+    })
+  );
+  return result;
+}
+
+export function useReferenceTets(referenceIds, biblioByCurie) {
   const [rows, setRows] = useState([]);
   const [unresolved, setUnresolved] = useState([]);
   const [loading, setLoading] = useState(true);
   const reqIdRef = useRef(0);
 
-  const loadRow = useCallback(async (input) => {
-    // AGRKB inputs are already canonical, so /reference/{id} and
-    // /topic_entity_tag/by_reference/{id} can be fired in parallel — that
-    // halves the per-row round-trip count for the common search-driven case
-    // where the grid is loaded with AGRKB curies. Non-AGRKB inputs still
-    // need the resolve step first because the TETs endpoint keys off the
-    // canonical AGRKB curie returned by /reference/by_cross_reference.
+  // Read the latest biblio map without making it an effect dependency: it is
+  // derived from the same search that produced referenceIds, so it changes in
+  // lockstep with them, and keying the effect on referenceIds alone avoids a
+  // redundant reload when only the map's identity changes.
+  const biblioMapRef = useRef(biblioByCurie);
+  biblioMapRef.current = biblioByCurie;
+
+  // Resolve one input to its canonical curie + biblio. When the caller already
+  // supplied biblio (search results), AGRKB inputs need NO network call — the
+  // curie is canonical and the biblio is in hand. Only non-AGRKB inputs, or
+  // AGRKB inputs without supplied biblio (standalone use), hit /reference.
+  const resolveBiblio = useCallback(async (input) => {
+    const supplied = biblioMapRef.current && biblioMapRef.current[input];
     if (input.startsWith('AGRKB:')) {
-      const [ref, tets] = await Promise.all([
-        resolveOne(input),
-        fetchTets(input),
-      ]);
-      if (!ref?.curie) return { input, ref: null };
-      return { input, ref, tets };
+      if (supplied) return { input, curie: input, biblio: supplied };
+      const ref = await resolveOne(input);
+      if (!ref?.curie) return { input, curie: null, biblio: null };
+      return { input, curie: ref.curie, biblio: ref };
     }
     const ref = await resolveOne(input);
-    if (!ref?.curie) return { input, ref: null };
-    const tets = await fetchTets(ref.curie);
-    return { input, ref, tets };
+    if (!ref?.curie) return { input, curie: null, biblio: null };
+    return { input, curie: ref.curie, biblio: ref };
   }, []);
 
   useEffect(() => {
@@ -117,31 +165,38 @@ export function useReferenceTets(referenceIds) {
       const ids = Array.from(
         new Set((referenceIds || []).map((s) => s.trim()).filter(Boolean))
       );
-      const newRows = [];
+      // Phase 1: resolve each input to its canonical curie + biblio (mostly
+      // free when search biblio is supplied), bounded by FETCH_CONCURRENCY.
+      const resolved = [];
       const newUnresolved = [];
       let cursor = 0;
       async function worker() {
         while (cursor < ids.length) {
           const i = cursor++;
-          const out = await loadRow(ids[i]);
+          const out = await resolveBiblio(ids[i]);
           if (cancelled || reqId !== reqIdRef.current) return;
-          if (!out.ref) {
-            newUnresolved.push(out.input);
-          } else {
-            newRows.push({
-              input: out.input,
-              curie: out.ref.curie,
-              biblio: out.ref,
-              tets: out.tets,
-            });
-          }
+          if (!out.curie || !out.biblio) newUnresolved.push(out.input);
+          else resolved.push(out);
         }
       }
       await Promise.all(
         Array.from({ length: Math.min(FETCH_CONCURRENCY, ids.length) }, worker)
       );
       if (cancelled || reqId !== reqIdRef.current) return;
-      setRows(newRows);
+
+      // Phase 2: fetch all TETs in one batched request (was one HTTP call per
+      // reference — the grid's main bottleneck).
+      const tetsByCurie = await fetchTetsBatch(resolved.map((r) => r.curie));
+      if (cancelled || reqId !== reqIdRef.current) return;
+
+      setRows(
+        resolved.map((r) => ({
+          input: r.input,
+          curie: r.curie,
+          biblio: r.biblio,
+          tets: tetsByCurie[r.curie] || [],
+        }))
+      );
       setUnresolved(newUnresolved);
       setLoading(false);
     })();
@@ -150,7 +205,7 @@ export function useReferenceTets(referenceIds) {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(referenceIds || [])]);
+  }, [JSON.stringify(referenceIds || []), resolveBiblio]);
 
   const refetchRow = useCallback(async (curie) => {
     const tets = await fetchTets(curie);

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -303,6 +303,7 @@ const SearchLayout = () => {
                                             excludedConfidenceLevels={excludedConfidenceLevels}
                                             confidenceScore={confidenceScore}
                                             biblioByCurie={biblioByCurie}
+                                            active={view === 'grid'}
                                             persistRef={gridStateRef}
                                         />
                                     </div>

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -46,12 +46,23 @@ const SearchLayout = () => {
     const searchResults = useSelector((s) => s.search.searchResults);
     const searchFacetsValues = useSelector((s) => s.search.searchFacetsValues);
     const searchExcludedFacetsValues = useSelector((s) => s.search.searchExcludedFacetsValues);
+    const confidenceScore = useSelector((s) => s.search.confidenceScore);
     const searchLoading = useSelector((s) => s.search.searchLoading);
 
     const referenceIds = useMemo(
         () => (searchResults || []).map((r) => r.curie).filter(Boolean),
         [searchResults]
     );
+    // Reuse the biblio data the search already returned (curie/title/authors/
+    // cross_references/date_published) so the grid can skip the per-row
+    // /reference/{curie} fetch. Keyed by canonical AGRKB curie.
+    const biblioByCurie = useMemo(() => {
+        const map = {};
+        for (const r of searchResults || []) {
+            if (r?.curie) map[r.curie] = r;
+        }
+        return map;
+    }, [searchResults]);
     const topicsForGrid = useMemo(() => {
         const arr = searchFacetsValues?.topics;
         if (!Array.isArray(arr) || arr.length === 0) return undefined;
@@ -290,6 +301,8 @@ const SearchLayout = () => {
                                             referenceIds={referenceIds}
                                             topics={topicsForGrid}
                                             excludedConfidenceLevels={excludedConfidenceLevels}
+                                            confidenceScore={confidenceScore}
+                                            biblioByCurie={biblioByCurie}
                                             persistRef={gridStateRef}
                                         />
                                     </div>

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -45,6 +45,7 @@ const SearchLayout = () => {
 
     const searchResults = useSelector((s) => s.search.searchResults);
     const searchFacetsValues = useSelector((s) => s.search.searchFacetsValues);
+    const searchExcludedFacetsValues = useSelector((s) => s.search.searchExcludedFacetsValues);
     const searchLoading = useSelector((s) => s.search.searchLoading);
 
     const referenceIds = useMemo(
@@ -59,6 +60,13 @@ const SearchLayout = () => {
         // grid via /ontology/map_curie_to_name/atpterm/{curie}.
         return arr.map((curie) => ({ curie, name: undefined }));
     }, [searchFacetsValues]);
+    // Confidence levels the user excluded (e.g. ['NEG']). The Topic grid fetches
+    // TETs independently of the search query, so it must apply the same
+    // "Exclude NEG" filter itself to avoid showing negative data the search hid.
+    const excludedConfidenceLevels = useMemo(
+        () => searchExcludedFacetsValues?.confidence_levels || [],
+        [searchExcludedFacetsValues]
+    );
 
     // Handle window resize
     useEffect(() => {
@@ -281,6 +289,7 @@ const SearchLayout = () => {
                                         <TetValidationGrid
                                             referenceIds={referenceIds}
                                             topics={topicsForGrid}
+                                            excludedConfidenceLevels={excludedConfidenceLevels}
                                             persistRef={gridStateRef}
                                         />
                                     </div>


### PR DESCRIPTION
Two things: (1) the Topic grid showed negative/low-confidence data even when the search excluded it, and (2) the grid was slow to load.

## Fixes — Exclude NEG / confidence (display correctness)
The grid fetches TETs independently of the search query, so it never applied the
search's confidence filters. Now it filters its TETs to match the search:
- Drops `confidence_level == 'NEG'` when the **Exclude NEG** chip is set
  (= the "confidence score ≤ 0.5" bucket, matching the backend `must_not`).
- Drops any TET whose numeric `confidence_score` is outside the **slider** range.
- Filtering is applied once at the row source, so every per-topic column
  (Sources / Data / Conf / Note) stays consistent.
- Also removed the `applyToSingleTag` gate in `searchActions` so **Exclude NEG**
  filters the search in **multi-tag** mode too — the backend already applies it
  per-tag, so this just stops silently dropping the filter.

## Performance

- **Batch TET fetch:** replaced the per-reference `GET /by_reference/{curie}`
  fan-out with a single `POST /topic_entity_tag/by_references` (chunked), with a
  per-reference fallback if the endpoint isn't available.
- **Reuse search biblio:** the grid now reuses the biblio the search already
  returned, skipping the per-row `/reference/{curie}` fetch for AGRKB curies.
- Net: a typical search page drops from ~2×N requests to ~1–2.

## Testing
- Added `fetchTetsBatch` tests (success, dedupe, empty input, per-reference
  fallback). Existing `resolveOne`/`fetchTets` tests unchanged.