### PR TITLE
fix(scrum-6295): show nXML- and TEI-derived markdown, hide raw tei files

### DIFF
--- a/src/components/biblio/BiblioFileManagement.js
+++ b/src/components/biblio/BiblioFileManagement.js
@@ -820,7 +820,9 @@ const CONVERTED_FILE_CLASSES = {
   ]
 };
 
-// All converted file classes (for filtering)
+// All converted file classes (for filtering). 'tei' stays listed so tei files
+// are kept out of the file table, even though tei links are no longer rendered
+// in the Converted Files column.
 const ALL_CONVERTED_FILE_CLASSES = [
   ...CONVERTED_FILE_CLASSES.main,
   ...CONVERTED_FILE_CLASSES.supplement,
@@ -837,6 +839,73 @@ const CONVERTED_FILE_LABELS = {
   'converted_grobid_supplement': 'grobid',
   'converted_docling_supplement': 'docling',
   'converted_marker_supplement': 'marker'
+};
+
+// Method suffixes used in converted file display names.
+// PDFX outputs use _grobid/_docling/_marker/_merged; XML-derived outputs use
+// _nxml (from nXML sources) and _tei (from TEI sources). Stripping any of
+// these yields the source display_name used as the grouping key.
+const METHOD_SUFFIXES = ['_grobid', '_docling', '_marker', '_merged', '_nxml', '_tei'];
+
+// Create a mapping of base display_name to converted files (markdown and TEI)
+// Converted files have names like "PMC123_grobid" but we need to map to "PMC123"
+export const getConvertedFilesMap = (referenceFiles) => {
+  const map = {};
+  referenceFiles.forEach(file => {
+    if (ALL_CONVERTED_FILE_CLASSES.includes(file.file_class)) {
+      // Strip method suffix to get base display_name
+      let baseDisplayName = file.display_name;
+      for (const suffix of METHOD_SUFFIXES) {
+        if (baseDisplayName.endsWith(suffix)) {
+          baseDisplayName = baseDisplayName.slice(0, -suffix.length);
+          break;
+        }
+      }
+      if (!map[baseDisplayName]) {
+        map[baseDisplayName] = {};
+      }
+      map[baseDisplayName][file.file_class] = file;
+    }
+  });
+  return map;
+};
+
+// Get the appropriate file class list based on the reference file class.
+// nXML sources are treated like main files because their markdown conversions
+// carry main converted classes (e.g. converted_merged_main).
+export const getConvertedFileClasses = (fileClass) => {
+  if (fileClass === 'main' || fileClass === 'nXML') {
+    return CONVERTED_FILE_CLASSES.main;
+  } else if (fileClass === 'supplement') {
+    return CONVERTED_FILE_CLASSES.supplement;
+  }
+  return [];
+};
+
+// Display-name method suffix of a converted file, or null when none matches.
+const getMethodSuffix = (displayName) =>
+  METHOD_SUFFIXES.find((suffix) => displayName.endsWith(suffix)) || null;
+
+// Ordered {file, label} entries for the Converted Files column of a row,
+// in merged, grobid, docling, marker order. Raw tei files are never included,
+// but tei-derived markdown (_tei suffix) is, on main/supplement rows.
+// A main PDF and an nXML file often share the same display_name, so the class
+// lists alone would show the same conversion on both rows; the _nxml suffix
+// pins nXML-derived markdown to its nXML source row and keeps it off the
+// main/supplement rows (and vice versa for the other suffixes).
+export const getConvertedFileEntries = (referenceFile, convertedFilesMap) => {
+  const convertedFiles = convertedFilesMap[referenceFile.display_name] || {};
+  const wantNxmlDerived = referenceFile.file_class === 'nXML';
+  return getConvertedFileClasses(referenceFile.file_class)
+    .filter((fileClass) => convertedFiles[fileClass])
+    .filter((fileClass) => {
+      const isNxmlDerived = getMethodSuffix(convertedFiles[fileClass].display_name) === '_nxml';
+      return isNxmlDerived === wantNxmlDerived;
+    })
+    .map((fileClass) => ({
+      file: convertedFiles[fileClass],
+      label: CONVERTED_FILE_LABELS[fileClass]
+    }));
 };
 
 const FileEditor = ({ onFileStatusChange }) => {
@@ -968,36 +1037,7 @@ const FileEditor = ({ onFileStatusChange }) => {
     }
   };
 
-  // Method suffixes used in converted file display names.
-  // PDFX outputs use _grobid/_docling/_marker/_merged; XML-derived outputs use
-  // _nxml (from nXML sources) and _tei (from TEI sources). Stripping any of
-  // these yields the source display_name used as the grouping key.
-  const METHOD_SUFFIXES = ['_grobid', '_docling', '_marker', '_merged', '_nxml', '_tei'];
-
-  // Create a mapping of base display_name to converted files (markdown and TEI)
-  // Converted files have names like "PMC123_grobid" but we need to map to "PMC123"
-  const getConvertedFilesMap = () => {
-    const map = {};
-    referenceFiles.forEach(file => {
-      if (ALL_CONVERTED_FILE_CLASSES.includes(file.file_class)) {
-        // Strip method suffix to get base display_name
-        let baseDisplayName = file.display_name;
-        for (const suffix of METHOD_SUFFIXES) {
-          if (baseDisplayName.endsWith(suffix)) {
-            baseDisplayName = baseDisplayName.slice(0, -suffix.length);
-            break;
-          }
-        }
-        if (!map[baseDisplayName]) {
-          map[baseDisplayName] = {};
-        }
-        map[baseDisplayName][file.file_class] = file;
-      }
-    });
-    return map;
-  };
-
-  const convertedFilesMap = getConvertedFilesMap();
+  const convertedFilesMap = getConvertedFilesMap(referenceFiles);
 
   // Helper to render a single converted file link
   const renderConvertedFileLink = (file, label, hasAccess) => {
@@ -1018,16 +1058,6 @@ const FileEditor = ({ onFileStatusChange }) => {
       );
     }
     return <span key={file.referencefile_id} style={{ marginRight: '8px' }} title={filename}>{label}</span>;
-  };
-
-  // Get the appropriate file class list based on the reference file class
-  const getConvertedFileClasses = (fileClass) => {
-    if (fileClass === 'main') {
-      return CONVERTED_FILE_CLASSES.main;
-    } else if (fileClass === 'supplement') {
-      return CONVERTED_FILE_CLASSES.supplement;
-    }
-    return [];
   };
 
   const getDisplayRowsFromReferenceFiles = (referenceFilesArray, hasAccess) => {
@@ -1053,37 +1083,15 @@ const FileEditor = ({ onFileStatusChange }) => {
         );
       }
 
-      // Get converted files for this reference file (merged, grobid, docling, marker order)
-      const convertedFiles = convertedFilesMap[referenceFile.display_name] || {};
-      const convertedFileClasses = getConvertedFileClasses(referenceFile.file_class);
-
-      // Also check for TEI file (legacy support)
-      const teiFile = convertedFiles['tei'];
-
-      // Build converted files display in order: merged, grobid, docling, marker
+      // Converted markdown files for this reference file (merged, grobid, docling, marker order)
+      const convertedFileEntries = getConvertedFileEntries(referenceFile, convertedFilesMap);
       let convertedFilesDisplay = null;
-      if (convertedFileClasses.length > 0 || teiFile) {
-        const fileLinks = [];
-
-        // Add markdown files in order: merged, grobid, docling, marker
-        convertedFileClasses.forEach(fileClass => {
-          const file = convertedFiles[fileClass];
-          if (file) {
-            const label = CONVERTED_FILE_LABELS[fileClass];
-            fileLinks.push(renderConvertedFileLink(file, label, hasAccess));
-          }
-        });
-
-        // Add TEI file if present (legacy)
-        if (teiFile) {
-          fileLinks.push(renderConvertedFileLink(teiFile, 'tei', hasAccess));
-        }
-
-        if (fileLinks.length > 0) {
-          convertedFilesDisplay = (
-            <div style={{ display: 'flex', flexWrap: 'wrap' }}>{fileLinks}</div>
-          );
-        }
+      if (convertedFileEntries.length > 0) {
+        convertedFilesDisplay = (
+          <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+            {convertedFileEntries.map(({ file, label }) => renderConvertedFileLink(file, label, hasAccess))}
+          </div>
+        );
       }
 
       return (

--- a/src/components/biblio/BiblioFileManagement.test.js
+++ b/src/components/biblio/BiblioFileManagement.test.js
@@ -1,0 +1,155 @@
+import {
+  getConvertedFilesMap,
+  getConvertedFileClasses,
+  getConvertedFileEntries,
+} from './BiblioFileManagement';
+
+let nextId = 1;
+const makeFile = (display_name, file_class, file_extension = 'md') => ({
+  referencefile_id: nextId++,
+  display_name,
+  file_class,
+  file_extension,
+  referencefile_mods: [],
+});
+
+const MAIN_CLASSES = [
+  'converted_merged_main',
+  'converted_grobid_main',
+  'converted_docling_main',
+  'converted_marker_main',
+];
+
+const SUPPLEMENT_CLASSES = [
+  'converted_merged_supplement',
+  'converted_grobid_supplement',
+  'converted_docling_supplement',
+  'converted_marker_supplement',
+];
+
+describe('getConvertedFileClasses', () => {
+  test('main rows show main converted classes in merged/grobid/docling/marker order', () => {
+    expect(getConvertedFileClasses('main')).toEqual(MAIN_CLASSES);
+  });
+
+  test('nXML rows show main converted classes (nXML→markdown outputs are converted_merged_main)', () => {
+    expect(getConvertedFileClasses('nXML')).toEqual(MAIN_CLASSES);
+  });
+
+  test('supplement rows show supplement converted classes', () => {
+    expect(getConvertedFileClasses('supplement')).toEqual(SUPPLEMENT_CLASSES);
+  });
+
+  test('other file classes show no converted files', () => {
+    expect(getConvertedFileClasses('figure')).toEqual([]);
+    expect(getConvertedFileClasses('tei')).toEqual([]);
+    expect(getConvertedFileClasses(undefined)).toEqual([]);
+  });
+});
+
+describe('getConvertedFilesMap', () => {
+  test('groups converted files under the source display_name by stripping method suffixes', () => {
+    const merged = makeFile('PMC123_merged', 'converted_merged_main');
+    const grobid = makeFile('PMC123_grobid', 'converted_grobid_main');
+    const map = getConvertedFilesMap([
+      makeFile('PMC123', 'main', 'pdf'),
+      merged,
+      grobid,
+    ]);
+    expect(map).toEqual({
+      PMC123: {
+        converted_merged_main: merged,
+        converted_grobid_main: grobid,
+      },
+    });
+  });
+
+  test('groups _nxml markdown under the nXML source display_name', () => {
+    const nxmlMd = makeFile('PMC456_nxml', 'converted_merged_main');
+    const map = getConvertedFilesMap([
+      makeFile('PMC456', 'nXML', 'xml'),
+      nxmlMd,
+    ]);
+    expect(map).toEqual({
+      PMC456: { converted_merged_main: nxmlMd },
+    });
+  });
+
+  test('ignores non-converted file classes', () => {
+    expect(getConvertedFilesMap([makeFile('PMC123', 'main', 'pdf')])).toEqual({});
+  });
+});
+
+describe('getConvertedFileEntries', () => {
+  test('returns ordered labeled entries for a main row', () => {
+    const merged = makeFile('PMC123_merged', 'converted_merged_main');
+    const grobid = makeFile('PMC123_grobid', 'converted_grobid_main');
+    const mainRow = makeFile('PMC123', 'main', 'pdf');
+    const map = getConvertedFilesMap([mainRow, merged, grobid]);
+    expect(getConvertedFileEntries(mainRow, map)).toEqual([
+      { file: merged, label: 'merged' },
+      { file: grobid, label: 'grobid' },
+    ]);
+  });
+
+  test('returns the nXML-derived markdown for an nXML row', () => {
+    const nxmlMd = makeFile('PMC456_nxml', 'converted_merged_main');
+    const nxmlRow = makeFile('PMC456', 'nXML', 'xml');
+    const map = getConvertedFilesMap([nxmlRow, nxmlMd]);
+    expect(getConvertedFileEntries(nxmlRow, map)).toEqual([
+      { file: nxmlMd, label: 'merged' },
+    ]);
+  });
+
+  test('does not include raw tei files (tei is no longer displayed)', () => {
+    const merged = makeFile('PMC123_merged', 'converted_merged_main');
+    const tei = makeFile('PMC123', 'tei', 'tei');
+    const mainRow = makeFile('PMC123', 'main', 'pdf');
+    const map = getConvertedFilesMap([mainRow, merged, tei]);
+    expect(getConvertedFileEntries(mainRow, map)).toEqual([
+      { file: merged, label: 'merged' },
+    ]);
+  });
+
+  test('includes tei-derived markdown (_tei suffix) on the main row', () => {
+    const teiMd = makeFile('PMC123_tei', 'converted_merged_main');
+    const tei = makeFile('PMC123', 'tei', 'tei');
+    const mainRow = makeFile('PMC123', 'main', 'pdf');
+    const map = getConvertedFilesMap([mainRow, tei, teiMd]);
+    expect(getConvertedFileEntries(mainRow, map)).toEqual([
+      { file: teiMd, label: 'merged' },
+    ]);
+  });
+
+  test('shows _nxml markdown only on the nXML row when main and nXML share a display_name', () => {
+    const nxmlMd = makeFile('PMC789_nxml', 'converted_merged_main');
+    const mainRow = makeFile('PMC789', 'main', 'pdf');
+    const nxmlRow = makeFile('PMC789', 'nXML', 'xml');
+    const map = getConvertedFilesMap([mainRow, nxmlRow, nxmlMd]);
+    expect(getConvertedFileEntries(nxmlRow, map)).toEqual([
+      { file: nxmlMd, label: 'merged' },
+    ]);
+    expect(getConvertedFileEntries(mainRow, map)).toEqual([]);
+  });
+
+  test('does not show non-nXML-derived markdown on the nXML row', () => {
+    const teiMd = makeFile('PMC321_tei', 'converted_merged_main');
+    const nxmlRow = makeFile('PMC321', 'nXML', 'xml');
+    const map = getConvertedFilesMap([nxmlRow, teiMd]);
+    expect(getConvertedFileEntries(nxmlRow, map)).toEqual([]);
+  });
+
+  test('returns supplement entries for a supplement row', () => {
+    const merged = makeFile('supp1_merged', 'converted_merged_supplement');
+    const suppRow = makeFile('supp1', 'supplement', 'pdf');
+    const map = getConvertedFilesMap([suppRow, merged]);
+    expect(getConvertedFileEntries(suppRow, map)).toEqual([
+      { file: merged, label: 'merged' },
+    ]);
+  });
+
+  test('returns no entries for rows with no converted files', () => {
+    const figureRow = makeFile('fig1', 'figure', 'jpg');
+    expect(getConvertedFileEntries(figureRow, {})).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

[SCRUM-6295](https://agr-jira.atlassian.net/browse/SCRUM-6295): the Biblio file-management table only displayed `_merged` markdown — markdown converted from nXML (`_nxml`) and TEI (`_tei`) sources was never shown. Raw `tei` files are also deprecated and should no longer be shown.

- **Root cause for `_nxml`**: nXML-derived markdown (`file_class: converted_merged_main`, display_name `<source>_nxml`) groups under the nXML source row, but `getConvertedFileClasses('nXML')` returned `[]`, so the nXML row's Converted Files column stayed empty. nXML rows are now treated like main rows.
- **Raw tei files** are no longer rendered as links. `'tei'` stays in `ALL_CONVERTED_FILE_CLASSES` so tei rows remain filtered out of the file table.
- **TEI-derived markdown** (`_tei` suffix) still displays on the main row (TEI files share the main PDF's display_name, so the stripped base matches the main row).
- **Dedup**: main PDFs and nXML files usually share a display_name (~180k refs on dev DB), which would have shown the same conversion on both rows. `_nxml` markdown is pinned to the nXML row; other conversions to main/supplement rows.
- The grouping/selection logic is hoisted to exported pure helpers with unit tests (15 cases).

Verified against dev-DB data: all 290,140 `converted_merged_main` rows end in `_tei`/`_nxml`/`_merged` and every one now anchors to a visible row, except ~309 duplicate-conversion artifacts (refs with two TEI files) that stay hidden as redundant copies.

## Test plan

- `CI=true npx react-app-rewired test src/components/biblio --watchAll=false` — 31 tests pass
- `npx eslint` on changed files — clean
- Traced real refs through the logic: `AGRKB:101000001212217` (markdown now visible on the nXML row) and the `PMC7971549` ref (tei-derived markdown on the main row, no raw tei link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6295]: https://agr-jira.atlassian.net/browse/SCRUM-6295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ