### PR TITLE
fix(scrum-6291): replace "validation" wording with "assessment" in topic grid UI

### DIFF
--- a/src/components/refs_tet_validation/TetGridErrorBoundary.jsx
+++ b/src/components/refs_tet_validation/TetGridErrorBoundary.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Button, Spinner } from 'react-bootstrap';
+
+// AgGrid (v32) + React 18 with reactiveCustomComponents (cells/headers rendered
+// as React portals) can desync during DOM-heavy transitions — data reload,
+// show/hide, dynamic column rebuild — and throw a commit-phase
+// "Failed to execute 'insertBefore'/'removeChild' on 'Node': ... not a child of
+// this node". Such a commit-phase error unwinds the entire React root and
+// leaves the whole page blank.
+//
+// This boundary contains the failure to the grid: a fresh remount behaves like
+// the first render (which is stable), so we auto-remount a bounded number of
+// times via a changing key, then fall back to a manual reload if it keeps
+// failing. It is a safety net, not a substitute for fixing the underlying
+// transition — but it guarantees the user never sees a blanked page.
+const MAX_AUTO_RETRIES = 2;
+
+export default class TetGridErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null, retries: 0 };
+    this._timer = null;
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[TetValidationGrid] recovered from a render error:',
+      error,
+      info
+    );
+    // Auto-remount on the next tick while under the cap. setState here is
+    // deferred so we are not updating during the failed commit.
+    if (this.state.retries < MAX_AUTO_RETRIES) {
+      this._timer = setTimeout(() => {
+        this.setState((s) => ({ error: null, retries: s.retries + 1 }));
+      }, 0);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this._timer) clearTimeout(this._timer);
+  }
+
+  handleManualRetry = () => {
+    this.setState((s) => ({ error: null, retries: s.retries + 1 }));
+  };
+
+  render() {
+    const { error, retries } = this.state;
+
+    if (error) {
+      // Still under the auto-retry cap: a remount is already scheduled.
+      if (retries < MAX_AUTO_RETRIES) {
+        return (
+          <div style={{ padding: 16 }}>
+            <Spinner animation="border" size="sm" /> Reloading topic grid…
+          </div>
+        );
+      }
+      // Exhausted auto-retries — let the user trigger a clean remount.
+      return (
+        <div style={{ padding: 16 }}>
+          <p>The topic grid hit a rendering error.</p>
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={this.handleManualRetry}
+          >
+            Reload grid
+          </Button>
+        </div>
+      );
+    }
+
+    // Keying on `retries` forces a fresh mount of the whole subtree on retry.
+    return <React.Fragment key={retries}>{this.props.children}</React.Fragment>;
+  }
+}

--- a/src/components/refs_tet_validation/TetValidationGrid.css
+++ b/src/components/refs_tet_validation/TetValidationGrid.css
@@ -848,6 +848,25 @@
   white-space: nowrap;
 }
 
+/* Loading veil shown while TET data is (re)fetched. Covers the live grid
+   instead of replacing it, so the AgGrid instance is never unmounted (which
+   would crash on teardown with domLayout="autoHeight"). Anchored to the grid
+   stack via position: relative on .tetv-grid-stack. */
+.tetv-loading-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 55;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 8px;
+  padding-top: 24px;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--tetv-accent-dark);
+  font-size: var(--tetv-secondary-font-size);
+  font-weight: 600;
+}
+
 /* Fullscreen toggle pill in the top-right of the grid wrapper. Sits above
    the sticky header (z-index 4) and the resize overlay (z-index 50). */
 .tetv-fullscreen-toggle {

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -1505,12 +1505,17 @@ export default function TetValidationGrid({
           gridApi?.deselectAll?.();
         }}
       />
+      {/* The two branches MUST have distinct keys: the top-scroll div gets
+          DOM-moved into AgGrid's .ag-root (see the sticky-scrollbar effect),
+          so React must never reconcile these divs in place and delete that
+          child individually — removeChild on its original parent would throw.
+          Distinct keys make React swap the whole subtree instead. */}
       {loading ? (
-        <div style={{ padding: 16 }}>
+        <div key="tetv-loading" style={{ padding: 16 }}>
           <Spinner animation="border" size="sm" /> Loading TET data
         </div>
       ) : (
-        <div className="tetv-grid-stack">
+        <div key="tetv-grid-stack" className="tetv-grid-stack">
           <div
             className="tetv-top-scroll"
             ref={topScrollRef}

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -1458,8 +1458,16 @@ export default function TetValidationGrid({
   ]);
 
   return (
+    // translate="no" / notranslate: DOM-mutating browser extensions (Google
+    // Translate above all) wrap this grid's text nodes in their own elements,
+    // which AgGrid + React 18 can't reconcile — React then throws a
+    // commit-phase "insertBefore/removeChild ... not a child of this node"
+    // that blanks the grid (confirmed: it renders fine with extensions
+    // disabled). Marking the subtree non-translatable keeps those extensions
+    // out of it. Ported from SCRUM-6229 (282675bc).
     <div
-      className={`ag-theme-quartz tetv-grid-wrapper${
+      translate="no"
+      className={`ag-theme-quartz tetv-grid-wrapper notranslate${
         isFullscreen ? ' tetv-fullscreen' : ''
       }`}
       style={{ width: '100%' }}
@@ -1505,95 +1513,102 @@ export default function TetValidationGrid({
           gridApi?.deselectAll?.();
         }}
       />
-      {/* The two branches MUST have distinct keys: the top-scroll div gets
-          DOM-moved into AgGrid's .ag-root (see the sticky-scrollbar effect),
-          so React must never reconcile these divs in place and delete that
-          child individually — removeChild on its original parent would throw.
-          Distinct keys make React swap the whole subtree instead. */}
-      {loading ? (
-        <div key="tetv-loading" style={{ padding: 16 }}>
-          <Spinner animation="border" size="sm" /> Loading TET data
-        </div>
-      ) : (
-        <div key="tetv-grid-stack" className="tetv-grid-stack">
+      {/* The AgGridReact below stays mounted at all times. Conditionally
+          rendering it (`loading ? spinner : grid`) tears the grid down on
+          every reload: with domLayout="autoHeight" that teardown triggers
+          React's "removeChild ... not a child of this node" crash (AgGrid
+          owns DOM nodes React's reconciler then can't find), and it would
+          also delete the DOM-moved top-scroll div from a parent React no
+          longer tracks. The loading state is an overlay veil on top of the
+          live grid instead. Ported from the SCRUM-6229 branch (7a957038). */}
+      <div className="tetv-grid-stack">
+        {loading && (
           <div
-            className="tetv-top-scroll"
-            ref={topScrollRef}
-            onScroll={onTopScroll}
-            style={{ marginLeft: pinnedLeftWidth, top: headerHeight }}
+            className="tetv-loading-overlay"
+            role="status"
+            aria-live="polite"
           >
-            <div
-              className="tetv-top-scroll-inner"
-              style={{ width: scrollContentWidth }}
-            />
+            <Spinner animation="border" size="sm" />
+            <span>Loading TET data…</span>
           </div>
-          {isResizing && (
-            <div
-              className="tetv-resize-overlay"
-              role="status"
-              aria-live="polite"
-            >
-              <Spinner animation="border" size="sm" />
-              <span>Adjusting columns…</span>
-            </div>
-          )}
-          <AgGridReact
-            rowData={rowData}
-            columnDefs={columnDefs}
-            domLayout="autoHeight"
-            animateRows={false}
-            suppressRowClickSelection
-            suppressColumnVirtualisation
-            reactiveCustomComponents
-            enableCellTextSelection
-            ensureDomOrder
-            enableBrowserTooltips
-            rowSelection="multiple"
-            getRowId={(p) => p.data?.curie || p.data?.input}
-            onSelectionChanged={(ev) => {
-              const next = new Set(
-                (ev.api.getSelectedRows?.() || [])
-                  .map((r) => r?.curie)
-                  .filter(Boolean)
-              );
-              setSelectedRefCuries(next);
-            }}
-            onGridReady={onGridReady}
-            onFirstDataRendered={() => {
-              // AgGrid signals first paint complete — run autosize on the
-              // next frame so we measure cells that are now in the DOM.
-              // With ~50 rows this is the only reliable signal that all
-              // cells have laid out; the row-count-scaled fallback in the
-              // useEffect above still runs as a safety net. We keep the
-              // resizing overlay on until autosize has flushed.
-              setIsResizing(true);
-              requestAnimationFrame(() => {
-                autoSizeAndFill();
-                requestAnimationFrame(() => setIsResizing(false));
-              });
-            }}
-            onBodyScroll={onBodyScroll}
-            onFilterChanged={handleFilterChanged}
-            onSortChanged={handleSortChanged}
-            getRowClass={(p) => {
-              if (!p?.data) return '';
-              // Only consider topics currently visible. A validation on a
-              // hidden topic shouldn't paint the row, because the curator
-              // can't see the corresponding "validated …" status anywhere.
-              for (const t of topicColumns) {
-                if (hiddenTopicCuries.has(t.curie)) continue;
-                const tets = p.data[`__topic_${t.curie}`];
-                if (
-                  professionalBiocuratorTopicTets(tets).length > 0
-                ) {
-                  return 'tetv-row-validated';
-                }
-              }
-              return '';
-            }}
+        )}
+        <div
+          className="tetv-top-scroll"
+          ref={topScrollRef}
+          onScroll={onTopScroll}
+          style={{ marginLeft: pinnedLeftWidth, top: headerHeight }}
+        >
+          <div
+            className="tetv-top-scroll-inner"
+            style={{ width: scrollContentWidth }}
           />
         </div>
-      )}
+        {isResizing && (
+          <div
+            className="tetv-resize-overlay"
+            role="status"
+            aria-live="polite"
+          >
+            <Spinner animation="border" size="sm" />
+            <span>Adjusting columns…</span>
+          </div>
+        )}
+        <AgGridReact
+          rowData={rowData}
+          columnDefs={columnDefs}
+          domLayout="autoHeight"
+          animateRows={false}
+          suppressRowClickSelection
+          suppressColumnVirtualisation
+          reactiveCustomComponents
+          enableCellTextSelection
+          ensureDomOrder
+          enableBrowserTooltips
+          rowSelection="multiple"
+          getRowId={(p) => p.data?.curie || p.data?.input}
+          onSelectionChanged={(ev) => {
+            const next = new Set(
+              (ev.api.getSelectedRows?.() || [])
+                .map((r) => r?.curie)
+                .filter(Boolean)
+            );
+            setSelectedRefCuries(next);
+          }}
+          onGridReady={onGridReady}
+          onFirstDataRendered={() => {
+            // AgGrid signals first paint complete — run autosize on the
+            // next frame so we measure cells that are now in the DOM.
+            // With ~50 rows this is the only reliable signal that all
+            // cells have laid out; the row-count-scaled fallback in the
+            // useEffect above still runs as a safety net. We keep the
+            // resizing overlay on until autosize has flushed.
+            setIsResizing(true);
+            requestAnimationFrame(() => {
+              autoSizeAndFill();
+              requestAnimationFrame(() => setIsResizing(false));
+            });
+          }}
+          onBodyScroll={onBodyScroll}
+          onFilterChanged={handleFilterChanged}
+          onSortChanged={handleSortChanged}
+          getRowClass={(p) => {
+            if (!p?.data) return '';
+            // Only consider topics currently visible. A validation on a
+            // hidden topic shouldn't paint the row, because the curator
+            // can't see the corresponding "validated …" status anywhere.
+            for (const t of topicColumns) {
+              if (hiddenTopicCuries.has(t.curie)) continue;
+              const tets = p.data[`__topic_${t.curie}`];
+              if (
+                professionalBiocuratorTopicTets(tets).length > 0
+              ) {
+                return 'tetv-row-validated';
+              }
+            }
+            return '';
+          }}
+        />
+      </div>
       {bulkPending && (
         <BulkValidationModal
           show={!!bulkPending}

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -61,7 +61,7 @@ const EMPTY_CELL_FILTER_FLAGS = Object.freeze({
 });
 
 const INNER_COLUMN_FILTER_LABELS = {
-  [INNER_COLUMN_TYPES.VALIDATION]: 'Validation status',
+  [INNER_COLUMN_TYPES.VALIDATION]: 'Assessment status',
   [INNER_COLUMN_TYPES.TAG]: 'Data',
   [INNER_COLUMN_TYPES.SOURCES]: 'Sources',
   [INNER_COLUMN_TYPES.CONF_SCORE]: 'Confidence score',
@@ -1339,7 +1339,7 @@ export default function TetValidationGrid({
           makeInnerColumn({
             headerName: 'Assessment by Biocurator',
             headerTooltip:
-              'Assessment by Biocurator. When at least one curator has submitted a topic-level tag, the cell shows the validation status (validated positive / validated negative / validation conflict). Otherwise, ✓ and ✗ buttons let the curator submit one.',
+              'Assessment by Biocurator. When at least one curator has submitted a topic-level tag, the cell shows the assessment status (positive / negative / assessment conflict). Otherwise, ✓ and ✗ buttons let the curator submit one.',
             colId: `${t.curie}__val`,
             kind: INNER_COLUMN_TYPES.VALIDATION,
             width: 90,
@@ -1429,7 +1429,7 @@ export default function TetValidationGrid({
           headerGroupComponent: HeaderGroupWithHelp,
           headerTooltip:
             `Topic "${t.name || t.curie}" (${t.curie}) — a topic from the MOD's ATP subset. ` +
-            'Sub-columns show the validation status, per-source TET data, a compact tag summary, and (optionally) confidence and notes for this topic on each reference.',
+            'Sub-columns show the assessment status, per-source TET data, a compact tag summary, and (optionally) confidence and notes for this topic on each reference.',
           groupId: `tg-${t.curie}`,
           marryChildren: true,
           // Allow long topic names to wrap inside the group header instead of

--- a/src/components/refs_tet_validation/cellRenderers/BulkValidationModal.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/BulkValidationModal.jsx
@@ -262,7 +262,7 @@ export default function BulkValidationModal({
               <Form.Control
                 as="textarea"
                 rows={3}
-                placeholder="Optional note applied to every assessment in this batch…"
+                placeholder="Optional note applied to every tag in this batch…"
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
                 disabled={isSubmitting}

--- a/src/components/refs_tet_validation/cellRenderers/BulkValidationModal.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/BulkValidationModal.jsx
@@ -220,7 +220,7 @@ export default function BulkValidationModal({
         {status === 'editing' && (
           <>
             <p style={{ marginBottom: 10 }}>
-              This will create one <strong>assessment TET tag</strong>{' '}
+              This will create one <strong>{kind}</strong> topic tag{' '}
               per selected reference attributed to{' '}
               <strong>{userEmail || uid || '(unknown user)'}</strong>.
             </p>

--- a/src/components/refs_tet_validation/cellRenderers/BulkValidationModal.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/BulkValidationModal.jsx
@@ -192,7 +192,7 @@ export default function BulkValidationModal({
   const disabledReason = noSource
     ? 'Curator source not yet loaded — the grid is still resolving your MOD-specific TET source.'
     : noEligible
-    ? 'All selected references already have a professional-biocurator validation for this topic.'
+    ? 'All selected references already have a professional-biocurator assessment for this topic.'
     : null;
 
   return (
@@ -205,7 +205,7 @@ export default function BulkValidationModal({
     >
       <Modal.Header closeButton={!isSubmitting}>
         <Modal.Title>
-          Bulk topic validation —{' '}
+          Bulk topic assessment —{' '}
           <span
             className={`tetv-validation-status ${
               kind === 'negative' ? 'tetv-validated-neg' : 'tetv-validated-pos'
@@ -220,7 +220,7 @@ export default function BulkValidationModal({
         {status === 'editing' && (
           <>
             <p style={{ marginBottom: 10 }}>
-              This will create one <strong>validation TET tag</strong>{' '}
+              This will create one <strong>assessment TET tag</strong>{' '}
               per selected reference attributed to{' '}
               <strong>{userEmail || uid || '(unknown user)'}</strong>.
             </p>
@@ -234,9 +234,9 @@ export default function BulkValidationModal({
               <dl className="tetv-validation-fields-list">
                 <dt>Selected references</dt>
                 <dd>{references.length}</dd>
-                <dt>To be validated</dt>
+                <dt>To be assessed</dt>
                 <dd>{eligible.length}</dd>
-                <dt>Already validated (will be skipped)</dt>
+                <dt>Already assessed (will be skipped)</dt>
                 <dd style={skipped.length === 0 ? noneStyle : undefined}>
                   {skipped.length === 0 ? 'none' : skipped.length}
                 </dd>
@@ -262,7 +262,7 @@ export default function BulkValidationModal({
               <Form.Control
                 as="textarea"
                 rows={3}
-                placeholder="Optional note applied to every validation in this batch…"
+                placeholder="Optional note applied to every assessment in this batch…"
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
                 disabled={isSubmitting}
@@ -344,13 +344,13 @@ export default function BulkValidationModal({
               {status === 'submitting' && (
                 <>
                   <Spinner animation="border" size="sm" /> Submitting{' '}
-                  validations…
+                  assessments…
                 </>
               )}
               {status === 'done' && (
                 <span style={{ color: '#1e7d3a', fontWeight: 600 }}>
                   <FontAwesomeIcon icon={faCheckCircle} /> All{' '}
-                  {successes.length} validation tag(s) created.
+                  {successes.length} assessment tag(s) created.
                 </span>
               )}
               {status === 'partial' && (
@@ -414,7 +414,7 @@ export default function BulkValidationModal({
               <FontAwesomeIcon
                 icon={kind === 'negative' ? faTimesCircle : faCheckCircle}
               />{' '}
-              Validate {eligible.length} reference
+              Assess {eligible.length} reference
               {eligible.length === 1 ? '' : 's'} {kind}
             </Button>
           </>

--- a/src/components/refs_tet_validation/cellRenderers/CellValidationStrip.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/CellValidationStrip.jsx
@@ -169,8 +169,8 @@ export default function CellValidationStrip({
             (pending.status === 'editing' || pending.status === 'submitting') && (
               <>
                 <p style={{ marginBottom: 12 }}>
-                  This will create a new <strong>assessment TET tag</strong>{' '}
-                  attributed to{' '}
+                  This will create a new <strong>{pending.kind}</strong>{' '}
+                  topic tag attributed to{' '}
                   <strong>{userEmail || uid || '(unknown user)'}</strong>.
                 </p>
 

--- a/src/components/refs_tet_validation/cellRenderers/CellValidationStrip.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/CellValidationStrip.jsx
@@ -192,7 +192,7 @@ export default function CellValidationStrip({
                   <Form.Control
                     as="textarea"
                     rows={3}
-                    placeholder="Optional note for this assessment…"
+                    placeholder="Optional note for this tag…"
                     value={pending.note}
                     onChange={(e) =>
                       setPending((s) => ({ ...s, note: e.target.value }))

--- a/src/components/refs_tet_validation/cellRenderers/CellValidationStrip.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/CellValidationStrip.jsx
@@ -162,14 +162,14 @@ export default function CellValidationStrip({
         size="lg"
       >
         <Modal.Header closeButton={!isSubmitting}>
-          <Modal.Title>Topic validation</Modal.Title>
+          <Modal.Title>Topic assessment</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           {pending &&
             (pending.status === 'editing' || pending.status === 'submitting') && (
               <>
                 <p style={{ marginBottom: 12 }}>
-                  This will create a new <strong>validation TET tag</strong>{' '}
+                  This will create a new <strong>assessment TET tag</strong>{' '}
                   attributed to{' '}
                   <strong>{userEmail || uid || '(unknown user)'}</strong>.
                 </p>
@@ -192,7 +192,7 @@ export default function CellValidationStrip({
                   <Form.Control
                     as="textarea"
                     rows={3}
-                    placeholder="Optional note for this validation…"
+                    placeholder="Optional note for this assessment…"
                     value={pending.note}
                     onChange={(e) =>
                       setPending((s) => ({ ...s, note: e.target.value }))
@@ -397,7 +397,7 @@ export default function CellValidationStrip({
           {pending?.status === 'error' && (
             <>
               <p style={{ color: '#b03a2e' }}>
-                Could not create the validation tag.
+                Could not create the assessment tag.
               </p>
               <pre
                 style={{

--- a/src/components/refs_tet_validation/cellRenderers/ValidationCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/ValidationCell.jsx
@@ -148,7 +148,7 @@ export default function ValidationCell(params) {
 
     let label, cls, tooltip, attribution;
     if (positives > 0 && negatives > 0) {
-      label = 'validation conflict';
+      label = 'assessment conflict';
       cls = 'tetv-validation-status tetv-validated-conflict';
       tooltip =
         `${positives} positive + ${negatives} negative professional ` +

--- a/src/components/refs_tet_validation/filters/TopicCellFilter.jsx
+++ b/src/components/refs_tet_validation/filters/TopicCellFilter.jsx
@@ -3,6 +3,12 @@ import { useGridFilter } from 'ag-grid-react';
 import { useSelector } from 'react-redux';
 import { TOPIC_CELL_FILTER_KEYS, cellPredicate } from '../helpers/groupTets';
 
+// Display labels for the (persisted) filter-model keys — the keys themselves
+// stay unchanged so saved filter models keep working (SCRUM-6291).
+const FILTER_KEY_LABELS = {
+  'my validation present': 'my assessment present',
+};
+
 const TopicCellFilter = ({ model: rawModel, onModelChange }) => {
   const model = Array.isArray(rawModel) ? rawModel : null;
   const uid = useSelector((s) => s.isLogged.uid);
@@ -49,7 +55,7 @@ const TopicCellFilter = ({ model: rawModel, onModelChange }) => {
             checked={!!(unappliedModel && unappliedModel.includes(k))}
             onChange={(e) => onChange(k, e.target.checked)}
           />
-          <label htmlFor={`tcf-${k}`}> {k}</label>
+          <label htmlFor={`tcf-${k}`}> {FILTER_KEY_LABELS[k] || k}</label>
         </div>
       ))}
       <hr />

--- a/src/components/refs_tet_validation/filters/ValidationFilter.jsx
+++ b/src/components/refs_tet_validation/filters/ValidationFilter.jsx
@@ -5,6 +5,12 @@ import {
   validationState,
 } from '../helpers/groupTets';
 
+// Display labels for the (persisted) filter-model keys — the keys themselves
+// stay unchanged so saved filter models keep working (SCRUM-6291).
+const FILTER_KEY_LABELS = {
+  unvalidated: 'unassessed',
+};
+
 const ValidationFilter = ({ model: rawModel, onModelChange }) => {
   const model = Array.isArray(rawModel) ? rawModel : null;
   const [closeFilter, setCloseFilter] = useState();
@@ -41,7 +47,7 @@ const ValidationFilter = ({ model: rawModel, onModelChange }) => {
 
   return (
     <div className="custom-filter">
-      <div>Validation status</div>
+      <div>Assessment status</div>
       <hr />
       {VALIDATION_FILTER_KEYS.map((k) => (
         <div key={k}>
@@ -51,7 +57,7 @@ const ValidationFilter = ({ model: rawModel, onModelChange }) => {
             checked={!!(unappliedModel && unappliedModel.includes(k))}
             onChange={(e) => onChange(k, e.target.checked)}
           />
-          <label htmlFor={`vf-${k}`}> {k}</label>
+          <label htmlFor={`vf-${k}`}> {FILTER_KEY_LABELS[k] || k}</label>
         </div>
       ))}
       <hr />

--- a/src/components/refs_tet_validation/hooks/useReferenceTets.js
+++ b/src/components/refs_tet_validation/hooks/useReferenceTets.js
@@ -297,6 +297,13 @@ export function useReferenceTets(
   // filter without deriving them from raw tags.
   const [discovery, setDiscovery] = useState(null);
   const reqIdRef = useRef(0);
+  // Key (ids + filters) of the last fetch that ran to completion. When the
+  // grid is merely re-activated (List view → Topic grid) with unchanged
+  // inputs, the rows already in state are still valid — skip the refetch
+  // instead of reloading the whole batch on every view toggle. A cancelled
+  // fetch never records its key, so re-activation after an aborted load
+  // still refetches.
+  const lastLoadedKeyRef = useRef(null);
 
   // Read the latest biblio map without making it an effect dependency: it is
   // derived from the same search that produced referenceIds, so it changes in
@@ -335,6 +342,8 @@ export function useReferenceTets(
     // but the grid stays mounted to preserve state). Otherwise every later
     // search would trigger a batch fetch for a grid nobody is looking at.
     if (!active) return undefined;
+    const fetchKey = `${JSON.stringify(referenceIds || [])}|${filtersKey}`;
+    if (lastLoadedKeyRef.current === fetchKey) return undefined;
     const reqId = ++reqIdRef.current;
     let cancelled = false;
     setLoading(true);
@@ -414,6 +423,7 @@ export function useReferenceTets(
       setUnresolved(newUnresolved);
       setDiscovery(discoveryResult);
       setLoading(false);
+      lastLoadedKeyRef.current = fetchKey;
       const rowTagCount = nextRows.reduce(
         (sum, row) => sum + (Array.isArray(row.tets) ? row.tets.length : 0),
         0

--- a/src/components/refs_tet_validation/toolbar/BulkActionBar.jsx
+++ b/src/components/refs_tet_validation/toolbar/BulkActionBar.jsx
@@ -46,7 +46,7 @@ export default function BulkActionBar({
   const disabled = noTopics || needsTopicPick;
 
   return (
-    <div className="tetv-bulk-bar" role="region" aria-label="Bulk validation">
+    <div className="tetv-bulk-bar" role="region" aria-label="Bulk assessment">
       <span className="tetv-bulk-count">
         <strong>{selectedCount}</strong> reference
         {selectedCount === 1 ? '' : 's'} selected
@@ -54,7 +54,7 @@ export default function BulkActionBar({
 
       {noTopics ? (
         <span className="tetv-bulk-msg">
-          Enable at least one topic column to validate.
+          Enable at least one topic column to assess.
         </span>
       ) : onlyOneTopic ? (
         <span className="tetv-bulk-msg">
@@ -97,11 +97,11 @@ export default function BulkActionBar({
           disabled={disabled}
           title={
             disabled
-              ? 'Pick a topic to validate first'
-              : `Validate ${selectedCount} reference(s) positive`
+              ? 'Pick a topic to assess first'
+              : `Assess ${selectedCount} reference(s) positive`
           }
         >
-          <FontAwesomeIcon icon={faCheckCircle} /> Validate positive
+          <FontAwesomeIcon icon={faCheckCircle} /> Positive
         </Button>
         <Button
           size="sm"
@@ -110,11 +110,11 @@ export default function BulkActionBar({
           disabled={disabled}
           title={
             disabled
-              ? 'Pick a topic to validate first'
-              : `Validate ${selectedCount} reference(s) negative`
+              ? 'Pick a topic to assess first'
+              : `Assess ${selectedCount} reference(s) negative`
           }
         >
-          <FontAwesomeIcon icon={faTimesCircle} /> Validate negative
+          <FontAwesomeIcon icon={faTimesCircle} /> Negative
         </Button>
         <Button
           size="sm"

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -13,6 +13,7 @@ import SearchOptions from "./SearchOptions";
 import BreadCrumbs from "./BreadCrumbs";
 import SearchPagination from "./SearchPagination";
 import TetValidationGrid from '../refs_tet_validation/TetValidationGrid';
+import TetGridErrorBoundary from '../refs_tet_validation/TetGridErrorBoundary';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
     faChevronLeft,
@@ -176,8 +177,18 @@ const SearchLayout = () => {
         setFacetsCollapsed(prev => !prev);
     }, []);
 
+    // Keep the grid mounted once it has been opened. referenceIds is derived
+    // from searchResults, which is cleared to [] while a new search loads, so
+    // gating the mount on referenceIds.length tore the grid down on every
+    // search. Remounting an autoHeight AgGrid crashes React's reconciler
+    // ("Failed to execute 'insertBefore'/'removeChild' ... not a child"),
+    // blanking the page on the 2nd visit. The grid handles an empty
+    // referenceIds itself (it shows its loading overlay and clears rows), so
+    // leaving it mounted across searches is safe. The second clause only
+    // covers the first render where view flips to 'grid' before the
+    // hasOpenedTopicGrid effect has run. Ported from SCRUM-6229 (252593a4).
     const shouldRenderTopicGrid =
-        referenceIds.length > 0 && (view === 'grid' || hasOpenedTopicGrid);
+        hasOpenedTopicGrid || (view === 'grid' && referenceIds.length > 0);
 
     return (
         <div>
@@ -346,16 +357,18 @@ const SearchLayout = () => {
                                             display: view === 'grid' && !searchLoading ? 'block' : 'none',
                                         }}
                                     >
-                                        <TetValidationGrid
-                                            referenceIds={referenceIds}
-                                            topics={topicsForGrid}
-                                            excludedConfidenceLevels={excludedConfidenceLevels}
-                                            confidenceScore={confidenceScore}
-                                            biblioByCurie={biblioByCurie}
-                                            searchFilters={searchFilters}
-                                            active={view === 'grid'}
-                                            persistRef={gridStateRef}
-                                        />
+                                        <TetGridErrorBoundary>
+                                            <TetValidationGrid
+                                                referenceIds={referenceIds}
+                                                topics={topicsForGrid}
+                                                excludedConfidenceLevels={excludedConfidenceLevels}
+                                                confidenceScore={confidenceScore}
+                                                biblioByCurie={biblioByCurie}
+                                                searchFilters={searchFilters}
+                                                active={view === 'grid'}
+                                                persistRef={gridStateRef}
+                                            />
+                                        </TetGridErrorBoundary>
                                     </div>
                                 )}
                             </div>

--- a/src/components/search/__tests__/SearchLayout.test.js
+++ b/src/components/search/__tests__/SearchLayout.test.js
@@ -16,10 +16,11 @@ jest.mock('react-redux', () => ({
   useSelector: (fn) => fn(mockState),
 }));
 
-// The grid unmounts on every search (results are cleared while loading). This
-// mock records how the persistRef store behaves across that remount: it writes
-// a marker on first mount and reads it back on the next mount. If SearchLayout
-// holds the store in a stable ref, the marker survives the remount.
+// Once opened, the grid must stay mounted across searches (remounting an
+// autoHeight AgGrid crashes React's reconciler — see SCRUM-6229). This mock
+// records mount/unmount counts to assert that, and still exercises the
+// persistRef store: it writes a marker on first mount and would read it back
+// on any later remount (e.g. leaving and revisiting the search page).
 const mockGrid = { mounts: 0, unmounts: 0, sawOnRemount: undefined };
 
 jest.mock('../../refs_tet_validation/TetValidationGrid', () => {
@@ -64,7 +65,7 @@ beforeEach(() => {
   });
 });
 
-test('grid persistence store survives the unmount/remount of a new search', () => {
+test('grid stays mounted across a new search once opened', () => {
   const { rerender } = render(<SearchLayout />);
 
   // Switch to the topic grid view; this mounts the grid once.
@@ -72,21 +73,23 @@ test('grid persistence store survives the unmount/remount of a new search', () =
   expect(screen.getByTestId('tet-grid')).toBeInTheDocument();
   expect(mockGrid.mounts).toBe(1);
 
-  // A new search (pagination/filter change) clears results while loading —
-  // referenceIds becomes empty so the grid unmounts.
+  // A new search (pagination/filter change) clears results while loading.
+  // The grid must NOT unmount — remounting an autoHeight AgGrid crashes
+  // React's reconciler ("removeChild/insertBefore ... not a child of this
+  // node") — it is only hidden while the search loads.
   setSearchState({ searchResults: [], searchLoading: true });
   rerender(<SearchLayout />);
-  expect(screen.queryByTestId('tet-grid')).not.toBeInTheDocument();
-  expect(mockGrid.unmounts).toBe(1);
+  expect(screen.getByTestId('tet-grid')).toBeInTheDocument();
+  expect(mockGrid.unmounts).toBe(0);
 
-  // Results return — the grid remounts and must read back the marker it stored
-  // before the unmount, proving the persistence container is stable.
+  // Results return — still the same grid instance, no remount, so the
+  // persistence store trivially survives the search.
   setSearchState({
     searchResults: [{ curie: 'AGRKB:101000000000002' }],
     searchLoading: false,
   });
   rerender(<SearchLayout />);
   expect(screen.getByTestId('tet-grid')).toBeInTheDocument();
-  expect(mockGrid.mounts).toBe(2);
-  expect(mockGrid.sawOnRemount).toBe('kept-selection');
+  expect(mockGrid.mounts).toBe(1);
+  expect(mockGrid.unmounts).toBe(0);
 });


### PR DESCRIPTION
## Summary

[SCRUM-6291](https://agr-jira.atlassian.net/browse/SCRUM-6291) — the topic grid column was renamed to **"Assessment by Biocurator"**, but buttons, modals, filters, and tooltips in the same view still said "validation" / "validate", which was confusing for curators. This PR aligns all remaining user-visible text with the new terminology ("assessment", or plain "positive" / "negative"), with follow-up refinements from curator review. It also fixes the topic-grid crash/reload issues found while testing, including porting the stability fixes stranded on the unmerged `SCRUM-6229` branch.

## Wording changes (UI text only)

- **Bulk action bar**: buttons now read "Positive" / "Negative" (with ✓ / ✗ icons); tooltips "Assess N reference(s) positive/negative" and "Pick a topic to assess first"; empty-state "Enable at least one topic column to assess."
- **Bulk confirmation modal**: title "Bulk topic assessment"; lead sentence "This will create one **positive|negative** topic tag per selected reference attributed to …" (polarity bolded); counters "To be assessed" / "Already assessed (will be skipped)"; note placeholder "Optional note applied to every tag in this batch…"; progress/success text "Submitting assessments…" / "All N assessment tag(s) created."; confirm button "Assess N reference(s) positive/negative".
- **Single-cell confirmation modal**: title "Topic assessment"; lead sentence "This will create a new **positive|negative** topic tag attributed to …"; note placeholder "Optional note for this tag…"; error "Could not create the assessment tag."
- **Status pill**: "validation conflict" → "assessment conflict".
- **Filters**: panel header "Assessment status"; displayed options "unassessed" and "my assessment present". Persisted filter-model keys are unchanged (label map only), so saved filter state keeps working.
- **Column tooltips**: now describe "assessment status (positive / negative / assessment conflict)".

Internal identifiers, CSS class names, and API payloads are untouched.

## Topic-grid stability fixes

Found while testing this PR: toggling List ⇄ Topic grid crashed with `NotFoundError: Failed to execute 'removeChild' on 'Node'`, and every return to the Topic grid refetched the whole batch.

- **Skip redundant refetch** (`8c9fa900`): `useReferenceTets` tracks the ids+filters key of the last completed load and skips the fetch when re-activated with unchanged inputs; new searches, changed filters, and aborted loads still refetch.
- **Ported from the unmerged `SCRUM-6229` branch** (`85c4ee05`, co-authored with @sweng66 — that ticket was closed Done but these commits never got a PR and were stranded when SCRUM-6242 rewrote the hook):
  - **Keep AgGridReact permanently mounted**: the loading state is an overlay veil on the live grid instead of a ternary swap that tore down (and later remounted) an autoHeight AgGrid — the root trigger of the `removeChild`/`insertBefore` reconciler crashes. Supersedes the interim keyed-ternary fix (`d203c66f`).
  - **Keep the grid mounted across searches**: `shouldRenderTopicGrid` no longer flips false while `searchResults` is cleared during a search load; the SearchLayout test now asserts the grid survives a search without unmounting.
  - **`TetGridErrorBoundary`**: bounded auto-remount then a manual "Reload grid" fallback, so a commit-phase AgGrid/React DOM error can never blank the whole page.
  - **`translate="no"` / `notranslate`** on the grid subtree so DOM-mutating browser extensions (Google Translate) can't desync React.
  - Not ported: topic-name seeding (`ff498858`) — subsumed by the server discovery aggregates `main` already consumes.

## Test plan

- `npx eslint` on all changed files: clean
- `CI=true npx react-app-rewired test src/components/refs_tet_validation src/components/search --watchAll=false`: 44/44 pass (SearchLayout test updated to the new keep-mounted contract)
- Swept `refs_tet_validation/` for remaining user-visible "validat" strings: none left
- Manual: toggle List ⇄ Topic grid repeatedly — no crash, no redundant batch reload; run a new search from grid view — grid stays mounted and updates in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SCRUM-6291]: https://agr-jira.atlassian.net/browse/SCRUM-6291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ