### PR TITLE
 consume server validation aggregates and validate write path

### DIFF
--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -49,6 +49,16 @@ import {
 import { debug } from './helpers/debug';
 import './TetValidationGrid.css';
 
+// Per-cell filter flags for a topic that is a column but carries no tags on a
+// given (server-aggregated) reference — the server omits such topics from its
+// filter_flags map, so "absent" means all-false.
+const EMPTY_CELL_FILTER_FLAGS = Object.freeze({
+  has_any: false,
+  has_y: false,
+  has_n: false,
+  has_note: false,
+});
+
 const INNER_COLUMN_FILTER_LABELS = {
   [INNER_COLUMN_TYPES.VALIDATION]: 'Validation status',
   [INNER_COLUMN_TYPES.TAG]: 'Data',
@@ -233,12 +243,13 @@ export default function TetValidationGrid({
   );
   const effectiveMod = mod || accessLevel;
 
-  const { rows: rawRows, unresolved, loading, refetchRow } = useReferenceTets(
-    referenceIds,
-    biblioByCurie,
-    active,
-    searchFilters
-  );
+  const {
+    rows: rawRows,
+    unresolved,
+    loading,
+    refetchRow,
+    applyValidatedCell,
+  } = useReferenceTets(referenceIds, biblioByCurie, active, searchFilters);
 
   // Honor the search's confidence filters in the grid. The grid fetches TETs
   // independently of the search query (useReferenceTets), so without this it
@@ -292,6 +303,25 @@ export default function TetValidationGrid({
       }),
     }));
   }, [rawRows, excludedConfLevelSet, confRangeActive, confMin, confMax]);
+
+  // Keep a ref to the current rows so handleValidated can decide — without being
+  // a memo/callback dependency — whether a row is on the server-aggregate path.
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
+
+  // After a curator validation, apply the single recomputed cell returned by
+  // POST /topic_entity_tag/validate when the row is server-aggregated; otherwise
+  // fall back to a full per-reference raw refetch (older backend / fallback).
+  const handleValidated = useCallback(
+    async (curie, topic, cell) => {
+      const row = rowsRef.current.find((r) => r.curie === curie);
+      const onServerPath =
+        row && row.validation != null && row.filterFlags != null && cell;
+      if (onServerPath) applyValidatedCell(curie, topic, cell);
+      else await refetchRow(curie);
+    },
+    [applyValidatedCell, refetchRow]
+  );
 
   // Ensure curator source id is loaded so the validation strip can submit
   useEffect(() => {
@@ -924,6 +954,17 @@ export default function TetValidationGrid({
             tets: flat,
             entries: hasServerEntries ? (r.entries[t.curie] || []) : null,
             counts: r.counts?.[t.curie] || {},
+            // Server-aggregated per-cell validation/flags. `undefined` => the row
+            // was not server-aggregated (older backend / per-ref fallback), so
+            // consumers derive from raw tets. For an aggregated row a topic
+            // absent from the map means "no curator validation" (null) / "no
+            // tags" (all-false flags), respectively.
+            validation:
+              r.validation == null ? undefined : (r.validation[t.curie] ?? null),
+            filterFlags:
+              r.filterFlags == null
+                ? undefined
+                : (r.filterFlags[t.curie] ?? EMPTY_CELL_FILTER_FLAGS),
           };
         }
         return {
@@ -1290,7 +1331,7 @@ export default function TetValidationGrid({
             cellRendererParams: {
               topicCurie: t.curie,
               topicName: t.name || t.curie,
-              refetchRow,
+              onValidated: handleValidated,
               curationStatusOptions,
               curationTagOptions,
             },
@@ -1386,7 +1427,7 @@ export default function TetValidationGrid({
   }, [
     visibleTopicColumns,
     displayOptions,
-    refetchRow,
+    handleValidated,
     sourceFilterModel,
     allIdPrefixes,
     selectedIdPrefixes,

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -1337,9 +1337,9 @@ export default function TetValidationGrid({
         });
         const children = [
           makeInnerColumn({
-            headerName: 'Validation by professional biocurator',
+            headerName: 'Assessment by Biocurator',
             headerTooltip:
-              'Validation by professional biocurators. When at least one curator has submitted a topic-level tag, the cell shows the validation status (validated positive / validated negative / validation conflict). Otherwise, ✓ and ✗ buttons let the curator submit one.',
+              'Assessment by Biocurator. When at least one curator has submitted a topic-level tag, the cell shows the validation status (validated positive / validated negative / validation conflict). Otherwise, ✓ and ✗ buttons let the curator submit one.',
             colId: `${t.curie}__val`,
             kind: INNER_COLUMN_TYPES.VALIDATION,
             width: 90,

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -57,6 +57,7 @@ const EMPTY_CELL_FILTER_FLAGS = Object.freeze({
   has_y: false,
   has_n: false,
   has_note: false,
+  my_validation_present: false,
 });
 
 const INNER_COLUMN_FILTER_LABELS = {
@@ -247,6 +248,7 @@ export default function TetValidationGrid({
     rows: rawRows,
     unresolved,
     loading,
+    discovery,
     refetchRow,
     applyValidatedCell,
   } = useReferenceTets(referenceIds, biblioByCurie, active, searchFilters);
@@ -378,13 +380,25 @@ export default function TetValidationGrid({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [topics, rows]);
 
-  // Data-driven topic curies (whatever actually appears in the loaded TETs)
-  const dataDrivenTopicCuries = useMemo(() => {
+  // Topics actually present in the batch. Prefer the server `discovery` aggregate
+  // (the distinct topic columns over the whole post-filter batch, carrying
+  // names) so the column set isn't derived from raw tags; fall back to scanning
+  // raw tets on an older backend that sent no discovery.
+  const presentTopicColumns = useMemo(() => {
+    if (discovery && Array.isArray(discovery.topics)) {
+      return discovery.topics.map((t) => {
+        const curie = normalizeCurie(t.curie);
+        return { curie, name: t.name || topicNameMap[curie] || curie };
+      });
+    }
     const present = new Set();
     for (const r of rows)
       for (const t of r.tets || []) present.add(normalizeCurie(t.topic));
-    return [...present];
-  }, [rows]);
+    return [...present].map((curie) => ({
+      curie,
+      name: topicNameMap[curie] || curie,
+    }));
+  }, [discovery, rows, topicNameMap]);
 
   // Final topic column set: ALWAYS includes both the requested topics (if any)
   // and the topics actually present in the data. Data-driven topics not in the
@@ -396,10 +410,7 @@ export default function TetValidationGrid({
       const curie = normalizeCurie(t.curie);
       return { curie, name: t.name || topicNameMap[curie] || curie };
     });
-    const fromData = dataDrivenTopicCuries.map((curie) => ({
-      curie,
-      name: topicNameMap[curie] || curie,
-    }));
+    const fromData = presentTopicColumns;
     const seen = new Set();
     return [...requested, ...fromData]
       .filter((t) => {
@@ -408,9 +419,18 @@ export default function TetValidationGrid({
         return true;
       })
       .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
-  }, [topics, dataDrivenTopicCuries, topicNameMap]);
+  }, [topics, presentTopicColumns, topicNameMap]);
 
   const allSources = useMemo(() => {
+    // Prefer the server `discovery` aggregate (distinct source labels over the
+    // non-curator tags of the whole post-filter batch) so the source filter
+    // isn't derived from raw tags; fall back to server entries, then raw tets,
+    // on an older backend that sent no discovery.
+    if (discovery && Array.isArray(discovery.sources)) {
+      return [
+        ...new Set(discovery.sources.map((s) => s.label).filter(Boolean)),
+      ].sort();
+    }
     const s = new Set();
     for (const r of rows) {
       const entries = r.entries ? Object.values(r.entries).flat() : [];
@@ -424,7 +444,7 @@ export default function TetValidationGrid({
       }
     }
     return [...s].sort();
-  }, [rows]);
+  }, [discovery, rows]);
 
   // Distinct curie prefixes across all loaded references — fed to IdPrefixFilter.
   const allIdPrefixes = useMemo(() => {

--- a/src/components/refs_tet_validation/cellRenderers/CellValidationStrip.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/CellValidationStrip.jsx
@@ -29,7 +29,6 @@ export default function CellValidationStrip({
   const testerMod = useSelector((s) => s.isLogged.testerMod);
   const accessLevelMod =
     testerMod && testerMod !== 'No' ? testerMod : cognitoMod;
-  const topicEntitySourceId = useSelector((s) => s.biblio.topicEntitySourceId);
   const modToTaxon = useSelector((s) => s.biblio.modToTaxon);
   const curieToNameTaxon = useSelector((s) => s.biblio.curieToNameTaxon);
   // pending = null | { kind, note, status, errorMessage?,
@@ -41,13 +40,7 @@ export default function CellValidationStrip({
   const greyPositive = myExisting && myExisting.negated === false;
   const greyNegative = myExisting && myExisting.negated === true;
 
-  const noSource = !topicEntitySourceId;
-  const disabledReason = noSource
-    ? 'Curator source not yet loaded — the grid is still resolving your MOD-specific TET source.'
-    : null;
-
   const openConfirm = (kind) => {
-    if (noSource) return;
     // Pre-fill the species from the MOD-to-taxon mapping when the MOD has a
     // single taxon (WB → C. elegans, ZFIN → D. rerio, …). Multi-taxon MODs
     // (XB) start blank so the curator picks. The curator can still clear or
@@ -140,13 +133,12 @@ export default function CellValidationStrip({
 
   return (
     <>
-      <div className="tetv-strip" title={disabledReason || undefined}>
+      <div className="tetv-strip">
         <button
           type="button"
           className={`tetv-strip-btn tetv-strip-pos ${greyPositive ? 'tetv-strip-active' : ''}`}
           onClick={() => openConfirm('positive')}
-          disabled={noSource}
-          title={disabledReason || 'positive (topic present)'}
+          title="positive (topic present)"
           aria-label="positive (topic present)"
         >
           <FontAwesomeIcon icon={faCheckCircle} />
@@ -155,8 +147,7 @@ export default function CellValidationStrip({
           type="button"
           className={`tetv-strip-btn tetv-strip-neg ${greyNegative ? 'tetv-strip-active' : ''}`}
           onClick={() => openConfirm('negative')}
-          disabled={noSource}
-          title={disabledReason || 'negative (topic not present)'}
+          title="negative (topic not present)"
           aria-label="negative (topic not present)"
         >
           <FontAwesomeIcon icon={faTimesCircle} />
@@ -317,11 +308,8 @@ export default function CellValidationStrip({
                     <dt>Source</dt>
                     <dd>
                       professional biocurator (
-                      {accessLevelMod || 'your MOD'} via abc_literature_system
-                      {topicEntitySourceId
-                        ? `, source id #${topicEntitySourceId}`
-                        : ''}
-                      )
+                      {accessLevelMod || 'your MOD'} via abc_literature_system,
+                      resolved server-side)
                     </dd>
 
                     <dt>Data novelty</dt>

--- a/src/components/refs_tet_validation/cellRenderers/CellValidationStrip.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/CellValidationStrip.jsx
@@ -74,25 +74,23 @@ export default function CellValidationStrip({
     setPending((s) => ({ ...s, status: 'submitting' }));
     const negated = pending.kind === 'negative';
     const note = pending.note?.trim() || null;
-    const tetPayload = {
+    // Thin validate payload: the server resolves the curator source and all the
+    // other tag fields (entity=null, data_novelty, force_insertion, …) and
+    // returns the single recomputed cell so the grid updates in place without
+    // re-fetching/re-aggregating the whole batch.
+    const validatePayload = {
       reference_curie: referenceCurie,
       topic: topicCurie,
+      mod_abbreviation: accessLevelMod,
       negated,
-      topic_entity_tag_source_id: topicEntitySourceId,
-      force_insertion: true,
-      entity: null,
-      entity_type: null,
-      species: pending.species?.curie || null,
-      data_novelty: 'ATP:0000335',
-      confidence_score: null,
-      confidence_level: null,
       note,
+      species: pending.species?.curie || null,
     };
     try {
-      // 1) always create the validation TET tag
-      debug.log('[CellValidationStrip] submit TET', tetPayload);
-      const res = await api.post('/topic_entity_tag/', tetPayload);
-      debug.log('[CellValidationStrip] TET OK', res?.status, res?.data);
+      // 1) always create the validation TET tag (server-resolved source)
+      debug.log('[CellValidationStrip] submit validate', validatePayload);
+      const res = await api.post('/topic_entity_tag/validate', validatePayload);
+      debug.log('[CellValidationStrip] validate OK', res?.status, res?.data);
 
       // 2) optionally create / update a curation status entry for this
       //    (reference, mod, topic) — only if the user toggled the section on
@@ -119,7 +117,8 @@ export default function CellValidationStrip({
         );
       }
 
-      if (onValidated) await onValidated(referenceCurie);
+      // Hand the recomputed cell back so the grid can update just this cell.
+      if (onValidated) await onValidated(referenceCurie, topicCurie, res?.data);
       setPending((s) => ({ ...s, status: 'success' }));
       setTimeout(closeConfirm, SUCCESS_CLOSE_DELAY_MS);
     } catch (e) {

--- a/src/components/refs_tet_validation/cellRenderers/ValidationCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/ValidationCell.jsx
@@ -11,6 +11,77 @@ function professionalBiocuratorTopicTets(tets) {
   return arr.filter(isCuratorValidationTet);
 }
 
+/** Derive the validation summary for a cell from its raw tets (the fallback
+ *  path used when the batch endpoint did not aggregate validation server-side).
+ *  Returns null when the cell has no curator validation.
+ *
+ *  Shape mirrors the server `validation` aggregate exactly so the renderer is
+ *  agnostic to where the summary came from:
+ *    { positives, negatives, byCurator: [{ name, negated,
+ *        sources: [{ method, label }], species: [curie] }] } */
+function deriveValidationSummary(tets) {
+  const validations = professionalBiocuratorTopicTets(tets);
+  if (validations.length === 0) return null;
+  const positives = validations.filter((t) => !t.negated).length;
+  const negatives = validations.filter((t) => t.negated).length;
+
+  // Group validations by (curator, polarity) and collect the source methods
+  // each (curator, polarity) combination used. If Curator A submitted both
+  // a positive and a negative tag they appear on both rows; multiple
+  // positives from the same curator collapse into one row but the source
+  // icons accumulate. We never drop a name even if created_by is missing —
+  // render as "(unknown curator)" instead, so every validation TET is
+  // accounted for.
+  const groups = new Map();
+  for (const t of validations) {
+    const name = t.created_by || '(unknown curator)';
+    const negated = !!t.negated;
+    const key = `${name}|${negated ? 'N' : 'Y'}`;
+    if (!groups.has(key)) {
+      groups.set(key, { name, negated, sources: new Map(), species: new Set() });
+    }
+    const src = t.topic_entity_tag_source?.source_method;
+    if (src) {
+      // Keep a Map source_method → label so the tooltip shows the full
+      // source label (method / data-provider) while the icon shows just
+      // the first letter.
+      const lab = `${src}${
+        t.topic_entity_tag_source?.secondary_data_provider_abbreviation
+          ? ` / ${t.topic_entity_tag_source.secondary_data_provider_abbreviation}`
+          : ''
+      }`;
+      groups.get(key).sources.set(src, lab);
+    }
+    if (t.species) groups.get(key).species.add(t.species);
+  }
+  const byCurator = [...groups.values()].map((g) => ({
+    name: g.name,
+    negated: g.negated,
+    sources: [...g.sources.entries()].map(([method, label]) => ({
+      method,
+      label,
+    })),
+    species: [...g.species],
+  }));
+  return { positives, negatives, byCurator };
+}
+
+/** Normalize the server `validation` aggregate into the renderer's summary
+ *  shape. Returns null when the server reports no curator validation. */
+function serverValidationSummary(cell) {
+  if (!cell) return null;
+  return {
+    positives: cell.positives || 0,
+    negatives: cell.negatives || 0,
+    byCurator: (cell.by_curator || []).map((g) => ({
+      name: g.name || '(unknown curator)',
+      negated: !!g.negated,
+      sources: Array.isArray(g.sources) ? g.sources : [],
+      species: Array.isArray(g.species) ? g.species : [],
+    })),
+  };
+}
+
 export default function ValidationCell(params) {
   const tets = Array.isArray(params.value)
     ? params.value
@@ -18,7 +89,7 @@ export default function ValidationCell(params) {
   const {
     topicCurie,
     topicName,
-    refetchRow,
+    onValidated,
     curationStatusOptions,
     curationTagOptions,
   } = params.colDef.cellRendererParams || {};
@@ -27,66 +98,20 @@ export default function ValidationCell(params) {
     (s) => s.biblio.curieToNameTaxon
   );
 
-  const validations = professionalBiocuratorTopicTets(tets);
-  if (validations.length > 0) {
-    const positives = validations.filter((t) => !t.negated).length;
-    const negatives = validations.filter((t) => t.negated).length;
+  // Prefer the server-aggregated validation cell when present so this column
+  // renders without re-deriving from raw tags. `undefined` => the row was not
+  // server-aggregated (older backend / per-ref fallback), derive from tets;
+  // `null` => the server aggregated the row and found no curator validation.
+  const serverCell = Array.isArray(params.value)
+    ? undefined
+    : params.value?.validation;
+  const summary =
+    serverCell !== undefined
+      ? serverValidationSummary(serverCell)
+      : deriveValidationSummary(tets);
 
-    // Group validations by (curator, polarity) and collect the source methods
-    // each (curator, polarity) combination used. If Curator A submitted both
-    // a positive and a negative tag they appear on both rows; multiple
-    // positives from the same curator collapse into one row but the source
-    // icons accumulate. We never drop a name even if created_by is missing —
-    // render as "(unknown curator)" instead, so every validation TET is
-    // accounted for.
-    const uniquePairs = (() => {
-      const groups = new Map();
-      for (const t of validations) {
-        const name = t.created_by || '(unknown curator)';
-        const negated = !!t.negated;
-        const key = `${name}|${negated ? 'N' : 'Y'}`;
-        if (!groups.has(key)) {
-          groups.set(key, {
-            name,
-            negated,
-            sources: new Map(),
-            species: new Set(),
-          });
-        }
-        const src = t.topic_entity_tag_source?.source_method;
-        if (src) {
-          // Keep a Map source_method → label so the tooltip shows the full
-          // source label (method / data-provider) while the icon shows just
-          // the first letter.
-          const lab = `${src}${
-            t.topic_entity_tag_source?.secondary_data_provider_abbreviation
-              ? ` / ${t.topic_entity_tag_source.secondary_data_provider_abbreviation}`
-              : ''
-          }`;
-          groups.get(key).sources.set(src, lab);
-        }
-        if (t.species) groups.get(key).species.add(t.species);
-      }
-      return [...groups.values()].map((g) => ({
-        ...g,
-        sources: [...g.sources.entries()].map(([method, label]) => ({
-          method,
-          label,
-        })),
-        species: [...g.species],
-      }));
-    })();
-    const uniqueNames = (() => {
-      const seen = new Set();
-      const out = [];
-      for (const p of uniquePairs) {
-        if (!seen.has(p.name)) {
-          seen.add(p.name);
-          out.push(p.name);
-        }
-      }
-      return out;
-    })();
+  if (summary) {
+    const { positives, negatives, byCurator: uniquePairs } = summary;
 
     const firstWord = (s) => String(s || '').split(/[_\s/]/)[0];
     const SourceIcons = ({ sources }) => (
@@ -197,7 +222,7 @@ export default function ValidationCell(params) {
         topicCurie={topicCurie}
         topicName={topicName}
         cellTets={tets}
-        onValidated={refetchRow}
+        onValidated={onValidated}
         curationStatusOptions={curationStatusOptions}
         curationTagOptions={curationTagOptions}
       />

--- a/src/components/refs_tet_validation/helpers/__tests__/groupTets.test.js
+++ b/src/components/refs_tet_validation/helpers/__tests__/groupTets.test.js
@@ -132,7 +132,7 @@ describe('cellPredicate', () => {
     expect(cellPredicate(tets, uid, ['has note'])).toBe(true);
     expect(cellPredicate([{ note: null }], uid, ['has note'])).toBe(false);
   });
-  test('"my validation present" matches when any TET created_by current uid', () => {
+  test('"my validation present" (raw fallback) matches when any TET created_by current uid', () => {
     expect(cellPredicate(tets, uid, ['my validation present'])).toBe(false);
     expect(
       cellPredicate(
@@ -141,6 +141,38 @@ describe('cellPredicate', () => {
         ['my validation present']
       )
     ).toBe(true);
+  });
+  test('prefers server filter_flags (incl. my_validation_present) over raw tets', () => {
+    // The cell value carries a server filterFlags object -> it is authoritative,
+    // even where it disagrees with the raw tets. my_validation_present is now
+    // server-provided (compared against the user's internal users.id).
+    const cell = {
+      tets: [{ negated: false, note: null, created_by: 'someone-else' }],
+      filterFlags: {
+        has_any: true,
+        has_y: false,
+        has_n: true,
+        has_note: true,
+        my_validation_present: true,
+      },
+    };
+    expect(cellPredicate(cell, uid, ['my validation present'])).toBe(true);
+    expect(cellPredicate(cell, uid, ['has N'])).toBe(true);
+    expect(cellPredicate(cell, uid, ['has Y'])).toBe(false);
+    expect(cellPredicate(cell, uid, ['has note'])).toBe(true);
+  });
+  test('server my_validation_present=false wins over a raw-tet uid match', () => {
+    const cell = {
+      tets: [{ created_by: uid }],
+      filterFlags: {
+        has_any: true,
+        has_y: false,
+        has_n: false,
+        has_note: false,
+        my_validation_present: false,
+      },
+    };
+    expect(cellPredicate(cell, uid, ['my validation present'])).toBe(false);
   });
   test('multiple selections combine with OR', () => {
     expect(cellPredicate([{ negated: false }], uid, ['has N', 'has Y'])).toBe(

--- a/src/components/refs_tet_validation/helpers/groupTets.js
+++ b/src/components/refs_tet_validation/helpers/groupTets.js
@@ -67,10 +67,25 @@ export function cellSortRank(tets) {
   return 1;
 }
 
+/** Server-aggregated validation carried on a cell value object, or `undefined`
+ *  when the value is a bare tets array / the row was not server-aggregated (older
+ *  backend or per-reference fallback) and the state must be derived from raw
+ *  tets. A value of `null` means the server DID aggregate the row but found no
+ *  curator validation for this topic (=> 'unvalidated'). */
+function cellServerValidation(value) {
+  if (!value || Array.isArray(value)) return undefined;
+  return value.validation;
+}
+
 /** Validation state of a (reference, topic) cell, considering only
  *  professional-biocurator topic-level TETs.
- *  Returns one of: 'unvalidated' | 'positive' | 'negative' | 'conflict'. */
+ *  Returns one of: 'unvalidated' | 'positive' | 'negative' | 'conflict'.
+ *  Prefers the server aggregate (value.validation.state) when present so the
+ *  grid sorts/filters without re-deriving from raw tags; falls back to deriving
+ *  from raw tets when the value carries no aggregate. */
 export function validationState(tets) {
+  const sv = cellServerValidation(tets);
+  if (sv !== undefined) return sv && sv.state ? sv.state : 'unvalidated';
   const validations = asTets(tets).filter(isCuratorValidationTet);
   if (validations.length === 0) return 'unvalidated';
   const hasPos = validations.some((t) => !t.negated);
@@ -105,18 +120,28 @@ export const TOPIC_CELL_FILTER_KEYS = [
 export function cellPredicate(tets, currentUid, model) {
   if (!Array.isArray(model) || model.length === 0) return true;
   const arr = asTets(tets);
+  // Prefer the server-aggregated per-cell flags (has_any/has_y/has_n/has_note)
+  // when present so filtering doesn't scan raw tags. `null`/`undefined` => no
+  // server aggregate, derive from raw tets. 'my validation present' is never
+  // server-provided (it needs the curator's identity, which the serialized
+  // created_by is a display name for), so it always derives from raw tets.
+  const flags =
+    tets && !Array.isArray(tets) ? tets.filterFlags : undefined;
+  const server = flags != null;
   return model.some((key) => {
     switch (key) {
       case 'empty':
-        return arr.length === 0;
+        return server ? !flags.has_any : arr.length === 0;
       case 'has any tag':
-        return arr.length > 0;
+        return server ? !!flags.has_any : arr.length > 0;
       case 'has Y':
-        return arr.some((t) => t.negated === false);
+        return server ? !!flags.has_y : arr.some((t) => t.negated === false);
       case 'has N':
-        return arr.some((t) => t.negated === true);
+        return server ? !!flags.has_n : arr.some((t) => t.negated === true);
       case 'has note':
-        return arr.some((t) => t.note != null && t.note !== '');
+        return server
+          ? !!flags.has_note
+          : arr.some((t) => t.note != null && t.note !== '');
       case 'my validation present':
         return arr.some((t) => t.created_by === currentUid);
       default:

--- a/src/components/refs_tet_validation/helpers/groupTets.js
+++ b/src/components/refs_tet_validation/helpers/groupTets.js
@@ -120,11 +120,14 @@ export const TOPIC_CELL_FILTER_KEYS = [
 export function cellPredicate(tets, currentUid, model) {
   if (!Array.isArray(model) || model.length === 0) return true;
   const arr = asTets(tets);
-  // Prefer the server-aggregated per-cell flags (has_any/has_y/has_n/has_note)
-  // when present so filtering doesn't scan raw tags. `null`/`undefined` => no
-  // server aggregate, derive from raw tets. 'my validation present' is never
-  // server-provided (it needs the curator's identity, which the serialized
-  // created_by is a display name for), so it always derives from raw tets.
+  // Prefer the server-aggregated per-cell flags (has_any/has_y/has_n/has_note/
+  // my_validation_present) when present so filtering doesn't scan raw tags.
+  // `null`/`undefined` => no server aggregate, derive from raw tets. The server
+  // computes my_validation_present by comparing each tag's created_by against
+  // the authenticated user's internal users.id -- the comparison the client
+  // cannot do reliably, since its uid is an Okta subject id and the serialized
+  // created_by is a display name. The raw-tets fallback keeps the older-backend
+  // path working.
   const flags =
     tets && !Array.isArray(tets) ? tets.filterFlags : undefined;
   const server = flags != null;
@@ -143,7 +146,9 @@ export function cellPredicate(tets, currentUid, model) {
           ? !!flags.has_note
           : arr.some((t) => t.note != null && t.note !== '');
       case 'my validation present':
-        return arr.some((t) => t.created_by === currentUid);
+        return server
+          ? !!flags.my_validation_present
+          : arr.some((t) => t.created_by === currentUid);
       default:
         return false;
     }

--- a/src/components/refs_tet_validation/helpers/innerColumnUtils.js
+++ b/src/components/refs_tet_validation/helpers/innerColumnUtils.js
@@ -1,4 +1,4 @@
-import { cellEntries, cellTets } from './buildEntries';
+import { cellEntries } from './buildEntries';
 import {
   VALIDATION_FILTER_KEYS,
   validationSortRank,
@@ -106,11 +106,12 @@ function compareNullableStrings(a, b) {
 
 export function innerColumnFilterValues(kind, tets, sourceFilterModel) {
   const entries = visibleEntries(tets, sourceFilterModel);
-  const rawTets = cellTets(tets);
 
   switch (kind) {
     case INNER_COLUMN_TYPES.VALIDATION:
-      return [validationState(rawTets)];
+      // Pass the whole cell value (not extracted rawTets) so validationState
+      // uses the server-aggregated state when present.
+      return [validationState(tets)];
     case INNER_COLUMN_TYPES.TAG:
       return uniqueValues(visibleTagLabels(entries));
     case INNER_COLUMN_TYPES.SOURCES:
@@ -145,13 +146,13 @@ export function innerColumnPassesFilter(
 
 export function innerColumnSortMeta(kind, tets, sourceFilterModel) {
   const entries = visibleEntries(tets, sourceFilterModel);
-  const rawTets = cellTets(tets);
 
   switch (kind) {
     case INNER_COLUMN_TYPES.VALIDATION: {
-      const state = validationState(rawTets);
+      // Pass the whole cell value so the server-aggregated state/rank is used.
+      const state = validationState(tets);
       return {
-        rank: validationSortRank(rawTets),
+        rank: validationSortRank(tets),
         text: state,
       };
     }

--- a/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
+++ b/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
@@ -240,6 +240,30 @@ describe('fetchTetsBatch', () => {
     ]);
   });
 
+  test('discards discovery (null) when a chunk falls back to per-reference GETs', async () => {
+    // 60 curies -> two chunks. First chunk returns discovery; the second chunk's
+    // POST fails and drops to per-reference GETs, contributing no discovery. A
+    // merged discovery would then cover only the first chunk and silently hide
+    // topics/sources that live only in the fallback references, so it must be
+    // discarded (null) -- consumers re-derive from raw tets, which cover all refs.
+    const many = Array.from({ length: 60 }, (_, i) => `AGRKB:${i + 1}`);
+    api.post
+      .mockResolvedValueOnce({
+        data: {
+          tags: {},
+          discovery: {
+            topics: [{ curie: 'ATP:0000122', name: 'phenotype' }],
+            sources: [{ label: 'src A' }],
+          },
+        },
+      })
+      .mockRejectedValueOnce({ response: { status: 404 } });
+    api.get.mockResolvedValue({ data: [] }); // per-reference fallback GETs
+    const out = await fetchTetsBatch(many);
+    expect(api.post).toHaveBeenCalledTimes(2);
+    expect(out.discovery).toBeNull();
+  });
+
   test('plumbs server validation + filter_flags maps (null on older backend)', async () => {
     api.post.mockResolvedValueOnce({
       data: {

--- a/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
+++ b/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
@@ -104,6 +104,7 @@ describe('fetchTetsBatch', () => {
       entries: {},
       validation: {},
       filterFlags: {},
+      discovery: null,
     });
     expect(api.post).not.toHaveBeenCalled();
   });
@@ -169,6 +170,94 @@ describe('fetchTetsBatch', () => {
     expect(out.tags['AGRKB:1']).toEqual([{ topic_entity_tag_id: 1 }]);
     expect(out.counts['AGRKB:1']).toEqual({});
     expect(out.entries['AGRKB:1']).toBeNull();
+    // No discovery key from an older backend => null (derive columns/sources
+    // from raw tags).
+    expect(out.discovery).toBeNull();
+  });
+
+  test('returns the batch-global discovery aggregate when present', async () => {
+    api.post.mockResolvedValueOnce({
+      data: {
+        tags: { 'AGRKB:1': [] },
+        counts: {},
+        discovery: {
+          topics: [{ curie: 'ATP:0000122', name: 'phenotype' }],
+          sources: [
+            {
+              label: 'phenotype neural network / WB',
+              method: 'phenotype neural network',
+            },
+          ],
+        },
+      },
+    });
+    const out = await fetchTetsBatch(['AGRKB:1']);
+    expect(out.discovery).toEqual({
+      topics: [{ curie: 'ATP:0000122', name: 'phenotype' }],
+      sources: [
+        {
+          label: 'phenotype neural network / WB',
+          method: 'phenotype neural network',
+        },
+      ],
+    });
+  });
+
+  test('merges + dedupes discovery across chunks (topics by curie, sources by label)', async () => {
+    // TETS_BATCH_SIZE is 50, so 60 curies split into two chunks -> two POSTs,
+    // each returning its own (overlapping) discovery. The merge unions them and
+    // uppercases topic curies for dedupe.
+    const many = Array.from({ length: 60 }, (_, i) => `AGRKB:${i + 1}`);
+    api.post
+      .mockResolvedValueOnce({
+        data: {
+          tags: {},
+          discovery: {
+            topics: [{ curie: 'atp:0000122', name: 'phenotype' }],
+            sources: [{ label: 'src A' }],
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          tags: {},
+          discovery: {
+            topics: [
+              { curie: 'ATP:0000122', name: 'phenotype' },
+              { curie: 'ATP:0000005', name: 'gene' },
+            ],
+            sources: [{ label: 'src A' }, { label: 'src B' }],
+          },
+        },
+      });
+    const out = await fetchTetsBatch(many);
+    expect(api.post).toHaveBeenCalledTimes(2);
+    const curies = out.discovery.topics.map((t) => t.curie).sort();
+    expect(curies).toEqual(['ATP:0000005', 'ATP:0000122']);
+    expect(out.discovery.sources.map((s) => s.label).sort()).toEqual([
+      'src A',
+      'src B',
+    ]);
+  });
+
+  test('plumbs server validation + filter_flags maps (null on older backend)', async () => {
+    api.post.mockResolvedValueOnce({
+      data: {
+        tags: { 'AGRKB:1': [], 'AGRKB:2': [] },
+        counts: {},
+        validation: { 'AGRKB:1': { 'ATP:1': { state: 'positive' } } },
+        filter_flags: {
+          'AGRKB:1': { 'ATP:1': { has_any: true, my_validation_present: true } },
+        },
+      },
+    });
+    const out = await fetchTetsBatch(['AGRKB:1', 'AGRKB:2']);
+    expect(out.validation['AGRKB:1']).toEqual({ 'ATP:1': { state: 'positive' } });
+    expect(out.filterFlags['AGRKB:1']['ATP:1'].my_validation_present).toBe(true);
+    // present in request, absent in the server maps => empty object (aggregated,
+    // just no rows), not null.
+    expect(out.validation['AGRKB:2']).toEqual({});
+    expect(out.filterFlags['AGRKB:2']).toEqual({});
   });
 
   test('dedupes curies and defaults missing keys to empty arrays', async () => {

--- a/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
+++ b/src/components/refs_tet_validation/hooks/__tests__/useReferenceTets.test.js
@@ -98,7 +98,13 @@ describe('fetchTets', () => {
 describe('fetchTetsBatch', () => {
   test('no curies → no request, empty tags/counts/entries', async () => {
     const out = await fetchTetsBatch([]);
-    expect(out).toEqual({ tags: {}, counts: {}, entries: {} });
+    expect(out).toEqual({
+      tags: {},
+      counts: {},
+      entries: {},
+      validation: {},
+      filterFlags: {},
+    });
     expect(api.post).not.toHaveBeenCalled();
   });
 
@@ -175,7 +181,9 @@ describe('fetchTetsBatch', () => {
     });
     expect(out.tags['AGRKB:1']).toEqual([{ x: 1 }]);
     expect(out.tags['AGRKB:3']).toEqual([]); // present in request, absent in response
-    expect(out.entries['AGRKB:3']).toEqual({});
+    // The response carried no entries map, so entries are null (derive from raw
+    // tags), consistent with the "older backend" case above.
+    expect(out.entries['AGRKB:3']).toBeNull();
   });
 
   test('falls back to per-reference GET when batch endpoint fails', async () => {

--- a/src/components/refs_tet_validation/hooks/useReferenceTets.js
+++ b/src/components/refs_tet_validation/hooks/useReferenceTets.js
@@ -133,8 +133,10 @@ function compactFilters(filters) {
  *
  * `discovery` is batch-global (the distinct topic columns + source labels across
  * the whole post-filter batch), so it is merged across chunks and returned once,
- * NOT keyed per curie. It is null when NO chunk's backend returned it (older
- * backend), so consumers fall back to deriving columns/sources from raw tags.
+ * NOT keyed per curie. It is null unless EVERY chunk contributed a discovery
+ * aggregate -- if any chunk hit an older backend or fell back to per-reference
+ * GETs, the merged result would be incomplete, so it is discarded and consumers
+ * derive columns/sources from raw tags (which cover every loaded reference).
  *
  * Returns { tags, counts, entries, validation, filterFlags, discovery }.
  */
@@ -146,13 +148,24 @@ export async function fetchTetsBatch(curies, filters) {
   const validation = {};
   const filterFlags = {};
   // Batch-global discovery merged across chunks. Keyed maps dedupe (topics by
-  // uppercased curie, sources by label); `sawDiscovery` distinguishes an
+  // uppercased curie, sources by label). `sawDiscovery` distinguishes an
   // empty-but-present aggregate from an older backend that never sent one.
+  // `discoveryComplete` guards against a PARTIAL aggregate: discovery covers only
+  // the chunks whose batch POST succeeded AND returned it, but the grid uses it
+  // exclusively (no raw-tet scan). So if ANY chunk contributed no discovery -- an
+  // older-backend chunk, or one that fell back to per-reference GETs -- the merged
+  // result would silently omit topics/sources that live only in those references.
+  // In that case we return null so consumers derive columns/sources from raw tets,
+  // which always cover every loaded reference.
   const discoveryTopics = new Map();
   const discoverySources = new Map();
   let sawDiscovery = false;
+  let discoveryComplete = true;
   const mergeDiscovery = (d) => {
-    if (!d || typeof d !== 'object') return;
+    if (!d || typeof d !== 'object') {
+      discoveryComplete = false;
+      return;
+    }
     sawDiscovery = true;
     for (const t of Array.isArray(d.topics) ? d.topics : []) {
       const key = t?.curie ? String(t.curie).toUpperCase() : null;
@@ -165,7 +178,7 @@ export async function fetchTetsBatch(curies, filters) {
     }
   };
   const buildDiscovery = () =>
-    sawDiscovery
+    sawDiscovery && discoveryComplete
       ? {
           topics: Array.from(discoveryTopics.values()),
           sources: Array.from(discoverySources.values()),
@@ -236,6 +249,9 @@ export async function fetchTetsBatch(curies, filters) {
           e?.response?.status,
           e?.response?.data?.detail || e?.message
         );
+        // This chunk contributed no discovery, so any merged discovery is now
+        // incomplete -- force the whole result back to raw-tet derivation.
+        discoveryComplete = false;
         await Promise.all(
           group.map(async (c) => {
             tags[c] = await fetchTets(c);

--- a/src/components/refs_tet_validation/hooks/useReferenceTets.js
+++ b/src/components/refs_tet_validation/hooks/useReferenceTets.js
@@ -21,6 +21,7 @@ const EMPTY_FILTER_FLAGS = Object.freeze({
   has_y: false,
   has_n: false,
   has_note: false,
+  my_validation_present: false,
 });
 
 // Exponential-backoff delays (ms) between retries — 5 retries total.
@@ -121,7 +122,8 @@ function compactFilters(filters) {
 /**
  * Fetch TETs for many references in one round-trip via POST
  * /topic_entity_tag/by_references, which returns { tags: {curie: tets[]},
- * counts: {curie: {topic: {...}}}, entries: {curie: {topic: entries[]}} }.
+ * counts: {curie: {topic: {...}}}, entries: {curie: {topic: entries[]}},
+ * discovery: {topics:[{curie,name}], sources:[{label,...}]} }.
  * `filters` carries the initial search's TET facet criteria so the API returns
  * ONLY the tags the search asked for (the main fix for the slow grid load).
  * Chunked so a very large page doesn't become one huge request. Falls back to
@@ -129,7 +131,12 @@ function compactFilters(filters) {
  * — the fallback can't filter/aggregate server-side, so the grid's own
  * client-side filters still apply on that path.
  *
- * Returns { tags, counts, entries } keyed by curie.
+ * `discovery` is batch-global (the distinct topic columns + source labels across
+ * the whole post-filter batch), so it is merged across chunks and returned once,
+ * NOT keyed per curie. It is null when NO chunk's backend returned it (older
+ * backend), so consumers fall back to deriving columns/sources from raw tags.
+ *
+ * Returns { tags, counts, entries, validation, filterFlags, discovery }.
  */
 export async function fetchTetsBatch(curies, filters) {
   const totalStart = performance.now();
@@ -138,8 +145,36 @@ export async function fetchTetsBatch(curies, filters) {
   const entries = {};
   const validation = {};
   const filterFlags = {};
+  // Batch-global discovery merged across chunks. Keyed maps dedupe (topics by
+  // uppercased curie, sources by label); `sawDiscovery` distinguishes an
+  // empty-but-present aggregate from an older backend that never sent one.
+  const discoveryTopics = new Map();
+  const discoverySources = new Map();
+  let sawDiscovery = false;
+  const mergeDiscovery = (d) => {
+    if (!d || typeof d !== 'object') return;
+    sawDiscovery = true;
+    for (const t of Array.isArray(d.topics) ? d.topics : []) {
+      const key = t?.curie ? String(t.curie).toUpperCase() : null;
+      if (key && !discoveryTopics.has(key)) {
+        discoveryTopics.set(key, { curie: key, name: t.name || key });
+      }
+    }
+    for (const s of Array.isArray(d.sources) ? d.sources : []) {
+      if (s?.label && !discoverySources.has(s.label)) discoverySources.set(s.label, s);
+    }
+  };
+  const buildDiscovery = () =>
+    sawDiscovery
+      ? {
+          topics: Array.from(discoveryTopics.values()),
+          sources: Array.from(discoverySources.values()),
+        }
+      : null;
   const unique = Array.from(new Set((curies || []).filter(Boolean)));
-  if (unique.length === 0) return { tags, counts, entries, validation, filterFlags };
+  if (unique.length === 0) {
+    return { tags, counts, entries, validation, filterFlags, discovery: null };
+  }
   const compactedFilters = compactFilters(filters);
   const groups = chunk(unique, TETS_BATCH_SIZE);
   debug.log(
@@ -179,6 +214,7 @@ export async function fetchTetsBatch(curies, filters) {
         const hasFlagMap =
           body.filter_flags && typeof body.filter_flags === 'object';
         const flagMap = hasFlagMap ? body.filter_flags : {};
+        mergeDiscovery(body.discovery);
         for (const c of group) {
           tags[c] = tagMap[c] || [];
           counts[c] = countMap[c] || {};
@@ -228,7 +264,7 @@ export async function fetchTetsBatch(curies, filters) {
     `[TetValidationGrid] TET batch fetch done: ${unique.length} references, ` +
     `${totalTags} tags, ${elapsedMs(totalStart)}`
   );
-  return { tags, counts, entries, validation, filterFlags };
+  return { tags, counts, entries, validation, filterFlags, discovery: buildDiscovery() };
 }
 
 export function useReferenceTets(
@@ -240,6 +276,10 @@ export function useReferenceTets(
   const [rows, setRows] = useState([]);
   const [unresolved, setUnresolved] = useState([]);
   const [loading, setLoading] = useState(true);
+  // Batch-global discovery aggregate ({topics, sources}) or null on an older
+  // backend that didn't send it — lets the grid build its column set + source
+  // filter without deriving them from raw tags.
+  const [discovery, setDiscovery] = useState(null);
   const reqIdRef = useRef(0);
 
   // Read the latest biblio map without making it an effect dependency: it is
@@ -284,6 +324,7 @@ export function useReferenceTets(
     setLoading(true);
     setRows([]);
     setUnresolved([]);
+    setDiscovery(null);
 
     (async () => {
       const loadStart = performance.now();
@@ -327,6 +368,7 @@ export function useReferenceTets(
         entries: entriesByCurie,
         validation: validationByCurie,
         filterFlags: filterFlagsByCurie,
+        discovery: discoveryResult,
       } = await fetchTetsBatch(
         resolved.map((r) => r.curie),
         filtersRef.current
@@ -354,6 +396,7 @@ export function useReferenceTets(
       }));
       setRows(nextRows);
       setUnresolved(newUnresolved);
+      setDiscovery(discoveryResult);
       setLoading(false);
       const rowTagCount = nextRows.reduce(
         (sum, row) => sum + (Array.isArray(row.tets) ? row.tets.length : 0),
@@ -410,5 +453,5 @@ export function useReferenceTets(
     );
   }, []);
 
-  return { rows, unresolved, loading, refetchRow, applyValidatedCell };
+  return { rows, unresolved, loading, discovery, refetchRow, applyValidatedCell };
 }

--- a/src/components/refs_tet_validation/hooks/useReferenceTets.js
+++ b/src/components/refs_tet_validation/hooks/useReferenceTets.js
@@ -14,6 +14,15 @@ import { debug } from '../helpers/debug';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Default per-cell filter flags for a topic with no tags (used when applying a
+// recomputed validate cell that carries no filter_flags for the topic).
+const EMPTY_FILTER_FLAGS = Object.freeze({
+  has_any: false,
+  has_y: false,
+  has_n: false,
+  has_note: false,
+});
+
 // Exponential-backoff delays (ms) between retries — 5 retries total.
 const DEFAULT_BACKOFF_DELAYS = [500, 1500, 4500, 13500, 40500];
 // Pull every TET for a reference in one request; references rarely exceed this.
@@ -127,8 +136,10 @@ export async function fetchTetsBatch(curies, filters) {
   const tags = {};
   const counts = {};
   const entries = {};
+  const validation = {};
+  const filterFlags = {};
   const unique = Array.from(new Set((curies || []).filter(Boolean)));
-  if (unique.length === 0) return { tags, counts, entries };
+  if (unique.length === 0) return { tags, counts, entries, validation, filterFlags };
   const compactedFilters = compactFilters(filters);
   const groups = chunk(unique, TETS_BATCH_SIZE);
   debug.log(
@@ -160,10 +171,20 @@ export async function fetchTetsBatch(curies, filters) {
           body.counts && typeof body.counts === 'object' ? body.counts : {};
         const hasEntryMap = body.entries && typeof body.entries === 'object';
         const entryMap = hasEntryMap ? body.entries : {};
+        // validation + filter_flags are aggregated server-side (newer backend).
+        // Null when absent so consumers fall back to deriving from raw tags.
+        const hasValidationMap =
+          body.validation && typeof body.validation === 'object';
+        const validationMap = hasValidationMap ? body.validation : {};
+        const hasFlagMap =
+          body.filter_flags && typeof body.filter_flags === 'object';
+        const flagMap = hasFlagMap ? body.filter_flags : {};
         for (const c of group) {
           tags[c] = tagMap[c] || [];
           counts[c] = countMap[c] || {};
           entries[c] = hasEntryMap ? (entryMap[c] || {}) : null;
+          validation[c] = hasValidationMap ? (validationMap[c] || {}) : null;
+          filterFlags[c] = hasFlagMap ? (flagMap[c] || {}) : null;
         }
         const tetCount = group.reduce(
           (sum, c) => sum + (Array.isArray(tags[c]) ? tags[c].length : 0),
@@ -184,6 +205,8 @@ export async function fetchTetsBatch(curies, filters) {
             tags[c] = await fetchTets(c);
             counts[c] = {};
             entries[c] = null;
+            validation[c] = null;
+            filterFlags[c] = null;
           })
         );
         const fallbackCount = group.reduce(
@@ -205,7 +228,7 @@ export async function fetchTetsBatch(curies, filters) {
     `[TetValidationGrid] TET batch fetch done: ${unique.length} references, ` +
     `${totalTags} tags, ${elapsedMs(totalStart)}`
   );
-  return { tags, counts, entries };
+  return { tags, counts, entries, validation, filterFlags };
 }
 
 export function useReferenceTets(
@@ -302,6 +325,8 @@ export function useReferenceTets(
         tags: tetsByCurie,
         counts: countsByCurie,
         entries: entriesByCurie,
+        validation: validationByCurie,
+        filterFlags: filterFlagsByCurie,
       } = await fetchTetsBatch(
         resolved.map((r) => r.curie),
         filtersRef.current
@@ -318,6 +343,14 @@ export function useReferenceTets(
         entries: entriesByCurie[r.curie] === null
           ? null
           : (entriesByCurie[r.curie] || {}),
+        // null => server didn't aggregate it (older backend / fallback);
+        // consumers then derive validation/flags from raw tets.
+        validation: validationByCurie?.[r.curie] == null
+          ? null
+          : validationByCurie[r.curie],
+        filterFlags: filterFlagsByCurie?.[r.curie] == null
+          ? null
+          : filterFlagsByCurie[r.curie],
       }));
       setRows(nextRows);
       setUnresolved(newUnresolved);
@@ -339,11 +372,43 @@ export function useReferenceTets(
   }, [JSON.stringify(referenceIds || []), resolveBiblio, active, filtersKey]);
 
   const refetchRow = useCallback(async (curie) => {
+    // Per-reference refresh after an edit returns raw tags only, not the
+    // server aggregates. Null them so the row re-derives validation/flags from
+    // the fresh tets and stays consistent until the next batch load.
     const tets = await fetchTets(curie);
     setRows((prev) =>
-      prev.map((r) => (r.curie === curie ? { ...r, tets } : r))
+      prev.map((r) =>
+        r.curie === curie
+          ? { ...r, tets, validation: null, filterFlags: null }
+          : r
+      )
     );
   }, []);
 
-  return { rows, unresolved, loading, refetchRow };
+  // Apply the single recomputed cell returned by POST /topic_entity_tag/validate
+  // ({ topic, validation, filter_flags }) to one row's per-topic aggregates,
+  // so a validation updates that cell without re-fetching/re-aggregating the
+  // whole batch. Only merges when the row is already on the server-aggregate
+  // path (validation/filterFlags are objects); for the fallback path the caller
+  // refetches instead (see handleValidated in TetValidationGrid).
+  const applyValidatedCell = useCallback((curie, topic, cell) => {
+    if (!cell) return;
+    const tkey = String(cell.topic || topic || '').toUpperCase();
+    setRows((prev) =>
+      prev.map((r) => {
+        if (r.curie !== curie) return r;
+        const validation =
+          r.validation && typeof r.validation === 'object'
+            ? { ...r.validation, [tkey]: cell.validation ?? null }
+            : r.validation;
+        const filterFlags =
+          r.filterFlags && typeof r.filterFlags === 'object'
+            ? { ...r.filterFlags, [tkey]: cell.filter_flags || EMPTY_FILTER_FLAGS }
+            : r.filterFlags;
+        return { ...r, validation, filterFlags };
+      })
+    );
+  }, []);
+
+  return { rows, unresolved, loading, refetchRow, applyValidatedCell };
 }

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -100,6 +100,17 @@ const SearchLayout = () => {
         if (nonEmpty(neg.confidence_levels)) f.negated_confidence_levels = neg.confidence_levels;
         if (nonEmpty(neg.source_methods)) f.negated_source_methods = neg.source_methods;
         if (nonEmpty(neg.source_evidence_assertions)) f.negated_source_evidence_assertions = neg.source_evidence_assertions;
+        // MOD scope: the corpus facet selection (in-corpus / needs-review /
+        // in-corpus-or-needs-review). The grid shows only the selected MOD's tags,
+        // so a shared reference doesn't surface another MOD's tags (e.g. an
+        // fb_svm_classifier / FB source when only WB is selected). Union across the
+        // three corpus facets; when none is selected, no MOD restriction is sent.
+        const corpusMods = Array.from(new Set([
+            ...(fv['mods_in_corpus.keyword'] || []),
+            ...(fv['mods_needs_review.keyword'] || []),
+            ...(fv['mods_in_corpus_or_needs_review.keyword'] || []),
+        ]));
+        if (corpusMods.length > 0) f.mods = corpusMods;
         if (Array.isArray(confidenceScore) && !(confidenceScore[0] === 0 && confidenceScore[1] === 1)) {
             f.confidence_score_min = confidenceScore[0];
             f.confidence_score_max = confidenceScore[1];


### PR DESCRIPTION


Wire the TET validation grid to the server-side aggregates so the Validation column renders, sorts and filters without re-deriving from raw tags, and route curator validations through the new thin write endpoint.

- ValidationCell renders from the server `validation` cell (by_curator / positives / negatives), falling back to deriving from raw tets when absent.
- groupTets validationState/cellPredicate prefer the per-cell server validation / filter_flags; "my validation present" stays raw-tag based since the server omits it (needs curator identity).
- innerColumnUtils VALIDATION sort/filter pass the whole cell value so the server-aggregated state/rank is used.
- TetValidationGrid plumbs validation/filterFlags into each cell value and, after a validation, applies the single recomputed cell in place (applyValidatedCell) instead of re-fetching/re-aggregating the batch; falls back to a per-reference refetch when the row is not server-aggregated.
- CellValidationStrip writes via POST /topic_entity_tag/validate (server resolves the curator source) and hands back the recomputed cell.

Also fix a pre-existing useReferenceTets test that expected entries {} where the code returns null for a response with no entries map.

