### PR TITLE
show first pass curation facet in Workflow Tags + hide Edit/Delete for non-ABC tags 

### DIFF
--- a/src/actions/biblioActions.js
+++ b/src/actions/biblioActions.js
@@ -171,7 +171,7 @@ export const getCuratorSourceId = async (mod) => {
         const res = await api.post('/topic_entity_tag/source', {
           "source_evidence_assertion": "ATP:0000036",
           "source_method": "abc_literature_system",
-          "validation_type": "professional_curator",
+          "validation_type": "professional_biocurator",
           "description": "Trained professional biocurator specializing in curation of model organism data using the ABC data entry form.",
           "secondary_data_provider_abbreviation": mod,
           "data_provider": mod,

--- a/src/components/AgGrid/TopicEntityTagActions.jsx
+++ b/src/components/AgGrid/TopicEntityTagActions.jsx
@@ -109,7 +109,11 @@ export default (props) => {
     }
 
 
-    let show_del = props.data.topic_entity_tag_source.validation_type === 'professional_biocurator' &&
+    // Only ABC-created tags may be edited or deleted: block imported/historic MOD tags
+    // by requiring the source to be the ABC literature system professional_biocurator
+    // (SCRUM-6304). secondary_data_provider_abbreviation still restricts to the curator's MOD.
+    let show_del = props.data.topic_entity_tag_source.source_method === 'abc_literature_system' &&
+        props.data.topic_entity_tag_source.validation_type === 'professional_biocurator' &&
         props.data.topic_entity_tag_source.secondary_data_provider_abbreviation === accessLevel;
     return (
     <span>

--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -78,6 +78,7 @@ export const RENAME_FACETS = {
     "manual_indexing": "Manual indexing",
     "curation_classification": "Curation classification",
     "community_curation": "Community curation",
+    "first_pass_curation": "First pass curation",
     "email_extraction": "Email extraction",
     "predicted_indexing_priority": "Predicted indexing priority",
     "indexing_priority": "Indexing priority",
@@ -128,7 +129,7 @@ export const RENAME_FACET_VALUES = {
 
 export const FACETS_CATEGORIES_WITH_FACETS = {
     "Alliance Metadata": ["mods in corpus", "mods needs review", "mods in corpus or needs review"],
-    "Workflow Tags": ["file_workflow", "reference_classification", "entity_extraction", "manual_indexing", "curation_classification", "community_curation", "email_extraction"],
+    "Workflow Tags": ["file_workflow", "reference_classification", "entity_extraction", "manual_indexing", "curation_classification", "community_curation", "first_pass_curation", "email_extraction"],
     "Curation Classification Tags": ["predicted_indexing_priority", "indexing_priority", "manual_indexing_curation_tag"],
     "Bibliographic Data": ["mod reference types", "pubmed types", "category", "pubmed publication status", "retraction status", "authors.name", "language"],
     "Images": ["can display image", "has image"],
@@ -430,7 +431,7 @@ const Facet = ({facetsToInclude, renameFacets}) => {
                 let key = facetToInclude.replaceAll(' ', '_');
                 if (!['topics', 'confidence_levels', 'confidence_scores', 'source_methods', 'source_evidence_assertions', 'data_novelty',
                         'file_workflow', 'manual_indexing', 'reference_classification',
-		                'entity_extraction', 'curation_classification', 'community_curation', 'email_extraction',
+		                'entity_extraction', 'curation_classification', 'community_curation', 'first_pass_curation', 'email_extraction',
                         'predicted_indexing_priority', 'indexing_priority', 'manual_indexing_curation_tag',
                         'can_display_image', 'has_image'].includes(key)) {
                     key = key + '.keyword';


### PR DESCRIPTION
Register the first_pass_curation Workflow facet returned by the API as a new parent under the "Workflow Tags" group (label + group membership + render whitelist so it is queried without a spurious .keyword suffix).