### PR TITLE
image facets/icon and support all XREF search (including PDD/GEO IDs)

### DIFF
--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -65,6 +65,8 @@ export const RENAME_FACETS = {
     "authors.name.keyword": "Authors",
     "mod_reference_types.keyword": "MOD reference type",
     "retraction_status.keyword": "Retraction Status",
+    "can_display_image": "Image permission",
+    "has_image": "Has images",
     "topics": "Topic",
     "confidence_levels": "Confidence level",
     "source_methods": "Source method",
@@ -112,6 +114,14 @@ export const RENAME_FACETS = {
 export const RENAME_FACET_VALUES = {
     "manual_indexing_curation_tag": {
         "no genetic data": "predicted no genetic data"
+    },
+    "can_display_image": {
+        "true": "Yes",
+        "false": "No"
+    },
+    "has_image": {
+        "true": "Yes",
+        "false": "No"
     }
 }
 
@@ -121,6 +131,7 @@ export const FACETS_CATEGORIES_WITH_FACETS = {
     "Workflow Tags": ["file_workflow", "reference_classification", "entity_extraction", "manual_indexing", "curation_classification", "community_curation", "email_extraction"],
     "Curation Classification Tags": ["predicted_indexing_priority", "indexing_priority", "manual_indexing_curation_tag"],
     "Bibliographic Data": ["mod reference types", "pubmed types", "category", "pubmed publication status", "retraction status", "authors.name", "language"],
+    "Images": ["can display image", "has image"],
     "Topics and Entities": ["topics", "confidence_levels", "confidence_scores", "source_methods", "source_evidence_assertions", "data_novelty"],
     "Date Range": ["Date Modified in Pubmed", "Date Added To Pubmed", "Date Published", "Date Added to ABC"]
 }
@@ -420,7 +431,8 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                 if (!['topics', 'confidence_levels', 'confidence_scores', 'source_methods', 'source_evidence_assertions', 'data_novelty',
                         'file_workflow', 'manual_indexing', 'reference_classification',
 		                'entity_extraction', 'curation_classification', 'community_curation', 'email_extraction',
-                        'predicted_indexing_priority', 'indexing_priority', 'manual_indexing_curation_tag'].includes(key)) {
+                        'predicted_indexing_priority', 'indexing_priority', 'manual_indexing_curation_tag',
+                        'can_display_image', 'has_image'].includes(key)) {
                     key = key + '.keyword';
                 }
 

--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -12,10 +12,9 @@ import {Modal} from 'react-bootstrap';
 import {setSearchError, searchXref} from '../../actions/searchActions';
 import Button from 'react-bootstrap/Button';
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faFilePdf, faPenSquare} from "@fortawesome/free-solid-svg-icons";
+import {faFilePdf, faPenSquare, faImage} from "@fortawesome/free-solid-svg-icons";
 import { api } from "../../api";
 import { useHistory } from "react-router-dom";
-import { datasetXrefPrefixes } from '../biblio/BiblioEditor';
 
 const MatchingTextBox = (highlight) => {
   return (
@@ -108,8 +107,9 @@ const SearchResultItem = ({ reference }) => {
       return '';
   };
 
-  const allXrefs = reference.cross_references || [];
-  const regularXrefs = allXrefs.filter(x => !datasetXrefPrefixes.includes(x.curie.split(':')[0]));
+  // Show every cross-reference, including dataset xrefs (PDB, GEO, ...), so curators
+  // can see the xref that matched their search.
+  const displayedXrefs = reference.cross_references || [];
 
   return (
     <Row>
@@ -126,7 +126,7 @@ const SearchResultItem = ({ reference }) => {
                           {reference.curie}
                       </Link>
                   </li>
-                  {regularXrefs.map((xref, i) => (
+                  {displayedXrefs.map((xref, i) => (
                       <li key={i}>
 		<span className="obsolete">
 		    {xref.is_obsolete === 'false' ? '' : 'obsolete '}
@@ -147,6 +147,13 @@ const SearchResultItem = ({ reference }) => {
               </ul>
               <TETRedirect curie={reference.curie}/>
             <FileDownloadIcon curie = {reference.curie}/>
+            {reference.image_count > 0 && (
+                <span className="image-indicator"
+                      title={`${reference.image_count} image${reference.image_count === 1 ? '' : 's'} uploaded`}
+                      style={{marginLeft: '8px', color: '#28a745'}}>
+                    <FontAwesomeIcon icon={faImage} size='2x'/>
+                </span>
+            )}
 
           </div></Col></Row>
           <div className="searchRow-other">Authors : <span dangerouslySetInnerHTML={{__html: reference.authors ? reference.authors.map((author, i) => ((i ? ' ' : '') + author.name)) : ''}} /></div>


### PR DESCRIPTION
Surface the reference image data now provided by the search API:
- New "Images" facet category with "Image permission" (can_display_image) and "Has images" (has_image) facets, so curators can filter to references with image permission and/or figures already uploaded.
- Show a green image icon on a result when image_count > 0, with a tooltip of the figure count.

Also stop hiding dataset cross-references (PDB, GEO) in search results so curators can see the xref that matched their search.