### PR TITLE
SCRUM-5781: show ml_model embedding columns in the Models table

### DIFF
--- a/src/components/reports/ModelsTable.js
+++ b/src/components/reports/ModelsTable.js
@@ -107,6 +107,8 @@ const ITEMS_INIT = [
   { headerName: 'File Classes', field: 'file_classes', id: 15, checked: true },
   { headerName: 'Description', field: 'description', id: 16, checked: true },
   { headerName: 'Parameters', field: 'parameters', id: 17, checked: true },
+  { headerName: 'Embedding Profile', field: 'embedding_profile', id: 19, checked: true },
+  { headerName: 'Embedding Version', field: 'embedding_version', id: 20, checked: true },
   { headerName: 'ID', field: 'ml_model_id', id: 18, checked: false }
 ];
 
@@ -257,6 +259,8 @@ const ModelsTable = ({ modSection }) => {
         tooltipField: 'parameters',
         onCellClicked: (p) => handleParametersClick(p.value)
       },
+      { headerName: 'Embedding Profile', field: 'embedding_profile', filter: true, comparator: caseInsensitiveComparator, tooltipField: 'embedding_profile' },
+      { headerName: 'Embedding Version', field: 'embedding_version', filter: 'agNumberColumnFilter' },
       { headerName: 'ID', field: 'ml_model_id', filter: 'agNumberColumnFilter' }
     ],
     [caseInsensitiveComparator, numericFormatter]


### PR DESCRIPTION
## Summary
Surface the new `ml_model` ABC-embedding columns in the Models report grid so curators can see which models were trained on the ABC's precomputed embeddings.

Adds two columns to `ModelsTable.js` (both to the column defs and the Hide/Show list):
- **Embedding Profile** (`embedding_profile`) — the ABC embedding profile; blank/NULL for legacy BioWordVec models.
- **Embedding Version** (`embedding_version`).

Both are populated from `/ml_model/all` (the fields are added in `agr_literature_service` PR #1245).

## Depends on
`agr_literature_service` PR #1245 — the API must return `embedding_profile`/`embedding_version` for these columns to populate. Until that's deployed the columns simply render blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)