### PR TITLE
add reusable entity-counts-by-MOD summary and store-backed TET loading

### DIFF
--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -976,6 +976,68 @@ export const fetchReferenceFiles = (referenceCurie, forceRefresh = false) => {
   };
 };
 
+export const setTopicEntityTags = (tags, referenceCurie) => {
+  return {
+    type: 'SET_TOPIC_ENTITY_TAGS',
+    payload: { tags, referenceCurie }
+  };
+};
+
+// Module-level cache to prevent concurrent duplicate fetches
+let pendingTopicEntityTagsRequest = null;
+let pendingTopicEntityTagsCurie = null;
+
+// Load all topic entity tags for a reference into the redux store so that any
+// reference-based (Biblio) page can reuse them (e.g. the entity counts summary)
+// without each component issuing its own request.
+export const fetchTopicEntityTags = (referenceCurie, forceRefresh = false) => {
+  return (dispatch, getState) => {
+    if (!referenceCurie) {
+      return Promise.resolve([]);
+    }
+
+    const { topicEntityTags, topicEntityTagsCurie } = getState().biblio;
+
+    // If data already loaded for this reference and not forcing a refresh, reuse it
+    if (!forceRefresh && topicEntityTagsCurie === referenceCurie) {
+      return Promise.resolve(topicEntityTags);
+    }
+
+    // If already fetching the SAME curie, return the pending promise
+    if (pendingTopicEntityTagsRequest && pendingTopicEntityTagsCurie === referenceCurie) {
+      return pendingTopicEntityTagsRequest;
+    }
+
+    dispatch({ type: 'SET_TOPIC_ENTITY_TAGS_LOADING', payload: true });
+
+    pendingTopicEntityTagsCurie = referenceCurie;
+
+    pendingTopicEntityTagsRequest = (async () => {
+      try {
+        const url = '/topic_entity_tag/by_reference/' + referenceCurie + '?page=1&page_size=8000';
+        const response = await api.get(url);
+        const tags = response.data || [];
+        // Only dispatch if this is still the curie we want
+        if (getState().biblio.referenceCurie === referenceCurie) {
+          dispatch(setTopicEntityTags(tags, referenceCurie));
+        }
+        return tags;
+      } catch (error) {
+        console.error('Error fetching topic_entity_tag by_reference:', error);
+        dispatch({ type: 'SET_TOPIC_ENTITY_TAGS_LOADING', payload: false });
+        return [];
+      } finally {
+        if (pendingTopicEntityTagsCurie === referenceCurie) {
+          pendingTopicEntityTagsRequest = null;
+          pendingTopicEntityTagsCurie = null;
+        }
+      }
+    })();
+
+    return pendingTopicEntityTagsRequest;
+  };
+};
+
 export const setBiblioEditorModalText = (payload) => {
   return {
     type: 'SET_BIBLIO_EDITOR_MODAL_TEXT',

--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -1003,8 +1003,10 @@ export const fetchTopicEntityTags = (referenceCurie, forceRefresh = false) => {
       return Promise.resolve(topicEntityTags);
     }
 
-    // If already fetching the SAME curie, return the pending promise
-    if (pendingTopicEntityTagsRequest && pendingTopicEntityTagsCurie === referenceCurie) {
+    // If already fetching the SAME curie, return the pending promise — but not
+    // when forcing a refresh, so a post-edit forceRefresh never resolves to an
+    // older in-flight (non-forced) fetch that predates the edit.
+    if (!forceRefresh && pendingTopicEntityTagsRequest && pendingTopicEntityTagsCurie === referenceCurie) {
       return pendingTopicEntityTagsRequest;
     }
 

--- a/src/components/Biblio.js
+++ b/src/components/Biblio.js
@@ -21,7 +21,8 @@ import { usePersonSettings } from './settings/usePersonSettings';
 import {
   downloadReferencefile,
   setReferenceCurie,
-  fetchReferenceFiles
+  fetchReferenceFiles,
+  fetchTopicEntityTags
 } from '../actions/biblioActions';
 import { setBiblioAction } from '../actions/biblioActions';
 import { biblioQueryReferenceCurie } from '../actions/biblioActions';
@@ -669,6 +670,14 @@ const Biblio = () => {
     if (paramAction !== null) { dispatch(setBiblioAction(paramAction)); }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.search, location.pathname]);
+
+  // Load the topic entity tags into the redux store on any reference-based
+  // (Biblio) page so the entity counts summary and future consumers can reuse
+  // them without re-fetching.
+  useEffect(() => {
+    if (referenceCurie !== '') { dispatch(fetchTopicEntityTags(referenceCurie)); }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [referenceCurie]);
 
   // citation needs to be updated after processing separate biblio api calls. update citation and make flag false
   // 2023 04 11 citation now updates from database triggers

--- a/src/components/biblio/BiblioEntity.js
+++ b/src/components/biblio/BiblioEntity.js
@@ -2,6 +2,7 @@ import {useSelector} from "react-redux";
 import TopicEntityCreateSGD from "./topic_entity_tag/TopicEntityCreateSGD";
 import TopicEntityCreate from "./topic_entity_tag/TopicEntityCreate";
 import TopicEntityTable from "./topic_entity_tag/TopicEntityTable";
+import EntityCountsByMod from "./shared/EntityCountsByMod";
 
 const BiblioEntity = () => {
   const cognitoMod = useSelector(state => state.isLogged.cognitoMod);
@@ -10,15 +11,17 @@ const BiblioEntity = () => {
   if (accessLevel === 'SGD') {
     return (
       <>
+        <EntityCountsByMod key="entityCounts" />
         <TopicEntityCreateSGD key="entityCreate" />
         <br/>
         <TopicEntityTable key="entityTable" />
       </>
     );
   };
-    
+
   return (
       <>
+        <EntityCountsByMod key="entityCounts" />
         <TopicEntityCreate key="entityCreate" />
         <br/>
         <TopicEntityTable key="entityTable" />

--- a/src/components/biblio/BiblioWorkflow.js
+++ b/src/components/biblio/BiblioWorkflow.js
@@ -13,6 +13,7 @@ import { patchWorkflowTag, deleteWorkflowTag, transitionWorkflowTag } from './Wo
 
 import BiblioPreferenceControls from '../settings/BiblioPreferenceControls';
 import TopicFilter from '../AgGrid/TopicFilter';
+import EntityCountsByMod from './shared/EntityCountsByMod';
 
 import { setAllTopics } from '../../actions/biblioActions';
 
@@ -1504,6 +1505,7 @@ const BiblioWorkflow = () => {
 
   return (
     <div>
+      <EntityCountsByMod />
       {/* Pre-curation Workflow Section */}
       <strong style={{ display: 'block', margin: '20px 0 10px', textAlign: 'center' }}>
         Pre-curation Workflow

--- a/src/components/biblio/shared/EntityCountsByMod.js
+++ b/src/components/biblio/shared/EntityCountsByMod.js
@@ -127,7 +127,7 @@ const EntityCountsByMod = ({ referenceCurie: referenceCurieProp }) => {
         <strong style={{ display: 'block', margin: '20px 0 10px', textAlign: 'center' }}>
           Entity Counts by MOD
         </strong>
-        <table className="entity-counts-by-mod-table" style={tableStyle}>
+        <table style={tableStyle}>
           <thead>
             <tr>
               <th style={headerCellStyle}>MOD</th>

--- a/src/components/biblio/shared/EntityCountsByMod.js
+++ b/src/components/biblio/shared/EntityCountsByMod.js
@@ -1,10 +1,49 @@
 import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import Row from 'react-bootstrap/Row';
-import Col from 'react-bootstrap/Col';
 import Spinner from 'react-bootstrap/Spinner';
 
 import { fetchTopicEntityTags } from '../../../actions/biblioActions';
+
+// Centered panel, sized to match the workflow tables (which center an 80%-wide
+// grid). The card itself stays left-aligned inside so multiple MOD rows are easy
+// to scan.
+const panelWrapperStyle = { display: 'flex', justifyContent: 'center' };
+const panelStyle = { width: '80%', maxWidth: 900 };
+
+const cellBorder = '1px solid #dee2e6';
+const tableStyle = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  border: cellBorder,
+  fontSize: '0.9rem'
+};
+const headerCellStyle = {
+  backgroundColor: 'var(--light-blue)',
+  textAlign: 'left',
+  padding: '6px 12px',
+  borderBottom: cellBorder,
+  fontWeight: 'bold'
+};
+const modCellStyle = {
+  width: 80,
+  fontWeight: 'bold',
+  textAlign: 'left',
+  padding: '6px 12px',
+  borderBottom: cellBorder,
+  verticalAlign: 'top',
+  whiteSpace: 'nowrap'
+};
+const entitiesCellStyle = {
+  textAlign: 'left',
+  padding: '6px 12px',
+  borderBottom: cellBorder,
+  verticalAlign: 'top',
+  color: '#212529'
+};
+
+// API entity type names arrive lowercase (e.g. "gene"); show them with a leading
+// capital ("Gene") to match the rest of the editor chrome.
+const capitalizeFirst = (str) => (str ? str.charAt(0).toUpperCase() + str.slice(1) : str);
 
 /**
  * Reusable summary of the unique entities associated with a reference, grouped
@@ -67,11 +106,13 @@ const EntityCountsByMod = ({ referenceCurie: referenceCurieProp }) => {
   // Loading the data for this reference for the first time
   if (topicEntityTagsLoading && topicEntityTagsCurie !== referenceCurie) {
     return (
-      <Row className="Row-general">
-        <Col className="Col-general" sm="12">
-          <Spinner animation="border" size="sm" />
-        </Col>
-      </Row>
+      <div style={panelWrapperStyle}>
+        <div style={panelStyle}>
+          <div className="text-center" style={{ padding: '10px' }}>
+            <Spinner animation="border" size="sm" />
+          </div>
+        </div>
+      </div>
     );
   }
 
@@ -81,31 +122,33 @@ const EntityCountsByMod = ({ referenceCurie: referenceCurieProp }) => {
   }
 
   return (
-    <Row className="Row-general entity-counts-by-mod" style={{ margin: '10px 0' }}>
-      <Col sm="12">
-        <table className="entity-counts-by-mod-table" style={{ borderCollapse: 'collapse' }}>
+    <div style={panelWrapperStyle}>
+      <div style={panelStyle}>
+        <strong style={{ display: 'block', margin: '20px 0 10px', textAlign: 'center' }}>
+          Entity Counts by MOD
+        </strong>
+        <table className="entity-counts-by-mod-table" style={tableStyle}>
+          <thead>
+            <tr>
+              <th style={headerCellStyle}>MOD</th>
+              <th style={headerCellStyle}>Entities</th>
+            </tr>
+          </thead>
           <tbody>
             {countsByMod.map(({ mod, entityTypes }) => (
               <tr key={mod}>
-                <td style={{ verticalAlign: 'top', fontWeight: 'bold', paddingRight: '1.5em', whiteSpace: 'nowrap' }}>
-                  {mod}
-                </td>
-                <td style={{ verticalAlign: 'top' }}>
-                  {'[ '}
-                  {entityTypes.map((entityType, idx) => (
-                    <span key={entityType.name}>
-                      {idx > 0 ? ', ' : ''}
-                      {entityType.name} ({entityType.count})
-                    </span>
-                  ))}
-                  {' ]'}
+                <td style={modCellStyle}>{mod}</td>
+                <td style={entitiesCellStyle}>
+                  {entityTypes
+                    .map((entityType) => `${capitalizeFirst(entityType.name)} (${entityType.count})`)
+                    .join(', ')}
                 </td>
               </tr>
             ))}
           </tbody>
         </table>
-      </Col>
-    </Row>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/biblio/shared/EntityCountsByMod.js
+++ b/src/components/biblio/shared/EntityCountsByMod.js
@@ -1,0 +1,112 @@
+import { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Spinner from 'react-bootstrap/Spinner';
+
+import { fetchTopicEntityTags } from '../../../actions/biblioActions';
+
+/**
+ * Reusable summary of the unique entities associated with a reference, grouped
+ * by MOD and entity type. There is no distinction between manual and automated
+ * tags. The MOD is taken from each tag's secondary data provider.
+ *
+ * Data is loaded into (and read from) the redux store so any reference-based
+ * (Biblio) page can reuse it. The component is self-contained so it can be
+ * dropped into the workflow editor, the topic/entity editor, the biblio
+ * display, or any other place in the future.
+ *
+ * Acceptance criteria honored here:
+ *   - counts of entities associated with a paper for each MOD
+ *   - only show a list for MODs that have associated entities
+ *   - only show entity types with a count > 0
+ *   - entity types listed in alphabetical order
+ */
+const EntityCountsByMod = ({ referenceCurie: referenceCurieProp }) => {
+  const dispatch = useDispatch();
+
+  const storeReferenceCurie = useSelector((state) => state.biblio.referenceCurie);
+  const referenceCurie = referenceCurieProp || storeReferenceCurie;
+
+  const topicEntityTags = useSelector((state) => state.biblio.topicEntityTags);
+  const topicEntityTagsLoading = useSelector((state) => state.biblio.topicEntityTagsLoading);
+  const topicEntityTagsCurie = useSelector((state) => state.biblio.topicEntityTagsCurie);
+
+  useEffect(() => {
+    if (referenceCurie) {
+      dispatch(fetchTopicEntityTags(referenceCurie));
+    }
+  }, [dispatch, referenceCurie]);
+
+  // Group unique entities by MOD then by entity type.
+  const countsByMod = useMemo(() => {
+    const byMod = {};
+    for (const tag of topicEntityTags || []) {
+      const mod = tag?.topic_entity_tag_source?.secondary_data_provider_abbreviation;
+      const entityType = tag?.entity_type_name;
+      const entity = tag?.entity; // entity curie; unique key for counting
+      // Skip rows without a MOD, entity type, or an actual entity (e.g. topic-only tags)
+      if (!mod || !entityType || !entity) continue;
+      if (!byMod[mod]) byMod[mod] = {};
+      if (!byMod[mod][entityType]) byMod[mod][entityType] = new Set();
+      byMod[mod][entityType].add(entity);
+    }
+
+    return Object.keys(byMod)
+      .sort((a, b) => a.localeCompare(b))
+      .map((mod) => ({
+        mod,
+        entityTypes: Object.keys(byMod[mod])
+          .map((name) => ({ name, count: byMod[mod][name].size }))
+          .filter((entityType) => entityType.count > 0)
+          .sort((a, b) => a.name.localeCompare(b.name))
+      }))
+      .filter((modGroup) => modGroup.entityTypes.length > 0);
+  }, [topicEntityTags]);
+
+  // Loading the data for this reference for the first time
+  if (topicEntityTagsLoading && topicEntityTagsCurie !== referenceCurie) {
+    return (
+      <Row className="Row-general">
+        <Col className="Col-general" sm="12">
+          <Spinner animation="border" size="sm" />
+        </Col>
+      </Row>
+    );
+  }
+
+  // Nothing to show when no MOD has associated entities
+  if (countsByMod.length === 0) {
+    return null;
+  }
+
+  return (
+    <Row className="Row-general entity-counts-by-mod" style={{ margin: '10px 0' }}>
+      <Col sm="12">
+        <table className="entity-counts-by-mod-table" style={{ borderCollapse: 'collapse' }}>
+          <tbody>
+            {countsByMod.map(({ mod, entityTypes }) => (
+              <tr key={mod}>
+                <td style={{ verticalAlign: 'top', fontWeight: 'bold', paddingRight: '1.5em', whiteSpace: 'nowrap' }}>
+                  {mod}
+                </td>
+                <td style={{ verticalAlign: 'top' }}>
+                  {'[ '}
+                  {entityTypes.map((entityType, idx) => (
+                    <span key={entityType.name}>
+                      {idx > 0 ? ', ' : ''}
+                      {entityType.name} ({entityType.count})
+                    </span>
+                  ))}
+                  {' ]'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Col>
+    </Row>
+  );
+};
+
+export default EntityCountsByMod;

--- a/src/components/biblio/topic_entity_tag/TopicEntityTable.js
+++ b/src/components/biblio/topic_entity_tag/TopicEntityTable.js
@@ -12,7 +12,6 @@ import {
   Row,
   Col
 } from 'react-bootstrap';
-import { api } from '../../../api';
 import { AgGridReact } from 'ag-grid-react';
 import { handleGridCopy } from '../../../utils/gridCopyHandler';
 
@@ -21,7 +20,8 @@ import {
   setAllEntities,
   setAllTopics,
   setAllEntityTypes,
-  fetchTaxonData
+  fetchTaxonData,
+  fetchTopicEntityTags
 } from '../../../actions/biblioActions';
 import TopicEntityTagActions from '../../AgGrid/TopicEntityTagActions.jsx';
 import ValidationByCurator from '../../AgGrid/ValidationByCurator.jsx';
@@ -296,8 +296,34 @@ const TopicEntityTable = () => {
   const filteredTags = useSelector((state) => state.biblio.filteredTags);
   const biblioUpdatingEntityAdd = useSelector((state) => state.biblio.biblioUpdatingEntityAdd);
 
-  const [topicEntityTags, setTopicEntityTags] = useState([]);
-  const [isLoadingData, setIsLoadingData] = useState(false);
+  // Topic entity tags are loaded into the redux store (shared with the entity
+  // counts summary and any other reference-based page). Consume them here
+  // rather than fetching a second copy.
+  const rawTopicEntityTags = useSelector((state) => state.biblio.topicEntityTags);
+  const isLoadingData = useSelector((state) => state.biblio.topicEntityTagsLoading);
+
+  // Apply the table's display transforms without mutating the redux state.
+  const topicEntityTags = useMemo(
+    () =>
+      (rawTopicEntityTags || []).map((orig) => {
+        const row = { ...orig };
+        if ('validation_by_author' in row) {
+          if (row.validation_by_author === 'validated_right_self') row.validation_by_author = '';
+          else if (row.validation_by_author === 'validated_right') row.validation_by_author = 'agree';
+          else if (row.validation_by_author === 'validated_wrong') row.validation_by_author = 'disagree';
+          else if (row.validation_by_author === 'not_validated') row.validation_by_author = 'no entry';
+        }
+        if ('validation_by_professional_biocurator' in row) {
+          if (row.validation_by_professional_biocurator === 'validated_right_self') {
+            row.validation_by_professional_biocurator = '';
+          }
+        }
+        row.no_data = row.negated === true ? 'no data' : '';
+        row.has_data = row.negated === true ? 'N' : 'Y';
+        return row;
+      }),
+    [rawTopicEntityTags]
+  );
 
   const [selectedCurie, setSelectedCurie] = useState(null);
   const [showCurieModal, setShowCurieModal] = useState(false);
@@ -333,52 +359,27 @@ const TopicEntityTable = () => {
 
   const getGridApi = useCallback(() => apiRef.current || gridRef.current?.api || null, []);
 
-  const fetchTableData = useCallback(async () => {
-    const url = '/topic_entity_tag/by_reference/' + referenceCurie + '?page=1&page_size=8000';
-
-    setIsLoadingData(true);
-    try {
-      const result = await api.get(url);
-
-      (result.data || []).forEach((row) => {
-        if ('validation_by_author' in row) {
-          if (row.validation_by_author === 'validated_right_self') row.validation_by_author = '';
-          else if (row.validation_by_author === 'validated_right') row.validation_by_author = 'agree';
-          else if (row.validation_by_author === 'validated_wrong') row.validation_by_author = 'disagree';
-          else if (row.validation_by_author === 'not_validated') row.validation_by_author = 'no entry';
-        }
-        if ('validation_by_professional_biocurator' in row) {
-          if (row.validation_by_professional_biocurator === 'validated_right_self') {
-            row.validation_by_professional_biocurator = '';
-          }
-        }
-        row.no_data = row.negated === true ? 'no data' : '';
-        row.has_data = row.negated === true ? 'N' : 'Y';
-      });
-
-      setTopicEntityTags(result.data || []);
-
-      const uniqueSpecies = [...new Set((result.data || []).map((o) => o.species))];
-      const uniqueEntityTypes = [...new Set((result.data || []).map((o) => o.entity_type_name))];
-      const uniqueTopics = [...new Set((result.data || []).map((o) => o.topic_name))];
-      const uniqueEntities = [...new Set((result.data || []).map((o) => o.entity_name))];
-
-      dispatch(setAllSpecies(uniqueSpecies));
-      dispatch(setAllEntityTypes(uniqueEntityTypes));
-      dispatch(setAllTopics(uniqueTopics));
-      dispatch(setAllEntities(uniqueEntities));
-    } catch (err) {
-      console.error('Error fetching topic_entity_tag:', err);
-    } finally {
-      setIsLoadingData(false);
-    }
-  }, [dispatch, referenceCurie]);
-
+  // Ensure the store has the tags for this reference. On initial load this is a
+  // no-op when Biblio already populated the cache; force a refresh only after an
+  // add/edit completes (biblioUpdatingEntityAdd transitions back to 0).
+  const prevUpdatingRef = useRef(biblioUpdatingEntityAdd);
   useEffect(() => {
-    if (biblioUpdatingEntityAdd === 0) {
-      fetchTableData();
+    if (referenceCurie && biblioUpdatingEntityAdd === 0) {
+      const justFinishedUpdate = prevUpdatingRef.current > 0;
+      dispatch(fetchTopicEntityTags(referenceCurie, justFinishedUpdate));
     }
-  }, [fetchTableData, biblioUpdatingEntityAdd]);
+    prevUpdatingRef.current = biblioUpdatingEntityAdd;
+  }, [dispatch, referenceCurie, biblioUpdatingEntityAdd]);
+
+  // Keep the shared unique-value lists (used by the column filters) in sync with
+  // the loaded tags.
+  useEffect(() => {
+    const tags = rawTopicEntityTags || [];
+    dispatch(setAllSpecies([...new Set(tags.map((o) => o.species))]));
+    dispatch(setAllEntityTypes([...new Set(tags.map((o) => o.entity_type_name))]));
+    dispatch(setAllTopics([...new Set(tags.map((o) => o.topic_name))]));
+    dispatch(setAllEntities([...new Set(tags.map((o) => o.entity_name))]));
+  }, [dispatch, rawTopicEntityTags]);
 
   const handleCurieClick = (curie) => {
     if (hasTextSelection()) return;

--- a/src/reducers/biblioReducer.js
+++ b/src/reducers/biblioReducer.js
@@ -39,6 +39,9 @@ const initialState = {
   referenceJsonHasChange: {},
   referenceFiles: [],
   referenceFilesLoading: false,
+  topicEntityTags: [],
+  topicEntityTagsLoading: false,
+  topicEntityTagsCurie: '',
   // loadingQuery: true,
   isLoading: true,
   queryFailure: false,
@@ -312,6 +315,20 @@ export default function(state = initialState, action) {
       return {
         ...state,
         referenceFilesLoading: action.payload
+      }
+
+    case 'SET_TOPIC_ENTITY_TAGS':
+      return {
+        ...state,
+        topicEntityTags: action.payload.tags,
+        topicEntityTagsCurie: action.payload.referenceCurie,
+        topicEntityTagsLoading: false
+      }
+
+    case 'SET_TOPIC_ENTITY_TAGS_LOADING':
+      return {
+        ...state,
+        topicEntityTagsLoading: action.payload
       }
 
     case 'SET_BIBLIO_EDITOR_MODAL_TEXT':
@@ -947,6 +964,9 @@ export default function(state = initialState, action) {
         referenceCurie: action.payload,
         referenceFiles: [],
         referenceFilesLoading: false,
+        topicEntityTags: [],
+        topicEntityTagsLoading: false,
+        topicEntityTagsCurie: '',
         tetPageSize: defaultTetPageSize,
         allSpecies: [],
         allEntities: [],


### PR DESCRIPTION
Add EntityCountsByMod, a reusable component that shows the unique entity count by entity type and MOD (from secondary data provider) for a reference, with no distinction between manual and automated tags. It lists only MODs with associated entities, only entity types with count > 0, sorted alphabetically. Placed in the workflow and topic/entity editors and kept self-contained for future reuse (biblio display, etc.).

Load topic entity tags into the redux store on any reference-based (Biblio) page so the summary and other consumers can reuse them. Refactor TopicEntityTable to consume the store instead of fetching its own copy, applying display transforms via a memo without mutating redux state, and force-refreshing only after an add/edit completes.