### PR TITLE
make image icon link to file management tab

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -746,6 +746,26 @@ em {
 #TET_icon_id {width: 100%; }
 #TET_text_id{font-size: 10px;}
 
+/* image indicator sits in the top-right icon cluster, just left of the TET button;
+   rendered as a Button but styled as a bare green icon */
+.image-indicator, .image-indicator:focus{
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  margin-right: 150px;
+  color: #28a745;
+  background: none;
+  border: none;
+  box-shadow: none;
+}
+
+.image-indicator:hover, .image-indicator:active{
+  color: #1e7e34;
+  background: none;
+  border: none;
+  box-shadow: none;
+}
+
 .sort-loading-indicator {
   position: fixed;
   top: 1rem;

--- a/src/App.css
+++ b/src/App.css
@@ -747,23 +747,12 @@ em {
 #TET_text_id{font-size: 10px;}
 
 /* image indicator sits in the top-right icon cluster, just left of the TET button;
-   rendered as a Button but styled as a bare green icon */
-.image-indicator, .image-indicator:focus{
+   sized to match the TET/PDF buttons */
+.image-indicator{
   position: absolute;
-  top: 20px;
+  top: 10px;
   right: 20px;
   margin-right: 150px;
-  color: #28a745;
-  background: none;
-  border: none;
-  box-shadow: none;
-}
-
-.image-indicator:hover, .image-indicator:active{
-  color: #1e7e34;
-  background: none;
-  border: none;
-  box-shadow: none;
 }
 
 .sort-loading-indicator {

--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -65,6 +65,20 @@ const SearchResultItem = ({ reference }) => {
     );
   };
 
+  const ImageIndicator = ({ curie, imageCount }) => {
+    const history = useHistory();
+    const goToFileManagement = () => {
+        history.push(`/Biblio/?action=filemanagement&referenceCurie=${curie}`);
+    };
+    return (
+        <Button className="image-indicator"
+                title={`${imageCount} image${imageCount === 1 ? '' : 's'} uploaded - click to manage files`}
+                onClick={goToFileManagement}>
+            <FontAwesomeIcon icon={faImage} size='2x'/>
+        </Button>
+    );
+  };
+
   function toggleAbstract() {
     setIsExpanded(!isExpanded);
   }
@@ -148,11 +162,7 @@ const SearchResultItem = ({ reference }) => {
               <TETRedirect curie={reference.curie}/>
             <FileDownloadIcon curie = {reference.curie}/>
             {reference.image_count > 0 && (
-                <span className="image-indicator"
-                      title={`${reference.image_count} image${reference.image_count === 1 ? '' : 's'} uploaded`}
-                      style={{marginLeft: '8px', color: '#28a745'}}>
-                    <FontAwesomeIcon icon={faImage} size='2x'/>
-                </span>
+                <ImageIndicator curie={reference.curie} imageCount={reference.image_count}/>
             )}
 
           </div></Col></Row>

--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -74,7 +74,7 @@ const SearchResultItem = ({ reference }) => {
         <Button className="image-indicator"
                 title={`${imageCount} image${imageCount === 1 ? '' : 's'} uploaded - click to manage files`}
                 onClick={goToFileManagement}>
-            <FontAwesomeIcon icon={faImage} size='2x'/>
+            <FontAwesomeIcon icon={faImage} size='3x'/>
         </Button>
     );
   };


### PR DESCRIPTION
Move the image indicator into the top-right icon cluster next to the TET/PDF buttons and make it clickable, routing to
/Biblio/?action=filemanagement&referenceCurie=<curie>.