### PR TITLE
show ontology label for evidence codes not in offline map

### DIFF
--- a/src/components/refs_tet_validation/TetValidationGrid.css
+++ b/src/components/refs_tet_validation/TetValidationGrid.css
@@ -286,6 +286,12 @@
   line-height: 1.3;
   padding: 0 0 2px;
   text-align: left;
+  /* Resolved ontology names can exceed the fixed Sources column width; clip to a
+     single line (keeping the one-line title-spacer height match that preserves
+     cross-column mini-row alignment) and expose the full text via the tooltip. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .tetv-evidence-title-spacer {
   font-size: var(--tetv-small-font-size);

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -1336,6 +1336,7 @@ export default function TetValidationGrid({
           kind,
           width,
           minWidth,
+          maxWidth,
           cellRenderer,
           cellRendererParams = {},
           cellClass = '',
@@ -1347,6 +1348,7 @@ export default function TetValidationGrid({
           field: topicField,
           width,
           minWidth,
+          maxWidth,
           autoHeight: true,
           sortable: true,
           filter: InnerValueFilter,
@@ -1396,6 +1398,11 @@ export default function TetValidationGrid({
             colId: t.curie,
             kind: INNER_COLUMN_TYPES.SOURCES,
             width: 180,
+            // Cap autosize growth: ellipsis clips painting, not intrinsic width,
+            // so autoSizeColumns would otherwise widen this column to fit a long
+            // (unmapped-code) ontology label. maxWidth bounds that; the tooltip
+            // carries the full text.
+            maxWidth: 260,
             cellRenderer: SourcesCell,
             cellRendererParams: {
               topicCurie: t.curie,

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -110,6 +110,13 @@ const ID_COLUMN_MIN_WIDTH = 200;
 const ID_COLUMN_CHAR_WIDTH = 8.5;
 const ID_COLUMN_PADDING = 42;
 
+// Cap how wide autoSizeColumns may grow a Sources column. Ellipsis clips
+// painting, not intrinsic width, so a long (unmapped-code) ontology label
+// would otherwise let autosize stretch the column arbitrarily. We clamp the
+// autosize result (below) rather than setting a colDef maxWidth, so the
+// fill-remaining-space pass and manual column resizing stay unconstrained.
+const SOURCES_AUTOSIZE_CAP = 260;
+
 const prefixOf = (curie) =>
   curie ? String(curie).split(':')[0].toUpperCase() : null;
 
@@ -667,6 +674,21 @@ export default function TetValidationGrid({
     const colIds = cols.map((c) => c.getColId?.()).filter(Boolean);
     if (colIds.length === 0) return;
     gridApi.autoSizeColumns?.(colIds, false);
+    // Clamp any Sources column (colId === topic curie, no `__suffix`) that
+    // autosize grew past the cap. Done here, not via a colDef maxWidth, so the
+    // rAF fill below can still expand these columns to absorb blank space and a
+    // curator can still drag the column border wider.
+    const overCap = cols
+      .filter((c) => {
+        const cid = c.getColId?.() || '';
+        return (
+          cid &&
+          !cid.includes('__') &&
+          (c.getActualWidth?.() || 0) > SOURCES_AUTOSIZE_CAP
+        );
+      })
+      .map((c) => ({ key: c.getColId(), newWidth: SOURCES_AUTOSIZE_CAP }));
+    if (overCap.length > 0) gridApi.setColumnWidths?.(overCap, false);
     requestAnimationFrame(() => {
       const wrapper = topScrollRef.current?.closest('.tetv-grid-wrapper');
       const viewport = wrapper?.querySelector('.ag-center-cols-viewport');
@@ -1398,11 +1420,6 @@ export default function TetValidationGrid({
             colId: t.curie,
             kind: INNER_COLUMN_TYPES.SOURCES,
             width: 180,
-            // Cap autosize growth: ellipsis clips painting, not intrinsic width,
-            // so autoSizeColumns would otherwise widen this column to fit a long
-            // (unmapped-code) ontology label. maxWidth bounds that; the tooltip
-            // carries the full text.
-            maxWidth: 260,
             cellRenderer: SourcesCell,
             cellRendererParams: {
               topicCurie: t.curie,

--- a/src/components/refs_tet_validation/cellRenderers/EvidencePanels.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/EvidencePanels.jsx
@@ -43,7 +43,13 @@ export default function EvidencePanels({
           {showTitles ? (
             <div
               className="tetv-evidence-title"
-              title={evidence ? `evidence: ${label} (${evidence})` : 'no evidence assertion'}
+              title={
+                evidence
+                  ? label === evidence
+                    ? `evidence: ${evidence}`
+                    : `evidence: ${label} (${evidence})`
+                  : 'no evidence assertion'
+              }
             >
               {label}
             </div>

--- a/src/components/refs_tet_validation/cellRenderers/EvidencePanels.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/EvidencePanels.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import {
-  evidenceAssertionName,
+  evidenceAssertionLabel,
   groupEntriesByEvidence,
 } from '../helpers/buildEntries';
 
@@ -43,7 +43,7 @@ export default function EvidencePanels({
               className="tetv-evidence-title"
               title={evidence ? `evidence: ${evidence}` : 'no evidence assertion'}
             >
-              {evidenceAssertionName(evidence)}
+              {evidenceAssertionLabel(panelEntries, evidence)}
             </div>
           ) : (
             <div className="tetv-evidence-title-spacer" aria-hidden="true">

--- a/src/components/refs_tet_validation/cellRenderers/EvidencePanels.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/EvidencePanels.jsx
@@ -33,7 +33,9 @@ export default function EvidencePanels({
 
   return (
     <>
-      {[...groups.entries()].map(([evidence, panelEntries], idx) => (
+      {[...groups.entries()].map(([evidence, panelEntries], idx) => {
+        const label = evidenceAssertionLabel(panelEntries, evidence);
+        return (
         <div
           className={`tetv-evidence-panel${idx > 0 ? ' tetv-evidence-panel-sep' : ''}`}
           key={evidence || `_${idx}`}
@@ -41,9 +43,9 @@ export default function EvidencePanels({
           {showTitles ? (
             <div
               className="tetv-evidence-title"
-              title={evidence ? `evidence: ${evidence}` : 'no evidence assertion'}
+              title={evidence ? `evidence: ${label} (${evidence})` : 'no evidence assertion'}
             >
-              {evidenceAssertionLabel(panelEntries, evidence)}
+              {label}
             </div>
           ) : (
             <div className="tetv-evidence-title-spacer" aria-hidden="true">
@@ -52,7 +54,8 @@ export default function EvidencePanels({
           )}
           {panelEntries.map((e) => renderEntry(e))}
         </div>
-      ))}
+        );
+      })}
     </>
   );
 }

--- a/src/components/refs_tet_validation/helpers/__tests__/evidenceAssertion.test.js
+++ b/src/components/refs_tet_validation/helpers/__tests__/evidenceAssertion.test.js
@@ -19,8 +19,8 @@ describe('evidenceAssertionName (offline fallback map)', () => {
   });
 });
 
-describe('evidenceAssertionLabel (prefers backend-resolved name)', () => {
-  test('uses source_evidence_assertion_name from the entry when present', () => {
+describe('evidenceAssertionLabel (curated map first, backend name as fallback)', () => {
+  test('keeps the curated short label for a mapped code, ignoring the backend name', () => {
     const entries = [
       {
         source_evidence_assertion: 'ECO:0008025',
@@ -28,11 +28,24 @@ describe('evidenceAssertionLabel (prefers backend-resolved name)', () => {
           'neural network method evidence used in automatic assertion',
       },
     ];
+    // ECO:0008025 is in the offline map, so its short curated label wins and the
+    // grid's established titles stay stable.
     expect(evidenceAssertionLabel(entries, 'ECO:0008025')).toBe(
-      'neural network method evidence used in automatic assertion'
+      'neural network method'
     );
   });
-  test('reads the resolved name from a nested raw tag', () => {
+  test('uses source_evidence_assertion_name for a code missing from the map', () => {
+    const entries = [
+      {
+        source_evidence_assertion: 'ECO:1234567',
+        source_evidence_assertion_name: 'some resolved label',
+      },
+    ];
+    expect(evidenceAssertionLabel(entries, 'ECO:1234567')).toBe(
+      'some resolved label'
+    );
+  });
+  test('reads the resolved name from a nested raw tag for an unmapped code', () => {
     const entries = [
       {
         tets: [
@@ -48,13 +61,7 @@ describe('evidenceAssertionLabel (prefers backend-resolved name)', () => {
       'some resolved label'
     );
   });
-  test('falls back to the offline map when no resolved name is supplied', () => {
-    const entries = [{ source_evidence_assertion: 'ECO:0008025' }];
-    expect(evidenceAssertionLabel(entries, 'ECO:0008025')).toBe(
-      'neural network method'
-    );
-  });
-  test('falls back to the raw curie when neither name nor map matches', () => {
+  test('falls back to the raw curie when neither map nor backend name matches', () => {
     expect(evidenceAssertionLabel([], 'ECO:9999999')).toBe('ECO:9999999');
   });
 });

--- a/src/components/refs_tet_validation/helpers/__tests__/evidenceAssertion.test.js
+++ b/src/components/refs_tet_validation/helpers/__tests__/evidenceAssertion.test.js
@@ -1,0 +1,60 @@
+import {
+  evidenceAssertionName,
+  evidenceAssertionLabel,
+} from '../buildEntries';
+
+describe('evidenceAssertionName (offline fallback map)', () => {
+  test('maps known curies to short labels', () => {
+    expect(evidenceAssertionName('ECO:0008004')).toBe('machine learning');
+    expect(evidenceAssertionName('ECO:0008025')).toBe('neural network method');
+  });
+  test('is case-insensitive on the curie', () => {
+    expect(evidenceAssertionName('eco:0008021')).toBe('string matching');
+  });
+  test('returns the curie unchanged when unknown', () => {
+    expect(evidenceAssertionName('ECO:9999999')).toBe('ECO:9999999');
+  });
+  test('handles empty input', () => {
+    expect(evidenceAssertionName('')).toBe('unspecified evidence');
+  });
+});
+
+describe('evidenceAssertionLabel (prefers backend-resolved name)', () => {
+  test('uses source_evidence_assertion_name from the entry when present', () => {
+    const entries = [
+      {
+        source_evidence_assertion: 'ECO:0008025',
+        source_evidence_assertion_name:
+          'neural network method evidence used in automatic assertion',
+      },
+    ];
+    expect(evidenceAssertionLabel(entries, 'ECO:0008025')).toBe(
+      'neural network method evidence used in automatic assertion'
+    );
+  });
+  test('reads the resolved name from a nested raw tag', () => {
+    const entries = [
+      {
+        tets: [
+          {
+            topic_entity_tag_source: {
+              source_evidence_assertion_name: 'some resolved label',
+            },
+          },
+        ],
+      },
+    ];
+    expect(evidenceAssertionLabel(entries, 'ECO:1234567')).toBe(
+      'some resolved label'
+    );
+  });
+  test('falls back to the offline map when no resolved name is supplied', () => {
+    const entries = [{ source_evidence_assertion: 'ECO:0008025' }];
+    expect(evidenceAssertionLabel(entries, 'ECO:0008025')).toBe(
+      'neural network method'
+    );
+  });
+  test('falls back to the raw curie when neither name nor map matches', () => {
+    expect(evidenceAssertionLabel([], 'ECO:9999999')).toBe('ECO:9999999');
+  });
+});

--- a/src/components/refs_tet_validation/helpers/buildEntries.js
+++ b/src/components/refs_tet_validation/helpers/buildEntries.js
@@ -1,10 +1,12 @@
 import { sourceLabel, isCuratorSourceTet } from './groupTets';
 
-/** Fallback evidence-assertion curie → human-readable label, used only when
- *  the backend did not supply a resolved name (source_evidence_assertion_name).
- *  This list is intentionally incomplete: the authoritative label comes from the
- *  ontology store via the API, so prefer entry.source_evidence_assertion_name and
- *  treat this map purely as a last-resort offline fallback. */
+/** Curated evidence-assertion curie → short human-readable label. This is the
+ *  FIRST choice in evidenceAssertionLabel: for the codes listed here the grid
+ *  keeps these stable, deliberately short titles (e.g. "manual", "automated")
+ *  regardless of the longer ontology phrase the backend may resolve. The map is
+ *  intentionally incomplete — codes absent from it fall through to the backend's
+ *  source_evidence_assertion_name, then to the raw curie. Add a code here only
+ *  when you want a curated short label to override the ontology name. */
 const EVIDENCE_ASSERTION_NAMES = {
   'ECO:0006155': 'manual',
   'ECO:0007669': 'automated',

--- a/src/components/refs_tet_validation/helpers/buildEntries.js
+++ b/src/components/refs_tet_validation/helpers/buildEntries.js
@@ -21,10 +21,19 @@ export function evidenceAssertionName(curie) {
   return EVIDENCE_ASSERTION_NAMES[key] || curie;
 }
 
-/** Resolve an evidence-assertion panel label, preferring the ontology name the
- *  backend already resolved from the persistent store over the local fallback
- *  map. `entries` are the mini-rows grouped under a single evidence curie. */
+/** Resolve an evidence-assertion panel label. Precedence, chosen so the grid's
+ *  established short titles stay stable while still labelling codes the offline
+ *  map does not cover:
+ *    1. the curated offline label (keeps manual/automated/... short and fixed);
+ *    2. the ontology name the backend resolved from the persistent store
+ *       (source_evidence_assertion_name) for any code missing from the map;
+ *    3. the raw curie as a last resort.
+ *  `entries` are the mini-rows grouped under a single evidence curie. These
+ *  resolved ontology names can be long, so callers must clip/ellipsize the
+ *  title and surface the full text via the cell tooltip. */
 export function evidenceAssertionLabel(entries, curie) {
+  const mapped = curie ? EVIDENCE_ASSERTION_NAMES[String(curie).toUpperCase()] : null;
+  if (mapped) return mapped;
   for (const e of entries || []) {
     const name =
       e?.source_evidence_assertion_name ||

--- a/src/components/refs_tet_validation/helpers/buildEntries.js
+++ b/src/components/refs_tet_validation/helpers/buildEntries.js
@@ -1,12 +1,16 @@
 import { sourceLabel, isCuratorSourceTet } from './groupTets';
 
-/** Common evidence-assertion curies → human-readable label. Mirrors the
- *  hardcoded mapping in the search backend's add_curie_to_name_values. */
+/** Fallback evidence-assertion curie → human-readable label, used only when
+ *  the backend did not supply a resolved name (source_evidence_assertion_name).
+ *  This list is intentionally incomplete: the authoritative label comes from the
+ *  ontology store via the API, so prefer entry.source_evidence_assertion_name and
+ *  treat this map purely as a last-resort offline fallback. */
 const EVIDENCE_ASSERTION_NAMES = {
   'ECO:0006155': 'manual',
   'ECO:0007669': 'automated',
   'ECO:0008004': 'machine learning',
   'ECO:0008021': 'string matching',
+  'ECO:0008025': 'neural network method',
   'ATP:0000035': 'author',
   'ATP:0000036': 'professional biocurator',
 };
@@ -15,6 +19,19 @@ export function evidenceAssertionName(curie) {
   if (!curie) return 'unspecified evidence';
   const key = String(curie).toUpperCase();
   return EVIDENCE_ASSERTION_NAMES[key] || curie;
+}
+
+/** Resolve an evidence-assertion panel label, preferring the ontology name the
+ *  backend already resolved from the persistent store over the local fallback
+ *  map. `entries` are the mini-rows grouped under a single evidence curie. */
+export function evidenceAssertionLabel(entries, curie) {
+  for (const e of entries || []) {
+    const name =
+      e?.source_evidence_assertion_name ||
+      e?.tets?.[0]?.topic_entity_tag_source?.source_evidence_assertion_name;
+    if (name) return name;
+  }
+  return evidenceAssertionName(curie);
 }
 
 /** Group a buildEntries output by source.source_evidence_assertion so cells


### PR DESCRIPTION
The topic grid rendered evidence-panel titles from a small hardcoded curie->label map, so codes missing from it (e.g. ECO:0008025 used by nnc_* source methods) displayed the raw curie. Prefer the backend- resolved source_evidence_assertion_name from the ontology store and fall back to the offline map only when absent. Add ECO:0008025 to the fallback map and cover the resolver with unit tests.