### PR TITLE
fix(SCRUM-6272): let alum be set regardless of is_lab_contact/can_edi…

### DIFF
--- a/src/components/person/PersonEditor.js
+++ b/src/components/person/PersonEditor.js
@@ -641,11 +641,6 @@ const PersonEditor = ({ person }) => {
     const r = {
       labCurie: '', labName: '', labStrain: '',
       alum: false, is_pi: false, former_pi: false,
-      // Carried for the roleFlagDisabled guard only (alum ↔ is_lab_contact /
-      // can_edit_lab). Not rendered/editable here and deliberately kept out of
-      // labFields, so they never enter changed/_saved and can't be PATCHed from
-      // the Person editor.
-      is_lab_contact: false, can_edit_lab: false,
       _alum_ts: null, _is_pi_ts: null, _former_pi_ts: null,
       _ts: null, _by: null, _id: null, _status: null, _error: null,
     };
@@ -660,11 +655,6 @@ const PersonEditor = ({ person }) => {
       alum: !!lp.alum,
       is_pi: !!lp.is_pi,
       former_pi: !!lp.former_pi,
-      // Guard-only (see emptyLab): lets roleFlagDisabled enforce the
-      // alum ↔ is_lab_contact / can_edit_lab exclusion even though those two
-      // boxes aren't rendered in this editor.
-      is_lab_contact: !!lp.is_lab_contact,
-      can_edit_lab: !!lp.can_edit_lab,
       _alum_ts: lp.alum ?? null,
       _is_pi_ts: lp.is_pi ?? null,
       _former_pi_ts: lp.former_pi ?? null,
@@ -1057,8 +1047,6 @@ const PersonEditor = ({ person }) => {
     applyResp: (d) => ({
       alum: !!d.alum, is_pi: !!d.is_pi, former_pi: !!d.former_pi,
       _alum_ts: d.alum ?? null, _is_pi_ts: d.is_pi ?? null, _former_pi_ts: d.former_pi ?? null,
-      // keep the guard-only flags in step with the server (not editable here)
-      is_lab_contact: !!d.is_lab_contact, can_edit_lab: !!d.can_edit_lab,
     }),
   });
   const deleteLab = (i) => deleteChild({ list: labs, update: updateLab, remove: removeLab, i, endpoint: '/laboratory_person' });
@@ -1486,9 +1474,6 @@ const PersonEditor = ({ person }) => {
                         checked={lab[key]}
                         savedValue={lab._saved?.[key]}
                         disabled={!lab.labCurie || roleFlagDisabled(lab, key)}
-                        title={key === 'alum' && !lab.alum && (lab.is_lab_contact || lab.can_edit_lab)
-                          ? 'Disabled because this person is a lab contact or can edit the lab — change that in the Laboratory editor.'
-                          : undefined}
                         onChange={(ev) => {
                           updateLab(i, { [key]: ev.target.checked });
                           saveLab(i, { [key]: ev.target.checked });

--- a/src/utils/labPersonRoles.js
+++ b/src/utils/labPersonRoles.js
@@ -1,29 +1,28 @@
 // Mutual-exclusion rule for the person-lab role/status checkboxes, shared by the
 // Person and Laboratory editors so the constraint lives in one place.
 //
-// The exclusions must be enforced BIDIRECTIONALLY (each side disables the other),
-// because only UNCHECKED boxes are disabled — a one-way rule would let the
-// forbidden state be reached by checking the boxes in the permissive order:
-//   - is_pi is mutually exclusive with former_pi and with alum
-//   - former_pi and alum may coexist
-//   - alum is mutually exclusive with is_lab_contact and can_edit_lab
+// Rules (only UNCHECKED boxes are disabled, so a checked box can always be
+// un-selected to back out):
+//   - is_pi is mutually exclusive with former_pi and with alum (bidirectional):
+//     checking one disables the others; each exclusion is enforced both ways.
+//   - former_pi and alum may coexist.
+//   - alum is NOT blocked by is_lab_contact / can_edit_lab. Curators set alum
+//     whenever they learn it and reconcile the contact/edit flags afterward, so
+//     nothing about contact/edit may disable the alum box.
+//   - Setting alum does still disable *adding* is_lab_contact / can_edit_lab in
+//     the Laboratory editor (they read row.alum); an already-set one stays
+//     checked and can be un-selected to clean it up. This one-directional gate
+//     is intentional — do not "restore" an alum -> contact/edit symmetry, it
+//     would re-block setting alum, which is exactly what this change removed.
 //
-// Since a checked box is never disabled, a curator can always un-select a flag
-// that is set — including one leg of a pre-existing invalid combination (e.g. a
-// row that already had alum + is_lab_contact set directly via the API), which is
-// resolved by unchecking either box.
-//
-// Editor scope: the is_lab_contact / can_edit_lab checkbox rows are rendered only
-// in the Laboratory editor. But the contact/edit legs of the alum case are live
-// in BOTH editors, so the Person editor — which renders only the three role
-// flags — must still supply row.is_lab_contact / row.can_edit_lab for the alum
-// exclusion to hold there. Do not treat those fields as dead weight in
-// PersonEditor's lab rows.
+// Note only the Laboratory editor renders the is_lab_contact / can_edit_lab
+// boxes; the Person editor renders just the three role flags and no longer needs
+// to carry those two fields (the alum case reads only is_pi).
 export const roleFlagDisabled = (row, key) => {
   if (row[key]) return false;
   if (key === 'is_pi') return !!(row.former_pi || row.alum);
   if (key === 'former_pi') return !!row.is_pi;
-  if (key === 'alum') return !!(row.is_pi || row.is_lab_contact || row.can_edit_lab);
+  if (key === 'alum') return !!row.is_pi;
   if (key === 'is_lab_contact' || key === 'can_edit_lab') return !!row.alum;
   return false;
 };


### PR DESCRIPTION
…t_lab

Per curator workflow, alum must be settable whenever known and the contact/edit flags reconciled afterward, so is_lab_contact/can_edit_lab no longer disable alum (alum is gated only by is_pi). The intended ruleset holds:
  - is_pi disables former_pi + alum
  - former_pi disables is_pi
  - alum disables everything except former_pi (is_pi, is_lab_contact, can_edit_lab)
  - only unchecked boxes are disabled, so a set flag can always be un-selected

Since alum no longer reads the contact/edit flags, remove the now-dead guard-only is_lab_contact/can_edit_lab fields (and the obsolete alum tooltip) from the Person editor's lab rows; it renders only the three role flags.