### PR TITLE
Speed up Search topic grid display 

### DIFF
--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -250,8 +250,13 @@ export default function TetValidationGrid({
   //    falls outside the selected [min, max] range, matching the backend nested
   //    range query. TETs without a numeric score (e.g. curator/author tags) are
   //    kept, since the slider targets scored ML/automated predictions.
-  // Filtering once here keeps every per-topic column (Sources / Data / Conf /
-  // Note) consistent, since they all iterate row.tets.
+  // This filters row.tets, which backs the Validation column and -- on the
+  // older-backend fallback path -- the per-topic cells too (they rebuild their
+  // mini-rows from row.tets via buildEntries). On the server-aggregated path the
+  // per-topic columns render row.entries instead, which the batch endpoint has
+  // already filtered with the SAME criteria (negated_confidence_levels +
+  // confidence_score range, both keeping unscored tags), so entries stay
+  // consistent with the filtered row.tets without re-filtering here.
   const excludedConfLevelSet = useMemo(
     () =>
       new Set(

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -175,6 +175,7 @@ export default function TetValidationGrid({
   excludedConfidenceLevels,
   confidenceScore,
   biblioByCurie,
+  searchFilters,
   active = true,
   persistRef,
 }) {
@@ -235,7 +236,8 @@ export default function TetValidationGrid({
   const { rows: rawRows, unresolved, loading, refetchRow } = useReferenceTets(
     referenceIds,
     biblioByCurie,
-    active
+    active,
+    searchFilters
   );
 
   // Honor the search's confidence filters in the grid. The grid fetches TETs

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -377,8 +377,17 @@ export default function TetValidationGrid({
 
   const allSources = useMemo(() => {
     const s = new Set();
-    for (const r of rows)
-      for (const t of r.tets || []) s.add(sourceLabel(t.topic_entity_tag_source));
+    for (const r of rows) {
+      const entries = r.entries ? Object.values(r.entries).flat() : [];
+      if (entries.length > 0) {
+        entries.forEach((entry) => {
+          const label = entry.sourceLabel || entry.source_label;
+          if (label) s.add(label);
+        });
+      } else {
+        for (const t of r.tets || []) s.add(sourceLabel(t.topic_entity_tag_source));
+      }
+    }
     return [...s].sort();
   }, [rows]);
 
@@ -874,14 +883,16 @@ export default function TetValidationGrid({
     const confidenceLevels = new Set();
 
     for (const row of rows) {
+      const rowEntries = row.entries ? Object.values(row.entries).flat() : null;
+      const rowCellValue = { tets: row.tets || [], entries: rowEntries };
       innerColumnFilterValues(
         INNER_COLUMN_TYPES.SOURCES,
-        row.tets || [],
+        rowCellValue,
         sourceFilterModel
       ).forEach((value) => sources.add(value));
       innerColumnFilterValues(
         INNER_COLUMN_TYPES.CONF_LEVEL,
-        row.tets || [],
+        rowCellValue,
         sourceFilterModel
       ).forEach((value) => confidenceLevels.add(value));
     }
@@ -902,7 +913,13 @@ export default function TetValidationGrid({
           const flat = [];
           const bySrc = grouped.get(t.curie);
           if (bySrc) for (const arr of bySrc.values()) flat.push(...arr);
-          cells[`__topic_${t.curie}`] = flat;
+          const hasServerEntries = !!r.entries &&
+            Object.prototype.hasOwnProperty.call(r.entries, t.curie);
+          cells[`__topic_${t.curie}`] = {
+            tets: flat,
+            entries: hasServerEntries ? (r.entries[t.curie] || []) : null,
+            counts: r.counts?.[t.curie] || {},
+          };
         }
         return {
           input: r.input,

--- a/src/components/refs_tet_validation/cellRenderers/ConfLevelCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/ConfLevelCell.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { buildEntries } from '../helpers/buildEntries';
+import { cellEntries } from '../helpers/buildEntries';
 import EvidencePanels from './EvidencePanels';
 
 function renderConfLevelEntry(e) {
@@ -7,7 +7,24 @@ function renderConfLevelEntry(e) {
     return (
       <div className="tetv-mini-row" key={e.key}>
         <span className="tetv-attr-value">
-          {e.tets[0].confidence_level || '–'}
+          {e.tets?.[0]?.confidence_level || e.confidence_level || '–'}
+        </span>
+      </div>
+    );
+  }
+  if (e.aggregated) {
+    const levels = e.confidence_levels || [];
+    if (levels.length === 0) {
+      return (
+        <div className="tetv-mini-row" key={e.key}>
+          <span className="tetv-attr-value">–</span>
+        </div>
+      );
+    }
+    return (
+      <div className="tetv-mini-row" key={e.key}>
+        <span className="tetv-attr-value" title={levels.join(', ')}>
+          {levels.length === 1 ? levels[0] : `(${levels.length} levels)`}
         </span>
       </div>
     );
@@ -37,11 +54,10 @@ function renderConfLevelEntry(e) {
 }
 
 export default function ConfLevelCell(params) {
-  const tets = params.value || [];
   const { sourceFilterModel } = params.colDef.cellRendererParams || {};
   const entries = useMemo(
-    () => buildEntries(tets, sourceFilterModel),
-    [tets, sourceFilterModel]
+    () => cellEntries(params.value, sourceFilterModel),
+    [params.value, sourceFilterModel]
   );
   return (
     <div className="tetv-attr-cell">

--- a/src/components/refs_tet_validation/cellRenderers/ConfScoreCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/ConfScoreCell.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { buildEntries } from '../helpers/buildEntries';
+import { cellEntries } from '../helpers/buildEntries';
 import EvidencePanels from './EvidencePanels';
 
 function fmt(v) {
@@ -12,7 +12,29 @@ function renderConfScoreEntry(e) {
     return (
       <div className="tetv-mini-row" key={e.key}>
         <span className="tetv-attr-value">
-          {fmt(e.tets[0].confidence_score)}
+          {fmt(e.tets?.[0]?.confidence_score ?? e.confidence_score)}
+        </span>
+      </div>
+    );
+  }
+  if (e.aggregated) {
+    const min = e.confidence_score_min;
+    const max = e.confidence_score_max;
+    const count = e.confidence_score_count || 0;
+    if (count === 0) {
+      return (
+        <div className="tetv-mini-row" key={e.key}>
+          <span className="tetv-attr-value">–</span>
+        </div>
+      );
+    }
+    return (
+      <div className="tetv-mini-row" key={e.key}>
+        <span
+          className="tetv-attr-value"
+          title={`${count} values, min ${fmt(min)} / max ${fmt(max)}`}
+        >
+          {min === max ? fmt(min) : `${fmt(min)}–${fmt(max)}`}
         </span>
       </div>
     );
@@ -44,11 +66,10 @@ function renderConfScoreEntry(e) {
 }
 
 export default function ConfScoreCell(params) {
-  const tets = params.value || [];
   const { sourceFilterModel } = params.colDef.cellRendererParams || {};
   const entries = useMemo(
-    () => buildEntries(tets, sourceFilterModel),
-    [tets, sourceFilterModel]
+    () => cellEntries(params.value, sourceFilterModel),
+    [params.value, sourceFilterModel]
   );
   return (
     <div className="tetv-attr-cell">

--- a/src/components/refs_tet_validation/cellRenderers/NoteCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/NoteCell.jsx
@@ -2,100 +2,106 @@ import React, { useMemo, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faStickyNote } from '@fortawesome/free-solid-svg-icons';
 import NoteModal from './NoteModal';
-import { buildEntries } from '../helpers/buildEntries';
+import { cellEntries } from '../helpers/buildEntries';
 import EvidencePanels from './EvidencePanels';
 
 export default function NoteCell(params) {
-  const tets = params.value || [];
   const { displayOptions, sourceFilterModel } =
     params.colDef.cellRendererParams || {};
   const expand = !!displayOptions?.inlineNote;
 
   const entries = useMemo(
-    () => buildEntries(tets, sourceFilterModel),
-    [tets, sourceFilterModel]
+    () => cellEntries(params.value, sourceFilterModel),
+    [params.value, sourceFilterModel]
   );
 
   const [modal, setModal] = useState(null); // { title, body } | null
 
   const renderEntry = (e) => {
-        if (e.kind === 'topic') {
-          const t = e.tets[0];
-          const note = t.note;
-          if (!note) {
-            return (
-              <div className="tetv-mini-row" key={e.key}>
-                <span className="tetv-attr-value">–</span>
-              </div>
-            );
-          }
-          return (
-            <div className="tetv-mini-row" key={e.key}>
-              {expand && (
-                <span className="tetv-inline-note" title={note}>
-                  {note}
-                </span>
-              )}
-              <button
-                type="button"
-                className="tetv-note-btn"
-                onClick={() => setModal({ title: e.sourceLabel, body: note })}
-                title="View full note"
-              >
-                <FontAwesomeIcon icon={faStickyNote} />
-              </button>
-            </div>
-          );
-        }
-        // entity-collapsed: list notes (one per entity that has one)
-        const noted = e.tets
-          .map((t) => ({
-            entity: t.entity_name || t.entity,
-            note: t.note,
-          }))
-          .filter((x) => x.note);
-        if (noted.length === 0) {
-          return (
-            <div className="tetv-mini-row" key={e.key}>
-              <span className="tetv-attr-value">–</span>
-            </div>
-          );
-        }
-        const body = noted
-          .map((x) => `${x.entity || '(no entity)'}: ${x.note}`)
-          .join('\n\n');
+    if (e.kind === 'topic') {
+      const t = e.tets?.[0] || e;
+      const note = t.note;
+      if (!note) {
         return (
           <div className="tetv-mini-row" key={e.key}>
-            {expand && (
-              <span className="tetv-inline-note" title={body}>
-                {noted.map((x, i) => (
-                  <span key={i} className="tetv-inline-note-line">
-                    <span className="tetv-inline-note-entity">
-                      {x.entity || '(no entity)'}:
-                    </span>{' '}
-                    {x.note}
-                  </span>
-                ))}
-              </span>
-            )}
-            <button
-              type="button"
-              className="tetv-note-btn"
-              onClick={() =>
-                setModal({
-                  title: `${e.sourceLabel} — ${noted.length} note${noted.length === 1 ? '' : 's'}`,
-                  body,
-                })
-              }
-              title={`${noted.length} note${noted.length === 1 ? '' : 's'}`}
-            >
-              <FontAwesomeIcon icon={faStickyNote} />
-              {noted.length > 1 && (
-                <span className="tetv-note-count"> {noted.length}</span>
-              )}
-            </button>
+            <span className="tetv-attr-value">–</span>
           </div>
         );
+      }
+      return (
+        <div className="tetv-mini-row" key={e.key}>
+          {expand && (
+            <span className="tetv-inline-note" title={note}>
+              {note}
+            </span>
+          )}
+          <button
+            type="button"
+            className="tetv-note-btn"
+            onClick={() =>
+              setModal({ title: e.sourceLabel || e.source_label, body: note })
+            }
+            title="View full note"
+          >
+            <FontAwesomeIcon icon={faStickyNote} />
+          </button>
+        </div>
+      );
+    }
+
+    // entity-collapsed: list notes (one per entity that has one)
+    const noted = e.notes ||
+      (e.tets || [])
+        .map((t) => ({
+          entity: t.entity_name || t.entity,
+          note: t.note,
+        }))
+        .filter((x) => x.note);
+    if (noted.length === 0) {
+      return (
+        <div className="tetv-mini-row" key={e.key}>
+          <span className="tetv-attr-value">–</span>
+        </div>
+      );
+    }
+
+    const body = noted
+      .map((x) => `${x.entity || '(no entity)'}: ${x.note}`)
+      .join('\n\n');
+    const sourceTitle = e.sourceLabel || e.source_label;
+    const noteLabel = `${noted.length} note${noted.length === 1 ? '' : 's'}`;
+    return (
+      <div className="tetv-mini-row" key={e.key}>
+        {expand && (
+          <span className="tetv-inline-note" title={body}>
+            {noted.map((x, i) => (
+              <span key={i} className="tetv-inline-note-line">
+                <span className="tetv-inline-note-entity">
+                  {x.entity || '(no entity)'}:
+                </span>{' '}
+                {x.note}
+              </span>
+            ))}
+          </span>
+        )}
+        <button
+          type="button"
+          className="tetv-note-btn"
+          onClick={() =>
+            setModal({
+              title: `${sourceTitle} — ${noteLabel}`,
+              body,
+            })
+          }
+          title={noteLabel}
+        >
+          <FontAwesomeIcon icon={faStickyNote} />
+          {noted.length > 1 && (
+            <span className="tetv-note-count"> {noted.length}</span>
+          )}
+        </button>
+      </div>
+    );
   };
 
   return (

--- a/src/components/refs_tet_validation/cellRenderers/SourcesCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/SourcesCell.jsx
@@ -1,13 +1,12 @@
 import React, { useMemo } from 'react';
-import { buildEntries } from '../helpers/buildEntries';
+import { cellEntries } from '../helpers/buildEntries';
 import EvidencePanels from './EvidencePanels';
 
 export default function SourcesCell(params) {
-  const tets = params.value;
   const { sourceFilterModel } = params.colDef.cellRendererParams || {};
   const entries = useMemo(
-    () => buildEntries(tets || [], sourceFilterModel),
-    [tets, sourceFilterModel]
+    () => cellEntries(params.value, sourceFilterModel),
+    [params.value, sourceFilterModel]
   );
 
   return (
@@ -17,17 +16,20 @@ export default function SourcesCell(params) {
         showTitles
         renderEntry={(e) => {
           const description =
-            e.tets?.[0]?.topic_entity_tag_source?.description || null;
+            e.source_description ||
+            e.tets?.[0]?.topic_entity_tag_source?.description ||
+            null;
+          const label = e.sourceLabel || e.source_label;
           return (
             <div className="tetv-mini-row" key={e.key}>
               <span
                 className="tetv-source-label"
                 title={
                   description ||
-                  `${e.sourceLabel} — no description provided for this source`
+                  `${label} — no description provided for this source`
                 }
               >
-                {e.sourceLabel}
+                {label}
               </span>
             </div>
           );

--- a/src/components/refs_tet_validation/cellRenderers/TagsCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/TagsCell.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { buildEntries } from '../helpers/buildEntries';
+import { cellEntries } from '../helpers/buildEntries';
 import EvidencePanels from './EvidencePanels';
 
 function PillTopic({ tet }) {
@@ -32,11 +32,10 @@ function entityLabel(t) {
 }
 
 export default function TagsCell(params) {
-  const tets = params.value;
   const { sourceFilterModel } = params.colDef.cellRendererParams || {};
   const entries = useMemo(
-    () => buildEntries(tets || [], sourceFilterModel),
-    [tets, sourceFilterModel]
+    () => cellEntries(params.value, sourceFilterModel),
+    [params.value, sourceFilterModel]
   );
 
   return (
@@ -46,20 +45,21 @@ export default function TagsCell(params) {
         renderEntry={(e) => (
           <div className="tetv-mini-row tetv-tag-row" key={e.key}>
             {e.kind === 'topic' ? (
-              <PillTopic tet={e.tets[0]} />
+              <PillTopic tet={e.tets?.[0] || e} />
             ) : (
               <PillEntityCount
-                count={e.tets.length}
+                count={e.count || (e.tets || []).length}
                 negated={e.kind === 'entity-neg'}
                 entitiesText={
-                  e.tets
+                  e.entities_text ||
+                  ((e.tets || [])
                     .slice(0, 20)
                     .map(entityLabel)
                     .filter(Boolean)
                     .join(', ') +
-                  (e.tets.length > 20
-                    ? `, ... (+${e.tets.length - 20} more)`
-                    : '')
+                    ((e.tets || []).length > 20
+                      ? `, ... (+${(e.tets || []).length - 20} more)`
+                      : ''))
                 }
               />
             )}

--- a/src/components/refs_tet_validation/cellRenderers/ValidationCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/ValidationCell.jsx
@@ -7,11 +7,14 @@ import { speciesBadgeLetter, speciesName } from '../helpers/speciesUtils';
 /** TETs from this cell that are *topic-level* and authored by a professional
  *  biocurator (i.e. count as a curator validation). */
 function professionalBiocuratorTopicTets(tets) {
-  return (tets || []).filter(isCuratorValidationTet);
+  const arr = Array.isArray(tets) ? tets : (tets?.tets || []);
+  return arr.filter(isCuratorValidationTet);
 }
 
 export default function ValidationCell(params) {
-  const tets = params.value || [];
+  const tets = Array.isArray(params.value)
+    ? params.value
+    : (params.value?.tets || []);
   const {
     topicCurie,
     topicName,

--- a/src/components/refs_tet_validation/helpers/buildEntries.js
+++ b/src/components/refs_tet_validation/helpers/buildEntries.js
@@ -24,11 +24,29 @@ export function groupEntriesByEvidence(entries) {
   const m = new Map();
   for (const e of entries || []) {
     const key =
-      e.tets?.[0]?.topic_entity_tag_source?.source_evidence_assertion || '';
+      e.source_evidence_assertion ||
+      e.tets?.[0]?.topic_entity_tag_source?.source_evidence_assertion ||
+      '';
     if (!m.has(key)) m.set(key, []);
     m.get(key).push(e);
   }
   return m;
+}
+
+export function cellTets(value) {
+  if (Array.isArray(value)) return value;
+  return value?.tets || [];
+}
+
+export function cellEntries(value, sourceFilterModel) {
+  const prebuilt = Array.isArray(value?.entries) ? value.entries : null;
+  if (prebuilt) {
+    if (!Array.isArray(sourceFilterModel)) return prebuilt;
+    return prebuilt.filter((entry) =>
+      sourceFilterModel.includes(entry.sourceLabel || entry.source_label)
+    );
+  }
+  return buildEntries(cellTets(value), sourceFilterModel);
 }
 
 /**

--- a/src/components/refs_tet_validation/helpers/buildEntries.js
+++ b/src/components/refs_tet_validation/helpers/buildEntries.js
@@ -38,11 +38,28 @@ export function cellTets(value) {
   return value?.tets || [];
 }
 
+/** Every mini-row is keyed on entry.key (React reconciliation across the
+ *  lockstep per-topic columns). buildEntries always sets key, but server-
+ *  supplied entries are passed through verbatim and an older/partial backend
+ *  could omit it, which would render sibling rows with key={undefined}. Derive a
+ *  stable fallback from the entry's own fields (kind + source + tag id), falling
+ *  back to the cell-local index only as a last resort. */
+function entryKey(entry, idx) {
+  if (entry.key != null) return entry.key;
+  const label = entry.sourceLabel || entry.source_label || '';
+  const id = entry.topic_entity_tag_id != null ? entry.topic_entity_tag_id : idx;
+  return `${entry.kind || 'entry'}-${label}-${id}`;
+}
+
 export function cellEntries(value, sourceFilterModel) {
   const prebuilt = Array.isArray(value?.entries) ? value.entries : null;
   if (prebuilt) {
-    if (!Array.isArray(sourceFilterModel)) return prebuilt;
-    return prebuilt.filter((entry) =>
+    // Guarantee a key on every server entry before any cell renders it.
+    const keyed = prebuilt.map((entry, idx) =>
+      entry.key != null ? entry : { ...entry, key: entryKey(entry, idx) }
+    );
+    if (!Array.isArray(sourceFilterModel)) return keyed;
+    return keyed.filter((entry) =>
       sourceFilterModel.includes(entry.sourceLabel || entry.source_label)
     );
   }

--- a/src/components/refs_tet_validation/helpers/groupTets.js
+++ b/src/components/refs_tet_validation/helpers/groupTets.js
@@ -15,9 +15,14 @@ export function normalizeCurie(curie) {
   return String(curie).toUpperCase();
 }
 
+function asTets(value) {
+  if (Array.isArray(value)) return value;
+  return value?.tets || [];
+}
+
 export function groupTetsByTopicAndSource(tets) {
   const byTopic = new Map();
-  for (const tet of tets || []) {
+  for (const tet of asTets(tets)) {
     const topicKey = normalizeCurie(tet.topic);
     const label = sourceLabel(tet.topic_entity_tag_source);
     if (!byTopic.has(topicKey)) byTopic.set(topicKey, new Map());
@@ -56,7 +61,7 @@ export function isCuratorValidationTet(tet) {
 }
 
 export function cellSortRank(tets) {
-  const arr = tets || [];
+  const arr = asTets(tets);
   if (arr.length === 0) return 0;
   if (arr.some((t) => t.negated === false)) return 2;
   return 1;
@@ -66,7 +71,7 @@ export function cellSortRank(tets) {
  *  professional-biocurator topic-level TETs.
  *  Returns one of: 'unvalidated' | 'positive' | 'negative' | 'conflict'. */
 export function validationState(tets) {
-  const validations = (tets || []).filter(isCuratorValidationTet);
+  const validations = asTets(tets).filter(isCuratorValidationTet);
   if (validations.length === 0) return 'unvalidated';
   const hasPos = validations.some((t) => !t.negated);
   const hasNeg = validations.some((t) => t.negated);
@@ -99,7 +104,7 @@ export const TOPIC_CELL_FILTER_KEYS = [
 
 export function cellPredicate(tets, currentUid, model) {
   if (!Array.isArray(model) || model.length === 0) return true;
-  const arr = tets || [];
+  const arr = asTets(tets);
   return model.some((key) => {
     switch (key) {
       case 'empty':

--- a/src/components/refs_tet_validation/helpers/innerColumnUtils.js
+++ b/src/components/refs_tet_validation/helpers/innerColumnUtils.js
@@ -1,4 +1,4 @@
-import { buildEntries } from './buildEntries';
+import { cellEntries, cellTets } from './buildEntries';
 import {
   VALIDATION_FILTER_KEYS,
   validationSortRank,
@@ -18,8 +18,8 @@ export const CONF_SCORE_FILTER_KEYS = ['has score', 'missing score'];
 export const NOTE_FILTER_KEYS = ['has note', 'empty'];
 export const TAG_FILTER_KEYS = ['Y', 'N', 'entity', 'entity negated', 'empty'];
 
-function visibleEntries(tets, sourceFilterModel) {
-  return buildEntries(tets, sourceFilterModel);
+function visibleEntries(value, sourceFilterModel) {
+  return cellEntries(value, sourceFilterModel);
 }
 
 function nonEmptyString(value) {
@@ -31,14 +31,21 @@ function uniqueValues(values) {
 }
 
 function visibleSourceLabels(entries) {
-  const labels = entries.map((entry) => entry.sourceLabel);
+  const labels = entries.map((entry) => entry.sourceLabel || entry.source_label);
   if (labels.length === 0) return ['empty'];
   return labels;
 }
 
 function visibleConfidenceScores(entries) {
   return entries
-    .flatMap((entry) => entry.tets.map((tet) => tet.confidence_score))
+    .flatMap((entry) => {
+      if (entry.aggregated) {
+        return entry.kind === 'topic'
+          ? [entry.confidence_score]
+          : [entry.confidence_score_min, entry.confidence_score_max];
+      }
+      return entry.tets.map((tet) => tet.confidence_score);
+    })
     .filter((value) => value !== null && value !== undefined && value !== '')
     .map(Number)
     .filter((value) => Number.isFinite(value));
@@ -46,7 +53,14 @@ function visibleConfidenceScores(entries) {
 
 function visibleConfidenceLevels(entries) {
   const levels = uniqueValues(
-    entries.flatMap((entry) => entry.tets.map((tet) => tet.confidence_level))
+    entries.flatMap((entry) => {
+      if (entry.aggregated) {
+        return entry.kind === 'topic'
+          ? [entry.confidence_level]
+          : (entry.confidence_levels || []);
+      }
+      return entry.tets.map((tet) => tet.confidence_level);
+    })
   );
   if (levels.length === 0) return ['empty'];
   return levels;
@@ -55,7 +69,10 @@ function visibleConfidenceLevels(entries) {
 function visibleTagLabels(entries) {
   const labels = entries.map((entry) => {
     if (entry.kind === 'topic') {
-      return entry.tets[0]?.negated === true ? 'N' : 'Y';
+      const negated = entry.aggregated
+        ? entry.negated
+        : entry.tets[0]?.negated;
+      return negated === true ? 'N' : 'Y';
     }
     return entry.kind === 'entity-neg' ? 'entity negated' : 'entity';
   });
@@ -65,7 +82,14 @@ function visibleTagLabels(entries) {
 
 function visibleNotes(entries) {
   return uniqueValues(
-    entries.flatMap((entry) => entry.tets.map((tet) => tet.note))
+    entries.flatMap((entry) => {
+      if (entry.aggregated) {
+        return entry.kind === 'topic'
+          ? [entry.note]
+          : (entry.notes || []).map((note) => note.note);
+      }
+      return entry.tets.map((tet) => tet.note);
+    })
   );
 }
 
@@ -82,10 +106,11 @@ function compareNullableStrings(a, b) {
 
 export function innerColumnFilterValues(kind, tets, sourceFilterModel) {
   const entries = visibleEntries(tets, sourceFilterModel);
+  const rawTets = cellTets(tets);
 
   switch (kind) {
     case INNER_COLUMN_TYPES.VALIDATION:
-      return [validationState(tets)];
+      return [validationState(rawTets)];
     case INNER_COLUMN_TYPES.TAG:
       return uniqueValues(visibleTagLabels(entries));
     case INNER_COLUMN_TYPES.SOURCES:
@@ -120,12 +145,13 @@ export function innerColumnPassesFilter(
 
 export function innerColumnSortMeta(kind, tets, sourceFilterModel) {
   const entries = visibleEntries(tets, sourceFilterModel);
+  const rawTets = cellTets(tets);
 
   switch (kind) {
     case INNER_COLUMN_TYPES.VALIDATION: {
-      const state = validationState(tets);
+      const state = validationState(rawTets);
       return {
-        rank: validationSortRank(tets),
+        rank: validationSortRank(rawTets),
         text: state,
       };
     }

--- a/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
+++ b/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
@@ -96,37 +96,75 @@ describe('fetchTets', () => {
 });
 
 describe('fetchTetsBatch', () => {
-  test('no curies → no request, empty map', async () => {
+  test('no curies → no request, empty tags/counts', async () => {
     const out = await fetchTetsBatch([]);
-    expect(out).toEqual({});
+    expect(out).toEqual({ tags: {}, counts: {} });
     expect(api.post).not.toHaveBeenCalled();
   });
 
-  test('posts curies to /by_references and returns the map', async () => {
+  test('posts curies (no filters) to /by_references and returns tags + counts', async () => {
     api.post.mockResolvedValueOnce({
       data: {
-        'AGRKB:1': [{ topic_entity_tag_id: 1 }],
-        'AGRKB:2': [],
+        tags: {
+          'AGRKB:1': [{ topic_entity_tag_id: 1 }],
+          'AGRKB:2': [],
+        },
+        counts: {
+          'AGRKB:1': { 'ATP:1': { entity_pos: 1, total: 1 } },
+          'AGRKB:2': {},
+        },
       },
     });
     const out = await fetchTetsBatch(['AGRKB:1', 'AGRKB:2']);
-    expect(api.post).toHaveBeenCalledWith(
-      '/topic_entity_tag/by_references',
-      ['AGRKB:1', 'AGRKB:2']
-    );
-    expect(out['AGRKB:1']).toHaveLength(1);
-    expect(out['AGRKB:2']).toEqual([]);
+    expect(api.post).toHaveBeenCalledWith('/topic_entity_tag/by_references', {
+      curies_or_reference_ids: ['AGRKB:1', 'AGRKB:2'],
+    });
+    expect(out.tags['AGRKB:1']).toHaveLength(1);
+    expect(out.tags['AGRKB:2']).toEqual([]);
+    expect(out.counts['AGRKB:1']).toEqual({ 'ATP:1': { entity_pos: 1, total: 1 } });
+    expect(out.counts['AGRKB:2']).toEqual({});
+  });
+
+  test('sends only non-empty filters in the request body', async () => {
+    api.post.mockResolvedValueOnce({ data: { tags: {}, counts: {} } });
+    await fetchTetsBatch(['AGRKB:1'], {
+      topics: ['ATP:0000122'],
+      confidence_levels: [],
+      negated_confidence_levels: ['NEG'],
+      confidence_score_min: 0.5,
+      confidence_score_max: 1,
+      data_novelty: null,
+    });
+    expect(api.post).toHaveBeenCalledWith('/topic_entity_tag/by_references', {
+      curies_or_reference_ids: ['AGRKB:1'],
+      filters: {
+        topics: ['ATP:0000122'],
+        negated_confidence_levels: ['NEG'],
+        confidence_score_min: 0.5,
+        confidence_score_max: 1,
+      },
+    });
+  });
+
+  test('tolerates an older backend returning a bare { curie: tets[] } map', async () => {
+    api.post.mockResolvedValueOnce({
+      data: { 'AGRKB:1': [{ topic_entity_tag_id: 1 }] },
+    });
+    const out = await fetchTetsBatch(['AGRKB:1']);
+    expect(out.tags['AGRKB:1']).toEqual([{ topic_entity_tag_id: 1 }]);
+    expect(out.counts['AGRKB:1']).toEqual({});
   });
 
   test('dedupes curies and defaults missing keys to empty arrays', async () => {
-    api.post.mockResolvedValueOnce({ data: { 'AGRKB:1': [{ x: 1 }] } });
+    api.post.mockResolvedValueOnce({
+      data: { tags: { 'AGRKB:1': [{ x: 1 }] }, counts: {} },
+    });
     const out = await fetchTetsBatch(['AGRKB:1', 'AGRKB:1', 'AGRKB:3']);
-    expect(api.post).toHaveBeenCalledWith(
-      '/topic_entity_tag/by_references',
-      ['AGRKB:1', 'AGRKB:3']
-    );
-    expect(out['AGRKB:1']).toEqual([{ x: 1 }]);
-    expect(out['AGRKB:3']).toEqual([]); // present in request, absent in response
+    expect(api.post).toHaveBeenCalledWith('/topic_entity_tag/by_references', {
+      curies_or_reference_ids: ['AGRKB:1', 'AGRKB:3'],
+    });
+    expect(out.tags['AGRKB:1']).toEqual([{ x: 1 }]);
+    expect(out.tags['AGRKB:3']).toEqual([]); // present in request, absent in response
   });
 
   test('falls back to per-reference GET when batch endpoint fails', async () => {
@@ -135,8 +173,9 @@ describe('fetchTetsBatch', () => {
       .mockResolvedValueOnce({ data: [{ topic_entity_tag_id: 11 }] })
       .mockResolvedValueOnce({ data: [{ topic_entity_tag_id: 22 }] });
     const out = await fetchTetsBatch(['AGRKB:1', 'AGRKB:2']);
-    expect(out['AGRKB:1']).toEqual([{ topic_entity_tag_id: 11 }]);
-    expect(out['AGRKB:2']).toEqual([{ topic_entity_tag_id: 22 }]);
+    expect(out.tags['AGRKB:1']).toEqual([{ topic_entity_tag_id: 11 }]);
+    expect(out.tags['AGRKB:2']).toEqual([{ topic_entity_tag_id: 22 }]);
+    expect(out.counts['AGRKB:1']).toEqual({});
     expect(api.get).toHaveBeenCalledWith(
       '/topic_entity_tag/by_reference/AGRKB:1?page=1&page_size=8000'
     );

--- a/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
+++ b/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
@@ -96,13 +96,13 @@ describe('fetchTets', () => {
 });
 
 describe('fetchTetsBatch', () => {
-  test('no curies → no request, empty tags/counts', async () => {
+  test('no curies → no request, empty tags/counts/entries', async () => {
     const out = await fetchTetsBatch([]);
-    expect(out).toEqual({ tags: {}, counts: {} });
+    expect(out).toEqual({ tags: {}, counts: {}, entries: {} });
     expect(api.post).not.toHaveBeenCalled();
   });
 
-  test('posts curies (no filters) to /by_references and returns tags + counts', async () => {
+  test('posts curies (no filters) to /by_references and returns tags + counts + entries', async () => {
     api.post.mockResolvedValueOnce({
       data: {
         tags: {
@@ -111,6 +111,10 @@ describe('fetchTetsBatch', () => {
         },
         counts: {
           'AGRKB:1': { 'ATP:1': { entity_pos: 1, total: 1 } },
+          'AGRKB:2': {},
+        },
+        entries: {
+          'AGRKB:1': { 'ATP:1': [{ kind: 'entity-pos', count: 1 }] },
           'AGRKB:2': {},
         },
       },
@@ -123,6 +127,8 @@ describe('fetchTetsBatch', () => {
     expect(out.tags['AGRKB:2']).toEqual([]);
     expect(out.counts['AGRKB:1']).toEqual({ 'ATP:1': { entity_pos: 1, total: 1 } });
     expect(out.counts['AGRKB:2']).toEqual({});
+    expect(out.entries['AGRKB:1']).toEqual({ 'ATP:1': [{ kind: 'entity-pos', count: 1 }] });
+    expect(out.entries['AGRKB:2']).toEqual({});
   });
 
   test('sends only non-empty filters in the request body', async () => {
@@ -133,6 +139,8 @@ describe('fetchTetsBatch', () => {
       negated_confidence_levels: ['NEG'],
       confidence_score_min: 0.5,
       confidence_score_max: 1,
+      entity_types: ['ATP:0000005'],
+      entities: [],
       data_novelty: null,
     });
     expect(api.post).toHaveBeenCalledWith('/topic_entity_tag/by_references', {
@@ -142,6 +150,7 @@ describe('fetchTetsBatch', () => {
         negated_confidence_levels: ['NEG'],
         confidence_score_min: 0.5,
         confidence_score_max: 1,
+        entity_types: ['ATP:0000005'],
       },
     });
   });
@@ -153,6 +162,7 @@ describe('fetchTetsBatch', () => {
     const out = await fetchTetsBatch(['AGRKB:1']);
     expect(out.tags['AGRKB:1']).toEqual([{ topic_entity_tag_id: 1 }]);
     expect(out.counts['AGRKB:1']).toEqual({});
+    expect(out.entries['AGRKB:1']).toBeNull();
   });
 
   test('dedupes curies and defaults missing keys to empty arrays', async () => {
@@ -165,6 +175,7 @@ describe('fetchTetsBatch', () => {
     });
     expect(out.tags['AGRKB:1']).toEqual([{ x: 1 }]);
     expect(out.tags['AGRKB:3']).toEqual([]); // present in request, absent in response
+    expect(out.entries['AGRKB:3']).toEqual({});
   });
 
   test('falls back to per-reference GET when batch endpoint fails', async () => {
@@ -176,6 +187,7 @@ describe('fetchTetsBatch', () => {
     expect(out.tags['AGRKB:1']).toEqual([{ topic_entity_tag_id: 11 }]);
     expect(out.tags['AGRKB:2']).toEqual([{ topic_entity_tag_id: 22 }]);
     expect(out.counts['AGRKB:1']).toEqual({});
+    expect(out.entries['AGRKB:1']).toBeNull();
     expect(api.get).toHaveBeenCalledWith(
       '/topic_entity_tag/by_reference/AGRKB:1?page=1&page_size=8000'
     );

--- a/src/components/refs_tet_validation/hooks/useReferenceTets.js
+++ b/src/components/refs_tet_validation/hooks/useReferenceTets.js
@@ -92,18 +92,42 @@ export async function fetchTets(curie) {
   }
 }
 
+// Drop empty arrays/objects so we don't send "topics: []" etc. — the API treats
+// an omitted/empty field as "no restriction", but keeping the payload lean also
+// avoids re-fetches keyed on noise.
+function compactFilters(filters) {
+  if (!filters || typeof filters !== 'object') return undefined;
+  const out = {};
+  for (const [k, v] of Object.entries(filters)) {
+    if (v == null) continue;
+    if (Array.isArray(v)) {
+      if (v.length > 0) out[k] = v;
+    } else {
+      out[k] = v;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 /**
  * Fetch TETs for many references in one round-trip via POST
- * /topic_entity_tag/by_references, which returns a { curie: tets[] } map.
- * Chunked so a very large page doesn't become one huge request. Falls back to
- * per-reference GETs if the batch endpoint is unavailable (e.g. older backend),
- * so the grid keeps working either way.
+ * /topic_entity_tag/by_references, which returns { tags: {curie: tets[]},
+ * counts: {curie: {topic: {...}}} }. `filters` carries the initial search's TET
+ * facet criteria so the API returns ONLY the tags the search asked for (the main
+ * fix for the slow grid load). Chunked so a very large page doesn't become one
+ * huge request. Falls back to per-reference GETs if the batch endpoint is
+ * unavailable (e.g. older backend) — the fallback can't filter server-side, so
+ * the grid's own client-side filters still apply on that path.
+ *
+ * Returns { tags: {curie: tets[]}, counts: {curie: {topic: {...}}} }.
  */
-export async function fetchTetsBatch(curies) {
+export async function fetchTetsBatch(curies, filters) {
   const totalStart = performance.now();
-  const result = {};
+  const tags = {};
+  const counts = {};
   const unique = Array.from(new Set((curies || []).filter(Boolean)));
-  if (unique.length === 0) return result;
+  if (unique.length === 0) return { tags, counts };
+  const compactedFilters = compactFilters(filters);
   const groups = chunk(unique, TETS_BATCH_SIZE);
   debug.log(
     `[TetValidationGrid] TET batch fetch start: ${unique.length} references in ${groups.length} request(s)`
@@ -117,13 +141,27 @@ export async function fetchTetsBatch(curies) {
         // all, and on persistent 5xx/timeout we'd rather fall back quickly than
         // burn the full ~60s backoff. The fallback path keeps its own retries.
         const r = await withBackoff(
-          () => api.post('/topic_entity_tag/by_references', group),
+          () =>
+            api.post('/topic_entity_tag/by_references', {
+              curies_or_reference_ids: group,
+              ...(compactedFilters ? { filters: compactedFilters } : {}),
+            }),
           { delays: [500] }
         );
-        const data = r.data && typeof r.data === 'object' ? r.data : {};
-        for (const c of group) result[c] = data[c] || [];
-        const tetCount = Object.values(data).reduce(
-          (sum, tets) => sum + (Array.isArray(tets) ? tets.length : 0),
+        // New shape: { tags, counts }. Tolerate an older backend that returns a
+        // bare { curie: tets[] } map so a deploy-order mismatch degrades to
+        // "tags only" rather than an error.
+        const body = r.data && typeof r.data === 'object' ? r.data : {};
+        const tagMap =
+          body.tags && typeof body.tags === 'object' ? body.tags : body;
+        const countMap =
+          body.counts && typeof body.counts === 'object' ? body.counts : {};
+        for (const c of group) {
+          tags[c] = tagMap[c] || [];
+          counts[c] = countMap[c] || {};
+        }
+        const tetCount = group.reduce(
+          (sum, c) => sum + (Array.isArray(tags[c]) ? tags[c].length : 0),
           0
         );
         debug.log(
@@ -138,11 +176,12 @@ export async function fetchTetsBatch(curies) {
         );
         await Promise.all(
           group.map(async (c) => {
-            result[c] = await fetchTets(c);
+            tags[c] = await fetchTets(c);
+            counts[c] = {};
           })
         );
         const fallbackCount = group.reduce(
-          (sum, c) => sum + (Array.isArray(result[c]) ? result[c].length : 0),
+          (sum, c) => sum + (Array.isArray(tags[c]) ? tags[c].length : 0),
           0
         );
         debug.log(
@@ -152,18 +191,23 @@ export async function fetchTetsBatch(curies) {
       }
     })
   );
-  const totalTags = Object.values(result).reduce(
-    (sum, tets) => sum + (Array.isArray(tets) ? tets.length : 0),
+  const totalTags = Object.values(tags).reduce(
+    (sum, t) => sum + (Array.isArray(t) ? t.length : 0),
     0
   );
   debug.log(
     `[TetValidationGrid] TET batch fetch done: ${unique.length} references, ` +
     `${totalTags} tags, ${elapsedMs(totalStart)}`
   );
-  return result;
+  return { tags, counts };
 }
 
-export function useReferenceTets(referenceIds, biblioByCurie, active = true) {
+export function useReferenceTets(
+  referenceIds,
+  biblioByCurie,
+  active = true,
+  filters = null
+) {
   const [rows, setRows] = useState([]);
   const [unresolved, setUnresolved] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -175,6 +219,14 @@ export function useReferenceTets(referenceIds, biblioByCurie, active = true) {
   // redundant reload when only the map's identity changes.
   const biblioMapRef = useRef(biblioByCurie);
   biblioMapRef.current = biblioByCurie;
+
+  // Same idea for the search filters: read the latest value from a ref, but key
+  // the effect on the filters' *value* (stringified) below so a real change to
+  // the search criteria triggers a re-fetch while an identity-only change does
+  // not.
+  const filtersRef = useRef(filters);
+  filtersRef.current = filters;
+  const filtersKey = JSON.stringify(filters || null);
 
   // Resolve one input to its canonical curie + biblio. When the caller already
   // supplied biblio (search results), AGRKB inputs need NO network call — the
@@ -237,9 +289,13 @@ export function useReferenceTets(referenceIds, biblioByCurie, active = true) {
       );
 
       // Phase 2: fetch all TETs in one batched request (was one HTTP call per
-      // reference — the grid's main bottleneck).
+      // reference — the grid's main bottleneck), restricted to the tags the
+      // search asked for.
       const fetchStart = performance.now();
-      const tetsByCurie = await fetchTetsBatch(resolved.map((r) => r.curie));
+      const { tags: tetsByCurie, counts: countsByCurie } = await fetchTetsBatch(
+        resolved.map((r) => r.curie),
+        filtersRef.current
+      );
       if (cancelled || reqId !== reqIdRef.current) return;
       debug.log(`[TetValidationGrid] fetch done: ${elapsedMs(fetchStart)}`);
 
@@ -248,6 +304,7 @@ export function useReferenceTets(referenceIds, biblioByCurie, active = true) {
         curie: r.curie,
         biblio: r.biblio,
         tets: tetsByCurie[r.curie] || [],
+        counts: countsByCurie[r.curie] || {},
       }));
       setRows(nextRows);
       setUnresolved(newUnresolved);
@@ -266,7 +323,7 @@ export function useReferenceTets(referenceIds, biblioByCurie, active = true) {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(referenceIds || []), resolveBiblio, active]);
+  }, [JSON.stringify(referenceIds || []), resolveBiblio, active, filtersKey]);
 
   const refetchRow = useCallback(async (curie) => {
     const tets = await fetchTets(curie);

--- a/src/components/refs_tet_validation/hooks/useReferenceTets.js
+++ b/src/components/refs_tet_validation/hooks/useReferenceTets.js
@@ -112,21 +112,23 @@ function compactFilters(filters) {
 /**
  * Fetch TETs for many references in one round-trip via POST
  * /topic_entity_tag/by_references, which returns { tags: {curie: tets[]},
- * counts: {curie: {topic: {...}}} }. `filters` carries the initial search's TET
- * facet criteria so the API returns ONLY the tags the search asked for (the main
- * fix for the slow grid load). Chunked so a very large page doesn't become one
- * huge request. Falls back to per-reference GETs if the batch endpoint is
- * unavailable (e.g. older backend) — the fallback can't filter server-side, so
- * the grid's own client-side filters still apply on that path.
+ * counts: {curie: {topic: {...}}}, entries: {curie: {topic: entries[]}} }.
+ * `filters` carries the initial search's TET facet criteria so the API returns
+ * ONLY the tags the search asked for (the main fix for the slow grid load).
+ * Chunked so a very large page doesn't become one huge request. Falls back to
+ * per-reference GETs if the batch endpoint is unavailable (e.g. older backend)
+ * — the fallback can't filter/aggregate server-side, so the grid's own
+ * client-side filters still apply on that path.
  *
- * Returns { tags: {curie: tets[]}, counts: {curie: {topic: {...}}} }.
+ * Returns { tags, counts, entries } keyed by curie.
  */
 export async function fetchTetsBatch(curies, filters) {
   const totalStart = performance.now();
   const tags = {};
   const counts = {};
+  const entries = {};
   const unique = Array.from(new Set((curies || []).filter(Boolean)));
-  if (unique.length === 0) return { tags, counts };
+  if (unique.length === 0) return { tags, counts, entries };
   const compactedFilters = compactFilters(filters);
   const groups = chunk(unique, TETS_BATCH_SIZE);
   debug.log(
@@ -156,9 +158,12 @@ export async function fetchTetsBatch(curies, filters) {
           body.tags && typeof body.tags === 'object' ? body.tags : body;
         const countMap =
           body.counts && typeof body.counts === 'object' ? body.counts : {};
+        const hasEntryMap = body.entries && typeof body.entries === 'object';
+        const entryMap = hasEntryMap ? body.entries : {};
         for (const c of group) {
           tags[c] = tagMap[c] || [];
           counts[c] = countMap[c] || {};
+          entries[c] = hasEntryMap ? (entryMap[c] || {}) : null;
         }
         const tetCount = group.reduce(
           (sum, c) => sum + (Array.isArray(tags[c]) ? tags[c].length : 0),
@@ -178,6 +183,7 @@ export async function fetchTetsBatch(curies, filters) {
           group.map(async (c) => {
             tags[c] = await fetchTets(c);
             counts[c] = {};
+            entries[c] = null;
           })
         );
         const fallbackCount = group.reduce(
@@ -199,7 +205,7 @@ export async function fetchTetsBatch(curies, filters) {
     `[TetValidationGrid] TET batch fetch done: ${unique.length} references, ` +
     `${totalTags} tags, ${elapsedMs(totalStart)}`
   );
-  return { tags, counts };
+  return { tags, counts, entries };
 }
 
 export function useReferenceTets(
@@ -292,7 +298,11 @@ export function useReferenceTets(
       // reference — the grid's main bottleneck), restricted to the tags the
       // search asked for.
       const fetchStart = performance.now();
-      const { tags: tetsByCurie, counts: countsByCurie } = await fetchTetsBatch(
+      const {
+        tags: tetsByCurie,
+        counts: countsByCurie,
+        entries: entriesByCurie,
+      } = await fetchTetsBatch(
         resolved.map((r) => r.curie),
         filtersRef.current
       );
@@ -305,6 +315,9 @@ export function useReferenceTets(
         biblio: r.biblio,
         tets: tetsByCurie[r.curie] || [],
         counts: countsByCurie[r.curie] || {},
+        entries: entriesByCurie[r.curie] === null
+          ? null
+          : (entriesByCurie[r.curie] || {}),
       }));
       setRows(nextRows);
       setUnresolved(newUnresolved);

--- a/src/components/refs_tet_validation/hooks/useReferenceTets.js
+++ b/src/components/refs_tet_validation/hooks/useReferenceTets.js
@@ -30,6 +30,10 @@ function chunk(arr, size) {
   return out;
 }
 
+function elapsedMs(start) {
+  return `${Math.round(performance.now() - start)}ms`;
+}
+
 /**
  * Retry an axios call on 5xx / network errors with exponential backoff.
  * 4xx errors fail fast (a 404 should never be retried). Default 5 retries
@@ -96,11 +100,17 @@ export async function fetchTets(curie) {
  * so the grid keeps working either way.
  */
 export async function fetchTetsBatch(curies) {
+  const totalStart = performance.now();
   const result = {};
   const unique = Array.from(new Set((curies || []).filter(Boolean)));
   if (unique.length === 0) return result;
+  const groups = chunk(unique, TETS_BATCH_SIZE);
+  debug.log(
+    `[TetValidationGrid] TET batch fetch start: ${unique.length} references in ${groups.length} request(s)`
+  );
   await Promise.all(
-    chunk(unique, TETS_BATCH_SIZE).map(async (group) => {
+    groups.map(async (group, index) => {
+      const groupStart = performance.now();
       try {
         // Fail fast (one short retry) before falling back to per-reference
         // GETs: a 4xx (older backend without this endpoint) isn't retried at
@@ -112,6 +122,14 @@ export async function fetchTetsBatch(curies) {
         );
         const data = r.data && typeof r.data === 'object' ? r.data : {};
         for (const c of group) result[c] = data[c] || [];
+        const tetCount = Object.values(data).reduce(
+          (sum, tets) => sum + (Array.isArray(tets) ? tets.length : 0),
+          0
+        );
+        debug.log(
+          `[TetValidationGrid] TET batch request ${index + 1}/${groups.length}: ` +
+          `${group.length} references, ${tetCount} tags, ${elapsedMs(groupStart)}`
+        );
       } catch (e) {
         debug.warn(
           '[TetValidationGrid] batch fetchTets failed; falling back per-reference:',
@@ -123,8 +141,24 @@ export async function fetchTetsBatch(curies) {
             result[c] = await fetchTets(c);
           })
         );
+        const fallbackCount = group.reduce(
+          (sum, c) => sum + (Array.isArray(result[c]) ? result[c].length : 0),
+          0
+        );
+        debug.log(
+          `[TetValidationGrid] TET fallback request ${index + 1}/${groups.length}: ` +
+          `${group.length} references, ${fallbackCount} tags, ${elapsedMs(groupStart)}`
+        );
       }
     })
+  );
+  const totalTags = Object.values(result).reduce(
+    (sum, tets) => sum + (Array.isArray(tets) ? tets.length : 0),
+    0
+  );
+  debug.log(
+    `[TetValidationGrid] TET batch fetch done: ${unique.length} references, ` +
+    `${totalTags} tags, ${elapsedMs(totalStart)}`
   );
   return result;
 }
@@ -171,11 +205,16 @@ export function useReferenceTets(referenceIds, biblioByCurie, active = true) {
     setUnresolved([]);
 
     (async () => {
+      const loadStart = performance.now();
       const ids = Array.from(
         new Set((referenceIds || []).map((s) => s.trim()).filter(Boolean))
       );
+      debug.log(
+        `[TetValidationGrid] load start: ${ids.length} input references`
+      );
       // Phase 1: resolve each input to its canonical curie + biblio (mostly
       // free when search biblio is supplied), bounded by FETCH_CONCURRENCY.
+      const resolveStart = performance.now();
       const resolved = [];
       const newUnresolved = [];
       let cursor = 0;
@@ -192,22 +231,35 @@ export function useReferenceTets(referenceIds, biblioByCurie, active = true) {
         Array.from({ length: Math.min(FETCH_CONCURRENCY, ids.length) }, worker)
       );
       if (cancelled || reqId !== reqIdRef.current) return;
+      debug.log(
+        `[TetValidationGrid] resolve done: ${resolved.length} resolved, ` +
+        `${newUnresolved.length} unresolved, ${elapsedMs(resolveStart)}`
+      );
 
       // Phase 2: fetch all TETs in one batched request (was one HTTP call per
       // reference — the grid's main bottleneck).
+      const fetchStart = performance.now();
       const tetsByCurie = await fetchTetsBatch(resolved.map((r) => r.curie));
       if (cancelled || reqId !== reqIdRef.current) return;
+      debug.log(`[TetValidationGrid] fetch done: ${elapsedMs(fetchStart)}`);
 
-      setRows(
-        resolved.map((r) => ({
-          input: r.input,
-          curie: r.curie,
-          biblio: r.biblio,
-          tets: tetsByCurie[r.curie] || [],
-        }))
-      );
+      const nextRows = resolved.map((r) => ({
+        input: r.input,
+        curie: r.curie,
+        biblio: r.biblio,
+        tets: tetsByCurie[r.curie] || [],
+      }));
+      setRows(nextRows);
       setUnresolved(newUnresolved);
       setLoading(false);
+      const rowTagCount = nextRows.reduce(
+        (sum, row) => sum + (Array.isArray(row.tets) ? row.tets.length : 0),
+        0
+      );
+      debug.log(
+        `[TetValidationGrid] load done: ${nextRows.length} rows, ` +
+        `${rowTagCount} tags, ${elapsedMs(loadStart)}`
+      );
     })();
 
     return () => {

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -109,8 +109,11 @@ const SearchLayout = () => {
         // positive nested-TET facets the same way: single-tag => one tag must
         // satisfy all of them; multi-tag => the search matched them across
         // different tags, so the grid must OR them or a genuine search hit would
-        // show an empty row. Default true matches the search reducer default.
-        f.apply_to_single_tag = applyToSingleTag !== false;
+        // show an empty row. Use the SAME truthiness test searchActions.js uses
+        // to pick processCombinedTETFacets (truthy) vs processSingleFacet
+        // (falsy), so the flag always matches the ES query path actually taken
+        // (the reducer defaults applyToSingleTag to true).
+        f.apply_to_single_tag = !!applyToSingleTag;
         return f;
     }, [searchFacetsValues, searchExcludedFacetsValues, confidenceScore, applyToSingleTag]);
 

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -78,6 +78,31 @@ const SearchLayout = () => {
         () => searchExcludedFacetsValues?.confidence_levels || [],
         [searchExcludedFacetsValues]
     );
+    // The TET facet criteria from the current search, forwarded to the grid's
+    // batch fetch so the API returns ONLY the tags the search asked for (e.g.
+    // when a curator selects a topic/entity) instead of every tag on every
+    // reference. This is the main fix for the slow grid load. Mirrors the TET
+    // facets the search itself sends in searchActions.js. Confidence-score is
+    // sent only when it differs from the default full range [0, 1].
+    const searchFilters = useMemo(() => {
+        const fv = searchFacetsValues || {};
+        const neg = searchExcludedFacetsValues || {};
+        const nonEmpty = (a) => Array.isArray(a) && a.length > 0;
+        const f = {};
+        if (nonEmpty(fv.topics)) f.topics = fv.topics;
+        if (nonEmpty(fv.confidence_levels)) f.confidence_levels = fv.confidence_levels;
+        if (nonEmpty(fv.source_methods)) f.source_methods = fv.source_methods;
+        if (nonEmpty(fv.source_evidence_assertions)) f.source_evidence_assertions = fv.source_evidence_assertions;
+        if (nonEmpty(fv.data_novelty)) f.data_novelty = fv.data_novelty;
+        if (nonEmpty(neg.confidence_levels)) f.negated_confidence_levels = neg.confidence_levels;
+        if (nonEmpty(neg.source_methods)) f.negated_source_methods = neg.source_methods;
+        if (nonEmpty(neg.source_evidence_assertions)) f.negated_source_evidence_assertions = neg.source_evidence_assertions;
+        if (Array.isArray(confidenceScore) && !(confidenceScore[0] === 0 && confidenceScore[1] === 1)) {
+            f.confidence_score_min = confidenceScore[0];
+            f.confidence_score_max = confidenceScore[1];
+        }
+        return Object.keys(f).length > 0 ? f : undefined;
+    }, [searchFacetsValues, searchExcludedFacetsValues, confidenceScore]);
 
     // Handle window resize
     useEffect(() => {
@@ -303,6 +328,7 @@ const SearchLayout = () => {
                                             excludedConfidenceLevels={excludedConfidenceLevels}
                                             confidenceScore={confidenceScore}
                                             biblioByCurie={biblioByCurie}
+                                            searchFilters={searchFilters}
                                             active={view === 'grid'}
                                             persistRef={gridStateRef}
                                         />

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -47,6 +47,7 @@ const SearchLayout = () => {
     const searchFacetsValues = useSelector((s) => s.search.searchFacetsValues);
     const searchExcludedFacetsValues = useSelector((s) => s.search.searchExcludedFacetsValues);
     const confidenceScore = useSelector((s) => s.search.confidenceScore);
+    const applyToSingleTag = useSelector((s) => s.search.applyToSingleTag);
     const searchLoading = useSelector((s) => s.search.searchLoading);
 
     const referenceIds = useMemo(
@@ -103,8 +104,15 @@ const SearchLayout = () => {
             f.confidence_score_min = confidenceScore[0];
             f.confidence_score_max = confidenceScore[1];
         }
-        return Object.keys(f).length > 0 ? f : undefined;
-    }, [searchFacetsValues, searchExcludedFacetsValues, confidenceScore]);
+        if (Object.keys(f).length === 0) return undefined;
+        // Mirror the search's single/multi-tag mode so the API combines the
+        // positive nested-TET facets the same way: single-tag => one tag must
+        // satisfy all of them; multi-tag => the search matched them across
+        // different tags, so the grid must OR them or a genuine search hit would
+        // show an empty row. Default true matches the search reducer default.
+        f.apply_to_single_tag = applyToSingleTag !== false;
+        return f;
+    }, [searchFacetsValues, searchExcludedFacetsValues, confidenceScore, applyToSingleTag]);
 
     // Handle window resize
     useEffect(() => {

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -94,6 +94,8 @@ const SearchLayout = () => {
         if (nonEmpty(fv.source_methods)) f.source_methods = fv.source_methods;
         if (nonEmpty(fv.source_evidence_assertions)) f.source_evidence_assertions = fv.source_evidence_assertions;
         if (nonEmpty(fv.data_novelty)) f.data_novelty = fv.data_novelty;
+        if (nonEmpty(fv.entity_types)) f.entity_types = fv.entity_types;
+        if (nonEmpty(fv.entities)) f.entities = fv.entities;
         if (nonEmpty(neg.confidence_levels)) f.negated_confidence_levels = neg.confidence_levels;
         if (nonEmpty(neg.source_methods)) f.negated_source_methods = neg.source_methods;
         if (nonEmpty(neg.source_evidence_assertions)) f.negated_source_evidence_assertions = neg.source_evidence_assertions;


### PR DESCRIPTION
Updated the UI batch hook to consume API-provided entries, counts, and filtered tags.

Updated the topic grid renderers, filters, and sorting helpers to use the API aggregates instead of rebuilding those buckets repeatedly in the browser.

Preserved fallback behavior for older API responses by locally grouping raw tags only when API entries are absent.

Kept raw TETs available for curator validation actions/status, so validation behavior should remain unchanged.

Forwarded entity filters from search state to the topic grid batch request when available.

