### PR TITLE
feat(wf-editor): First Pass Curation row for FB users (SCRUM-5478)

### DIFF
--- a/src/components/biblio/BiblioWorkflow.js
+++ b/src/components/biblio/BiblioWorkflow.js
@@ -1421,7 +1421,15 @@ const BiblioWorkflow = () => {
       // Refresh data after successful update
       fetchIndexingWorkflowOverview();
     } catch (error) {
-      const errorMessage = `API error: ${error.message}`;
+      const backendDetail = error.response?.data?.detail;
+      let errorMessage;
+      if (rowData?.section === 'First Pass Curation' && error.response?.status === 422) {
+        // Blank-start / illegal First Pass Curation transitions come back as a 422
+        // ("not allowed as not initial state"); show a curator-friendly message instead.
+        errorMessage = 'Unable to set First Pass Curation until entity extraction, reference classification and curation classification are all complete.';
+      } else {
+        errorMessage = `API error: ${backendDetail || error.message}`;
+      }
       setApiErrorMessage(errorMessage);
       setShowApiErrorModal(true);
       console.error('Error updating workflow/indexing priority:', error);

--- a/src/components/biblio/BiblioWorkflow.js
+++ b/src/components/biblio/BiblioWorkflow.js
@@ -230,10 +230,12 @@ const BiblioWorkflow = () => {
 
         const sectionOrder = [
           'community curation',
+          'first pass curation',
           'manual indexing'
         ];
         const sectionDisplayNames = {
           'community curation': 'Community Curation',
+          'first pass curation': 'First Pass Curation',
           'manual indexing': 'Manual Indexing',
         };
 
@@ -1616,7 +1618,9 @@ const BiblioWorkflow = () => {
       {['WB', 'SGD', 'FB', 'ZFIN'].includes(accessLevel) && (
         <>
           <strong style={{ display: 'block', margin: '20px 0 10px' }}>
-            Manual Indexing and Community Curation
+            {accessLevel === 'FB'
+              ? 'Manual Indexing, First Pass Curation and Community Curation'
+              : 'Manual Indexing and Community Curation'}
           </strong>
           <div style={containerStyle}>
             <div


### PR DESCRIPTION
## Summary

Adds a **First Pass Curation** row to the workflow editor's manual indexing / community curation table for **FlyBase (FB)** users, backing the SCRUM-5478 backend work in `agr_literature_service`.

- New row is placed **between Community Curation and Manual Indexing**, labeled **First Pass Curation**.
- The row is **data-driven** off the `GET /workflow_tag/indexing-community/{curie}/{mod}` response, which returns the `first pass curation` section **for FB only** — so the row is automatically FB-gated (no extra MOD check in the UI).
- Reuses the existing generic write path: status changes go through `transitionWorkflowTag` (backend validates the transition), and the existing **Curation Tag** and **Note** columns work as-is.
- Section header is expanded to name First Pass Curation **only for FB**.

## Friendlier error handling

When a First Pass Curation status is selected on a reference that has no valid initial state yet, the backend returns a `422` ("not allowed as not initial state"). Instead of the generic `API error: Request failed with status code 422`, the modal now shows:

> Unable to set First Pass Curation until entity extraction, reference classification and curation classification are all complete.

(The three states match the backend prerequisites in `workflow_transition_actions/first_pass_curation.py`.) Other errors now surface the backend's `detail` text instead of the generic status-code string.

## Files

- `src/components/biblio/BiblioWorkflow.js` (only file changed)

## Testing

- `npm start` compiles cleanly; ESLint reports 0 errors.
- Manual UI check as FB confirmed the row appears and transitions; the blocked-transition case surfaced the new message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)