### PR TITLE
Fixed Search query builder to only allow a tag to carry each field at most once

### DIFF
--- a/src/components/search/Facets.js
+++ b/src/components/search/Facets.js
@@ -741,9 +741,7 @@ const Facets = () => {
                                 {facetCategory === 'Date Range'
                                     ? <DateFacet facetsToInclude={facetsInCategory}/>
                                     : (facetCategory === 'Topics and Entities' && searchMode === 'advanced')
-                                        ? <div style={{ marginLeft: '30px', marginRight: '10px', fontSize: '0.8rem', color: '#6c757d' }}>
-                                              The advanced query builder is shown above the results, where it has more room.
-                                          </div>
+                                        ? null
                                         : <Facet facetsToInclude={facetsInCategory} renameFacets={RENAME_FACETS}/>}
                             </div>
                         </Collapse>

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -406,18 +406,11 @@ const SearchLayout = () => {
                                         backgroundColor: '#fbfdff',
                                         boxShadow: '0 1px 4px rgba(13, 110, 253, 0.08)',
                                         marginBottom: '16px',
-                                        overflow: 'hidden',
                                     }}>
-                                        <div style={{
-                                            padding: '8px 14px',
-                                            borderBottom: '1px solid #cfe2ff',
-                                            backgroundColor: '#eef5ff',
-                                            fontWeight: 600,
-                                            textAlign: 'left',
-                                            letterSpacing: '0.01em',
-                                        }}>
-                                            Advanced Topic query
-                                        </div>
+                                        {/* Title, help and the sticky preview/actions
+                                            footer are rendered inside the builder. No
+                                            overflow:hidden here so the footer's
+                                            position:sticky keeps working. */}
                                         <AdvancedTopicQueryBuilder/>
                                     </div>
                                 )}

--- a/src/components/search/SearchLayout.js
+++ b/src/components/search/SearchLayout.js
@@ -273,40 +273,11 @@ const SearchLayout = () => {
                     </Col>
                 </Row>
                 <Row><Col style={{ padding: 0 }}>&nbsp;</Col></Row>
-                {/* Advanced Topic query builder (SCRUM-6228-2): in advanced mode the
-                    builder is lifted out of the narrow facet sidebar and rendered as a
-                    full-width band here, above the results, so it gets the horizontal
-                    room its tag/field/value layout needs. The facet sidebar below still
-                    holds the mode toggle and the other facets (corpus/MOD, dates,
-                    category, workflow) that continue to apply on top of the query. */}
-                {searchMode === 'advanced' && (
-                    <>
-                        <Row style={{ margin: 0 }}>
-                            <Col style={{ padding: 0 }}>
-                                <div style={{
-                                    border: '1px solid #cfe2ff',
-                                    borderRadius: '8px',
-                                    backgroundColor: '#fbfdff',
-                                }}>
-                                    <div style={{
-                                        padding: '6px 12px',
-                                        borderBottom: '1px solid #cfe2ff',
-                                        backgroundColor: '#eef5ff',
-                                        borderTopLeftRadius: '8px',
-                                        borderTopRightRadius: '8px',
-                                        fontWeight: 600,
-                                        textAlign: 'left',
-                                    }}>
-                                        Advanced Topic query
-                                    </div>
-                                    <AdvancedTopicQueryBuilder/>
-                                </div>
-                            </Col>
-                        </Row>
-                        <Row><Col style={{ padding: 0 }}>&nbsp;</Col></Row>
-                    </>
-                )}
-                {/* The flex container wrapping both the facet panel and search results */}
+                {/* The flex container wrapping both the facet panel and search results.
+                    The Advanced Topic query builder (SCRUM-6333) is rendered inside the
+                    results column below, at the top of the results, so the facet sidebar
+                    stays visible to its left instead of being pushed down by a full-width
+                    band above the whole page. */}
                 <Row style={{ margin: 0 }}>
                     <Col style={{ padding: 0 }}>
                         {facetsCollapsed && (
@@ -424,6 +395,32 @@ const SearchLayout = () => {
                                 padding: 0,
                                 marginLeft: isMobile ? 0 : undefined
                             }}>
+                                {/* Advanced Topic query builder (SCRUM-6333): anchored at
+                                    the top of the results column so the facet sidebar stays
+                                    visible to its left and the results flow directly
+                                    beneath it (was a full-width band above the page). */}
+                                {searchMode === 'advanced' && (
+                                    <div style={{
+                                        border: '1px solid #cfe2ff',
+                                        borderRadius: '10px',
+                                        backgroundColor: '#fbfdff',
+                                        boxShadow: '0 1px 4px rgba(13, 110, 253, 0.08)',
+                                        marginBottom: '16px',
+                                        overflow: 'hidden',
+                                    }}>
+                                        <div style={{
+                                            padding: '8px 14px',
+                                            borderBottom: '1px solid #cfe2ff',
+                                            backgroundColor: '#eef5ff',
+                                            fontWeight: 600,
+                                            textAlign: 'left',
+                                            letterSpacing: '0.01em',
+                                        }}>
+                                            Advanced Topic query
+                                        </div>
+                                        <AdvancedTopicQueryBuilder/>
+                                    </div>
+                                )}
                                 {referenceIds.length > 0 && (
                                     <div className="tetv-view-switchbar">
                                         <ToggleButtonGroup

--- a/src/components/search/advanced/AdvancedTopicQueryBuilder.css
+++ b/src/components/search/advanced/AdvancedTopicQueryBuilder.css
@@ -1,0 +1,18 @@
+/* Remove controls (field-row "×" and the tag "Remove tag" trashcan). Dark slate
+   grey at rest so they read as active without shouting, red only on hover/focus to
+   signal the destructive action at the point of intent, and the light disabled grey
+   when the last tag/field can't be removed. Color lives here (not inline) so the
+   :hover/:focus states can override the resting color. The `.btn` prefix lifts
+   specificity above react-bootstrap's own `.btn-link` color rules. */
+.btn.tetv-adv-remove-btn {
+  color: #475569;
+  transition: color 0.12s ease;
+}
+.btn.tetv-adv-remove-btn:not(:disabled):hover,
+.btn.tetv-adv-remove-btn:not(:disabled):focus-visible {
+  color: #dc3545;
+}
+.btn.tetv-adv-remove-btn:disabled,
+.btn.tetv-adv-remove-btn.disabled {
+  color: #cbd5e1;
+}

--- a/src/components/search/advanced/AdvancedTopicQueryBuilder.js
+++ b/src/components/search/advanced/AdvancedTopicQueryBuilder.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Badge, Button, ButtonGroup, Form, InputGroup } from 'react-bootstrap';
+import { Button, Form, InputGroup, OverlayTrigger, Popover } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrashAlt, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { api } from '../../../api';
 import {
   setAdvancedTopicQuery,
@@ -246,14 +248,15 @@ const ValueEditor = ({ row, onChange, tagContext }) => {
       {values.map((chip, idx) => (
         <React.Fragment key={chip.value}>
           {idx > 0 && (
-            <Badge variant="secondary" style={{ fontSize: '0.65rem' }}>OR</Badge>
+            <span style={{
+              fontSize: '0.62rem', fontWeight: 600, color: '#6c757d',
+              backgroundColor: '#e9ecef', borderRadius: '10px', padding: '1px 7px',
+              letterSpacing: '0.02em',
+            }}>or</span>
           )}
           <ValueChip chip={chip} onRemove={() => removeChip(idx)} />
         </React.Fragment>
       ))}
-      {values.length > 0 && (
-        <span style={{ fontSize: '0.7rem', color: '#6c757d', whiteSpace: 'nowrap' }}>or</span>
-      )}
       {row.field === 'entity' ? (
         <EntityValueAdder
           hasValues={values.length > 0}
@@ -266,14 +269,19 @@ const ValueEditor = ({ row, onChange, tagContext }) => {
           as="select"
           size="sm"
           aria-label="add value"
-          style={{ width: 'auto', maxWidth: '12rem', flex: '0 0 auto' }}
+          style={{
+            width: 'auto', maxWidth: '12rem', flex: '0 0 auto',
+            border: '1px dashed #cbd5e1', borderRadius: '14px',
+            color: '#64748b', backgroundColor: 'transparent', fontSize: '0.8rem',
+            height: 'auto', paddingTop: '2px', paddingBottom: '2px',
+          }}
           value=""
           onChange={(e) => {
             const opt = options.find((o) => o.value === e.target.value);
             if (opt) addChip(opt.value, opt.label);
           }}
         >
-          <option value="">{values.length ? 'add value (same field)…' : '— select —'}</option>
+          <option value="">{values.length ? 'add value…' : '— select —'}</option>
           {options
             .filter((o) => !values.some((c) => c.value === o.value))
             .map((o) => (
@@ -284,8 +292,11 @@ const ValueEditor = ({ row, onChange, tagContext }) => {
         <Form.Control
           type="text"
           size="sm"
-          style={{ width: '12rem', maxWidth: '100%', flex: '0 0 auto' }}
-          placeholder={values.length ? 'add value (same field)…' : 'type value, Enter'}
+          style={{
+            width: '12rem', maxWidth: '100%', flex: '0 0 auto',
+            border: '1px dashed #cbd5e1', borderRadius: '14px', fontSize: '0.8rem',
+          }}
+          placeholder={values.length ? 'add value…' : 'type value, Enter'}
           aria-label="add value"
           value={text}
           onChange={(e) => setText(e.target.value)}
@@ -304,12 +315,12 @@ const ValueEditor = ({ row, onChange, tagContext }) => {
 };
 
 const FieldRow = ({ row, onChange, onRemove, canRemove, tagContext }) => (
-  <div style={{ display: 'flex', alignItems: 'flex-start', gap: '6px', marginBottom: '6px' }}>
+  <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '2px' }}>
     <Form.Control
       as="select"
       size="sm"
       aria-label="sub-facet field"
-      style={{ maxWidth: '11rem', flex: '0 0 auto' }}
+      style={{ maxWidth: '11rem', minWidth: '9rem', flex: '0 0 auto' }}
       value={row.field}
       onChange={(e) => onChange(createFieldRow(e.target.value))}
     >
@@ -317,13 +328,23 @@ const FieldRow = ({ row, onChange, onRemove, canRemove, tagContext }) => (
         <option key={def.key} value={def.key}>{def.label}</option>
       ))}
     </Form.Control>
-    <span style={{ padding: '4px 2px', color: '#6c757d' }}>=</span>
-    <ValueEditor row={row} onChange={onChange} tagContext={tagContext} />
+    <span style={{ color: '#94a3b8', fontWeight: 600, flex: '0 0 auto' }}>=</span>
+    <div style={{
+      flex: 1, display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '4px',
+      border: '1px solid #e3e8ef', borderRadius: '8px', backgroundColor: '#fbfcfe',
+      padding: '4px 8px', minHeight: '36px',
+    }}>
+      <ValueEditor row={row} onChange={onChange} tagContext={tagContext} />
+    </div>
     <Button
-      variant="outline-danger" size="sm"
+      variant="link" size="sm"
       onClick={onRemove} disabled={!canRemove}
       title="Remove field"
-      style={{ flex: '0 0 auto' }}
+      aria-label="remove field"
+      style={{
+        flex: '0 0 auto', color: '#adb5bd', textDecoration: 'none',
+        fontSize: '1.15rem', lineHeight: 1, padding: '0 4px',
+      }}
     >×</Button>
   </div>
 );
@@ -357,10 +378,6 @@ const TagCard = ({ leaf, index, onChange, onRemove, canRemove }) => {
     dispatch(fetchAdvancedFacetsVocab());
   };
 
-  const scope = index === 0
-    ? 'one tag must match all of these (same tag)'
-    : 'a different tag on the same paper must match all of these';
-
   // Sibling context for the Entity resolver: the specific-entity lookup needs the
   // Tag's entity type (-> name) and species (-> NCBITaxon curie), both taken from
   // the first value of the matching field in this same Tag.
@@ -372,43 +389,66 @@ const TagCard = ({ leaf, index, onChange, onRemove, canRemove }) => {
 
   return (
     <div style={{
-      border: '1px solid #cfe2ff', borderRadius: '8px',
-      padding: '8px 10px', margin: '8px 0', backgroundColor: '#f6faff',
+      border: '1px solid #e3e8ef', borderRadius: '12px',
+      padding: '14px 16px', margin: '12px 0', backgroundColor: '#fff',
+      boxShadow: '0 1px 3px rgba(15, 23, 42, 0.06)',
     }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <Badge variant="primary">{index + 1}</Badge>
-          <span style={{ fontWeight: 600 }}>Tag {index + 1}</span>
-        </div>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        flexWrap: 'wrap', gap: '8px', marginBottom: '10px',
+      }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <span style={{
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            width: '22px', height: '22px', borderRadius: '50%', backgroundColor: '#2563eb',
+            color: '#fff', fontSize: '0.75rem', fontWeight: 700,
+          }}>{index + 1}</span>
+          <span style={{ fontWeight: 700 }}>Tag {index + 1}</span>
+          <span style={{
+            fontSize: '0.68rem', color: '#64748b', backgroundColor: '#f1f5f9',
+            border: '1px solid #e2e8f0', borderRadius: '10px', padding: '2px 8px',
+          }}>fields are AND inside Tag</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '14px' }}>
           <Form.Check
             type="checkbox"
-            label="exclude (paper must NOT have this tag)"
+            id={`tetv-tag-exclude-${index}`}
+            label={<span style={{ fontSize: '0.8rem' }} title="paper must NOT have this tag">exclude</span>}
             checked={!!leaf.negate}
-            style={{ fontSize: '0.8rem' }}
+            style={{ marginBottom: 0 }}
             onChange={(e) => onChange({ ...leaf, negate: e.target.checked })}
           />
           <Button
-            variant="outline-danger" size="sm"
+            variant="link" size="sm"
             onClick={onRemove} disabled={!canRemove}
             title="Remove tag"
-          >Remove tag</Button>
+            style={{ color: '#94a3b8', textDecoration: 'none', padding: 0, fontSize: '0.8rem' }}
+          ><FontAwesomeIcon icon={faTrashAlt} style={{ marginRight: '5px' }} />Remove tag</Button>
         </div>
       </div>
-      <div style={{ fontSize: '0.75rem', color: '#6c757d', marginBottom: '6px' }}>
-        {scope}. Fields are combined with AND; multiple values on one field match any (OR).
-      </div>
       {leaf.fields.map((row, idx) => (
-        <FieldRow
-          key={idx}
-          row={row}
-          onChange={(newRow) => setField(idx, newRow)}
-          onRemove={() => removeField(idx)}
-          canRemove={leaf.fields.length > 1}
-          tagContext={tagContext}
-        />
+        <React.Fragment key={idx}>
+          {idx > 0 && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '6px', width: '11rem', margin: '3px 0' }}>
+              <span style={{ flex: 1, height: '1px', backgroundColor: '#e3e8ef' }} />
+              <span style={{ fontSize: '0.6rem', fontWeight: 700, color: '#94a3b8', letterSpacing: '0.08em' }}>AND</span>
+              <span style={{ flex: 1, height: '1px', backgroundColor: '#e3e8ef' }} />
+            </div>
+          )}
+          <FieldRow
+            row={row}
+            onChange={(newRow) => setField(idx, newRow)}
+            onRemove={() => removeField(idx)}
+            canRemove={leaf.fields.length > 1}
+            tagContext={tagContext}
+          />
+        </React.Fragment>
       ))}
-      <Button variant="link" size="sm" style={{ padding: 0 }} onClick={addField}>+ add field (same tag)</Button>
+      <Button
+        variant="outline-secondary" size="sm"
+        onClick={addField}
+        style={{ marginTop: '10px', borderRadius: '16px', fontSize: '0.8rem' }}
+      ><FontAwesomeIcon icon={faPlus} style={{ marginRight: '6px' }} />Add field to Tag {index + 1}</Button>
     </div>
   );
 };
@@ -485,168 +525,223 @@ const AdvancedTopicQueryBuilder = () => {
     ? ` AND corpus in (${corpusMods.map((m) => `"${m}"`).join(', ')})`
     : '';
 
+  // The full "how to use" content, moved out of a page-consuming <details> block
+  // into a click-to-open help popover so it no longer pushes Tag 1 off-screen (#3).
+  const helpPopover = (
+    <Popover id="tetv-adv-help" style={{ maxWidth: '540px' }}>
+      <Popover.Title as="h3" style={{ fontSize: '0.9rem' }}>
+        How to use — AND/OR, tags, and examples
+      </Popover.Title>
+      <Popover.Content style={{
+        fontSize: '0.8rem', color: '#333', lineHeight: 1.5,
+        maxHeight: '65vh', overflowY: 'auto',
+      }}>
+        <p style={{ marginBottom: '8px' }}>
+          Build a query over Topic sub-facets. Each <b>Tag</b> is one topic-entity tag the
+          paper must have; fields inside a Tag apply to that <b>same</b> tag. Add another Tag
+          for a requirement on a <b>different</b> tag of the same paper. Corpus, date and
+          workflow facets still apply. Facet counts are not shown in advanced mode.
+        </p>
+        <div style={{ fontWeight: 600, marginTop: '2px' }}>The building blocks</div>
+        <ul style={{ margin: '2px 0 6px', paddingLeft: '18px' }}>
+          <li>
+            A <b>Tag</b> is one topic-entity tag on a paper. Everything inside a Tag
+            card must be true of that <b>same</b> tag.
+          </li>
+          <li>
+            <b>Fields within a Tag</b> (Topic, Source method, Confidence level, Has
+            data, …) are combined with <b>AND</b> — the same tag must satisfy all of them.
+          </li>
+          <li>
+            <b>Multiple values on one field</b> are combined with <b>OR</b> — e.g. a
+            Topic field with two values matches a tag whose topic is <i>either</i> one.
+          </li>
+          <li>
+            <b>Multiple Tags</b> put requirements on <b>different</b> tags of the same
+            paper. The <b>“paper must match”</b> selector (shown once you add a second
+            Tag) sets how tags combine: <b>ALL Tags (AND)</b> = the paper must have
+            every tag; <b>ANY Tag (OR)</b> = the paper must have at least one.
+          </li>
+          <li>
+            <b>Exclude (paper must NOT have this tag)</b> — check this on a Tag to
+            require the paper has <b>no</b> tag matching that card.
+          </li>
+          <li>
+            <b>Entity</b> matches a specific entity (e.g. the gene <i>ACT1</i>) by
+            name and stores its curie. Picking it adds <b>Entity type</b> and{' '}
+            <b>Species</b> fields for you (an entity is species-specific); choose
+            those, then type the exact name and press Enter to validate it.
+          </li>
+          <li>
+            <b>Has data</b> distinguishes positive tags (has data) from negated tags
+            (no data). The tree-wide <b>Exclude no-data tags</b> toggle (off by
+            default) adds has-data=yes to every tag condition — the facet search’s
+            “exclude negative”. Turn it on for positive-only results, or add an
+            explicit <b>Has data</b> field to a Tag (set to <b>no</b>) to control a
+            single tag.
+          </li>
+          <li>
+            <b>Validation (biocurator)</b> filters predicted tags by professional
+            biocurator review: <b>validated right</b>, <b>validated wrong</b>,{' '}
+            <b>not validated</b> (and <i>validation conflict</i> /{' '}
+            <i>validated right (self)</i>). Use it to keep only confirmed predictions
+            or to exclude ones a biocurator marked wrong.
+          </li>
+          <li>
+            <b>Confidence score</b> is a min/max range. Value lists are scoped to the
+            selected corpus/MOD; corpus, date and workflow facets still apply.
+          </li>
+          <li>The <b>Query preview</b> shows exactly what will be searched.</li>
+        </ul>
+        <div style={{ fontWeight: 600 }}>Examples</div>
+        <ol style={{ margin: '2px 0 0', paddingLeft: '18px' }}>
+          <li>
+            <b>Disease-model tag from the ACKnowledge form that has data</b> — one Tag:
+            Topic = disease model, Source method = acknowledge_form, Has data = yes.
+          </li>
+          <li>
+            <b>Papers with BOTH a disease-model tag AND a separate gene tag</b> — Tag 1:
+            Topic = disease model; Tag 2: Topic = gene expression; paper must match =
+            ALL Tags (AND).
+          </li>
+          <li>
+            <b>Disease-model tag from EITHER the ACKnowledge form OR the ABC classifier</b>
+            {' '}— one Tag: Topic = disease model, and add two values to Source method
+            (acknowledge_form OR abc classifier).
+          </li>
+          <li>
+            <b>Exclude papers that have a no-data disease-model tag</b> — one Tag with
+            “exclude” checked: Topic = disease model, Has data = no.
+          </li>
+          <li>
+            <b>New-to-field transgene predictions, minus the ones a biocurator
+            rejected</b> — one Tag: Topic = transgene, Data novelty = new to field,
+            and add two values to Validation (biocurator): validated right OR not
+            validated (this keeps confirmed and un-reviewed predictions while dropping
+            “validated wrong”).
+          </li>
+        </ol>
+      </Popover.Content>
+    </Popover>
+  );
+
   return (
-    <div style={{ padding: '4px 10px 10px', textAlign: 'left' }}>
-      <div style={{ fontSize: '0.8rem', color: '#666', marginBottom: '6px' }}>
-        Build a query over Topic sub-facets. Each <b>Tag</b> is one topic-entity tag the
-        paper must have; fields inside a Tag apply to that <b>same</b> tag. Add another Tag
-        for a requirement on a <b>different</b> tag of the same paper. Corpus, date and
-        workflow facets still apply. Facet counts are not shown in advanced mode.
-      </div>
-
-      <div style={{ marginBottom: '8px' }}>
-        <Form.Check
-          type="checkbox"
-          id="tetv-adv-exclude-no-data"
-          checked={tree.excludeNoData === true}
-          onChange={(e) => update({ ...tree, excludeNoData: e.target.checked })}
-          label={
-            <span style={{ fontSize: '0.8rem' }}>
-              <b>Exclude no-data tags</b> — match only positive (has-data) tags, like
-              the facet search’s “exclude negative”. Off by default; check it to add
-              has-data=yes to every tag condition (it then appears in the query
-              preview), or add an explicit “Has data” field to a Tag to control it
-              per tag.
-            </span>
-          }
-        />
-      </div>
-
-      <details style={{
-        fontSize: '0.8rem', color: '#333', marginBottom: '8px',
-        border: '1px solid #cfe2ff', borderRadius: '6px', backgroundColor: '#f6faff',
-        padding: '4px 8px',
-      }}>
-        <summary style={{ cursor: 'pointer', fontWeight: 600, color: '#0d6efd' }}>
-          How to use — AND/OR, tags, and examples
-        </summary>
-        <div style={{ marginTop: '6px', lineHeight: 1.5 }}>
-          <div style={{ fontWeight: 600, marginTop: '2px' }}>The building blocks</div>
-          <ul style={{ margin: '2px 0 6px', paddingLeft: '18px' }}>
-            <li>
-              A <b>Tag</b> is one topic-entity tag on a paper. Everything inside a Tag
-              card must be true of that <b>same</b> tag.
-            </li>
-            <li>
-              <b>Fields within a Tag</b> (Topic, Source method, Confidence level, Has
-              data, …) are combined with <b>AND</b> — the same tag must satisfy all of them.
-            </li>
-            <li>
-              <b>Multiple values on one field</b> are combined with <b>OR</b> — e.g. a
-              Topic field with two values matches a tag whose topic is <i>either</i> one.
-            </li>
-            <li>
-              <b>Multiple Tags</b> put requirements on <b>different</b> tags of the same
-              paper. The <b>“paper must match”</b> selector (shown once you add a second
-              Tag) sets how tags combine: <b>ALL Tags (AND)</b> = the paper must have
-              every tag; <b>ANY Tag (OR)</b> = the paper must have at least one.
-            </li>
-            <li>
-              <b>Exclude (paper must NOT have this tag)</b> — check this on a Tag to
-              require the paper has <b>no</b> tag matching that card.
-            </li>
-            <li>
-              <b>Entity</b> matches a specific entity (e.g. the gene <i>ACT1</i>) by
-              name and stores its curie. Picking it adds <b>Entity type</b> and{' '}
-              <b>Species</b> fields for you (an entity is species-specific); choose
-              those, then type the exact name and press Enter to validate it.
-            </li>
-            <li>
-              <b>Has data</b> distinguishes positive tags (has data) from negated tags
-              (no data). The tree-wide <b>Exclude no-data tags</b> toggle (off by
-              default) adds has-data=yes to every tag condition — the facet search’s
-              “exclude negative”. Turn it on for positive-only results, or add an
-              explicit <b>Has data</b> field to a Tag (set to <b>no</b>) to control a
-              single tag.
-            </li>
-            <li>
-              <b>Validation (biocurator)</b> filters predicted tags by professional
-              biocurator review: <b>validated right</b>, <b>validated wrong</b>,{' '}
-              <b>not validated</b> (and <i>validation conflict</i> /{' '}
-              <i>validated right (self)</i>). Use it to keep only confirmed predictions
-              or to exclude ones a biocurator marked wrong.
-            </li>
-            <li>
-              <b>Confidence score</b> is a min/max range. Value lists are scoped to the
-              selected corpus/MOD; corpus, date and workflow facets still apply.
-            </li>
-            <li>The <b>Query preview</b> shows exactly what will be searched.</li>
-          </ul>
-          <div style={{ fontWeight: 600 }}>Examples</div>
-          <ol style={{ margin: '2px 0 0', paddingLeft: '18px' }}>
-            <li>
-              <b>Disease-model tag from the ACKnowledge form that has data</b> — one Tag:
-              Topic = disease model, Source method = acknowledge_form, Has data = yes.
-            </li>
-            <li>
-              <b>Papers with BOTH a disease-model tag AND a separate gene tag</b> — Tag 1:
-              Topic = disease model; Tag 2: Topic = gene expression; paper must match =
-              ALL Tags (AND).
-            </li>
-            <li>
-              <b>Disease-model tag from EITHER the ACKnowledge form OR the ABC classifier</b>
-              {' '}— one Tag: Topic = disease model, and add two values to Source method
-              (acknowledge_form OR abc classifier).
-            </li>
-            <li>
-              <b>Exclude papers that have a no-data disease-model tag</b> — one Tag with
-              “exclude” checked: Topic = disease model, Has data = no.
-            </li>
-            <li>
-              <b>New-to-field transgene predictions, minus the ones a biocurator
-              rejected</b> — one Tag: Topic = transgene, Data novelty = new to field,
-              and add two values to Validation (biocurator): validated right OR not
-              validated (this keeps confirmed and un-reviewed predictions while dropping
-              “validated wrong”).
-            </li>
-          </ol>
-        </div>
-      </details>
-
-      {tags.length >= 2 && (
-        <InputGroup size="sm" style={{ width: 'auto', marginBottom: '4px' }}>
-          <InputGroup.Text>paper must match</InputGroup.Text>
-          <Form.Control
-            as="select"
-            aria-label="top-level operator"
-            style={{ maxWidth: '11rem' }}
-            value={tree.operator}
-            onChange={(e) => update({ ...tree, operator: e.target.value })}
-          >
-            <option value="AND">ALL Tags (AND)</option>
-            <option value="OR">ANY Tag (OR)</option>
-          </Form.Control>
-        </InputGroup>
-      )}
-
-      {tags.map((leaf, idx) => (
-        <TagCard
-          key={idx}
-          leaf={leaf}
-          index={idx}
-          onChange={(newLeaf) => setTag(idx, newLeaf)}
-          onRemove={() => removeTag(idx)}
-          canRemove={tags.length > 1}
-        />
-      ))}
-
-      <Button variant="link" size="sm" style={{ padding: 0 }} onClick={addTag}>+ add Tag (different tag on same paper)</Button>
-
+    <div style={{ textAlign: 'left' }}>
+      {/* Header: title + global options (Exclude no-data) + help icon (#3). The long
+          intro/help text now lives in the help popover instead of stacked above Tag 1. */}
       <div style={{
-        marginTop: '8px', backgroundColor: '#f8f9fa', border: '1px solid #dee2e6',
-        borderRadius: '6px', padding: '6px 8px',
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '12px',
+        padding: '10px 16px', borderBottom: '1px solid #cfe2ff', backgroundColor: '#eef5ff',
+        borderTopLeftRadius: '9px', borderTopRightRadius: '9px', flexWrap: 'wrap',
       }}>
-        <div style={{ fontSize: '0.7rem', color: '#6c757d', marginBottom: '2px' }}>Query preview</div>
-        <code style={{ fontSize: '0.75rem', color: '#212529', wordBreak: 'break-word' }}>
-          PAPER WHERE {tetPart}{corpusPart}
-        </code>
+        <span style={{ fontWeight: 600, letterSpacing: '0.01em' }}>Advanced Topic query</span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '14px' }}>
+          <Form.Check
+            type="checkbox"
+            id="tetv-adv-exclude-no-data"
+            checked={tree.excludeNoData === true}
+            onChange={(e) => update({ ...tree, excludeNoData: e.target.checked })}
+            label={
+              <span
+                style={{ fontSize: '0.8rem' }}
+                title="Match only positive (has-data) tags — adds has-data=yes to every tag condition. See help for details."
+              >Exclude no-data tags</span>
+            }
+            style={{ marginBottom: 0 }}
+          />
+          <OverlayTrigger trigger="click" placement="bottom-end" rootClose overlay={helpPopover}>
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label="How to use the advanced query builder"
+              style={{
+                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                width: '20px', height: '20px', borderRadius: '50%',
+                border: '1px solid #0d6efd', color: '#0d6efd',
+                fontSize: '0.72rem', fontWeight: 700, lineHeight: 1, cursor: 'pointer',
+              }}
+            >?</span>
+          </OverlayTrigger>
+        </div>
       </div>
 
-      <div style={{ marginTop: '8px' }}>
-        <ButtonGroup size="sm">
-          <Button variant="primary" onClick={runSearch} disabled={empty}>Run query</Button>
-          <Button variant="outline-secondary" onClick={reset}>Reset</Button>
-        </ButtonGroup>
+      <div style={{ padding: '12px 16px' }}>
+        {tags.length >= 2 && (
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap',
+            marginBottom: '4px',
+          }}>
+            <span style={{
+              fontSize: '0.72rem', fontWeight: 700, color: '#475569', letterSpacing: '0.06em',
+            }}>PAPER MUST MATCH</span>
+            <Form.Control
+              as="select"
+              size="sm"
+              aria-label="top-level operator"
+              style={{ maxWidth: '11rem', width: 'auto', borderRadius: '16px' }}
+              value={tree.operator}
+              onChange={(e) => update({ ...tree, operator: e.target.value })}
+            >
+              <option value="AND">ALL Tags (AND)</option>
+              <option value="OR">ANY Tag (OR)</option>
+            </Form.Control>
+            <span style={{ fontSize: '0.8rem', color: '#94a3b8' }}>
+              {tree.operator === 'AND'
+                ? 'Paper must contain every Tag below'
+                : 'Paper must contain at least one Tag below'}
+            </span>
+          </div>
+        )}
+
+        {tags.map((leaf, idx) => (
+          <TagCard
+            key={idx}
+            leaf={leaf}
+            index={idx}
+            onChange={(newLeaf) => setTag(idx, newLeaf)}
+            onRemove={() => removeTag(idx)}
+            canRemove={tags.length > 1}
+          />
+        ))}
+
+        <Button
+          variant="outline-primary"
+          onClick={addTag}
+          style={{
+            width: '100%', marginTop: '4px', borderStyle: 'dashed',
+            borderRadius: '10px', fontSize: '0.85rem',
+          }}
+        ><FontAwesomeIcon icon={faPlus} style={{ marginRight: '6px' }} />Add another Tag (different tag on same paper)</Button>
+      </div>
+
+      {/* Sticky footer: query preview + Run/Reset, kept in view while editing (#4). */}
+      <div style={{
+        position: 'sticky', bottom: 0, zIndex: 5,
+        display: 'flex', alignItems: 'stretch', gap: '12px', flexWrap: 'wrap',
+        padding: '10px 16px', backgroundColor: '#fff',
+        borderTop: '1px solid #e3e8ef',
+        borderBottomLeftRadius: '9px', borderBottomRightRadius: '9px',
+        boxShadow: '0 -2px 6px rgba(15, 23, 42, 0.05)',
+      }}>
+        <div style={{
+          flex: 1, minWidth: '240px', backgroundColor: '#0d1b2a',
+          borderRadius: '8px', padding: '8px 12px', overflowX: 'auto',
+        }}>
+          <div style={{
+            fontSize: '0.62rem', color: '#7c96b3', marginBottom: '3px',
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+          }}>Query preview</div>
+          <code style={{
+            fontSize: '0.75rem', color: '#a9d5ff', wordBreak: 'break-word',
+            whiteSpace: 'pre-wrap', fontFamily: 'monospace',
+          }}>
+            PAPER WHERE {tetPart}{corpusPart}
+          </code>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', justifyContent: 'center' }}>
+          <Button variant="primary" size="sm" onClick={runSearch} disabled={empty}>Run query</Button>
+          <Button variant="outline-secondary" size="sm" onClick={reset}>Reset</Button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/search/advanced/AdvancedTopicQueryBuilder.js
+++ b/src/components/search/advanced/AdvancedTopicQueryBuilder.js
@@ -1,8 +1,6 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Badge, Button, ButtonGroup, Form, InputGroup } from 'react-bootstrap';
-import { AsyncTypeahead } from 'react-bootstrap-typeahead';
-import 'react-bootstrap-typeahead/css/Typeahead.css';
 import { api } from '../../../api';
 import {
   setAdvancedTopicQuery,
@@ -10,7 +8,7 @@ import {
   searchReferences,
   fetchAdvancedFacetsVocab,
 } from '../../../actions/searchActions';
-import { changeFieldEntityEntityList } from '../../../actions/biblioActions';
+import { changeFieldEntityEntityList, fetchTaxonData } from '../../../actions/biblioActions';
 import {
   TET_FIELD_DEFS,
   FIELD_DEF_BY_KEY,
@@ -35,11 +33,22 @@ const ENTITY_WARN_CURIES = [
   'no WB curie', 'no SGD curie', 'no mod curie', 'duplicate',
 ];
 
-// Stable per-instance id (AsyncTypeahead requires an id and we may render several).
-let advUidCounter = 0;
-const useAdvUid = (prefix) => {
-  const [id] = useState(() => `${prefix}-${(advUidCounter += 1)}`);
-  return id;
+// Species options for the Species field's dropdown: the Alliance MOD taxa (plus
+// human), matching the TET create form's species list. Read from the shared
+// biblio taxon data (loaded once by the builder via fetchTaxonData). Value is the
+// NCBITaxon curie (what tags store, and what the entity lookup needs); label is the
+// species name. Returns null until the data has loaded.
+const useSpeciesOptions = () => {
+  const modToTaxon = useSelector((s) => s.biblio.modToTaxon);
+  const curieToNameTaxon = useSelector((s) => s.biblio.curieToNameTaxon);
+  return useMemo(() => {
+    if (!modToTaxon || !curieToNameTaxon) return null;
+    const curies = [...new Set(Object.values(modToTaxon).flat().concat('NCBITaxon:9606'))];
+    return curies
+      .filter((c) => c && curieToNameTaxon[c])
+      .map((c) => ({ value: c, label: curieToNameTaxon[c] }))
+      .sort((a, b) => (a.label > b.label ? 1 : -1));
+  }, [modToTaxon, curieToNameTaxon]);
 };
 
 // Process-wide cache of resolved ATP/ECO curie -> display name, so switching
@@ -124,53 +133,6 @@ const ValueChip = ({ chip, onRemove }) => (
   </span>
 );
 
-// Species adder: a taxon typeahead backed by /ontology/search_species. Stores the
-// NCBITaxon curie as the chip value (labelled with the name) so it matches the
-// taxon curie tags carry, and so an Entity field in the same Tag can resolve names
-// against it. Mirrors the SpeciesPicker convention of "<name> <curie>" options.
-const SpeciesValueAdder = ({ hasValues, onAdd }) => {
-  const id = useAdvUid('adv-species-ta');
-  const ref = useRef(null);
-  const [options, setOptions] = useState([]);
-  const [loading, setLoading] = useState(false);
-  return (
-    <div style={{ width: '16rem', maxWidth: '100%', flex: '0 0 auto' }}>
-      <AsyncTypeahead
-        id={id}
-        ref={ref}
-        size="sm"
-        isLoading={loading}
-        minLength={1}
-        useCache={false}
-        placeholder={hasValues ? 'add species…' : 'species name, e.g. Saccharomyces'}
-        options={options}
-        selected={[]}
-        onSearch={async (query) => {
-          setLoading(true);
-          try {
-            const res = await api.get(`/ontology/search_species/${encodeURIComponent(query)}`);
-            setOptions(Array.isArray(res.data)
-              ? res.data.filter((it) => it?.curie && it?.name).map((it) => `${it.name} ${it.curie}`)
-              : []);
-          } catch (e) {
-            setOptions([]);
-          } finally {
-            setLoading(false);
-          }
-        }}
-        onChange={(selected) => {
-          if (selected && selected.length > 0) {
-            const m = String(selected[selected.length - 1]).match(/(.+)\s+(NCBITaxon:\d+)$/);
-            if (m) onAdd(m[2], `${m[1]} (${m[2]})`);
-            ref.current?.clear?.();
-            setOptions([]);
-          }
-        }}
-      />
-    </div>
-  );
-};
-
 // Entity adder: a specific entity (e.g. gene "ACT1"). The validation endpoint
 // matches an EXACT name for a given entity type + taxon, so this is a
 // type-the-name-then-validate box (not a suggestion typeahead). It needs the
@@ -185,7 +147,7 @@ const EntityValueAdder = ({ hasValues, entityTypeCurie, taxon, onAdd }) => {
   if (!typeName || !taxonReady) {
     return (
       <span style={{ fontSize: '0.75rem', color: '#b02a37' }}>
-        Add an <b>Entity type</b> and a <b>Species</b> field to this tag first, then enter an entity name.
+        Choose an <b>Entity type</b> and a <b>Species</b> for this tag first, then enter an entity name.
       </span>
     );
   }
@@ -231,11 +193,16 @@ const EntityValueAdder = ({ hasValues, entityTypeCurie, taxon, onAdd }) => {
 };
 
 // The value editor for one field row: a chip list (OR) plus an adder. Range fields
-// (confidence score) use a min/max pair instead of chips. Entity/Species use their
-// own resolver widgets (tagContext carries the sibling entity type + taxon).
+// (confidence score) use a min/max pair instead of chips. Species uses the fixed
+// MOD species dropdown; Entity uses a validate-on-type box (tagContext carries the
+// sibling entity type + taxon it resolves against).
 const ValueEditor = ({ row, onChange, tagContext }) => {
   const dispatch = useDispatch();
-  const options = useFieldOptions(row.field);
+  const fieldOptions = useFieldOptions(row.field);
+  const speciesOptions = useSpeciesOptions();
+  // Species is a controlled dropdown of the MOD taxa; [] while the list loads so it
+  // still renders as a (temporarily empty) select rather than a free-text box.
+  const options = row.field === 'species' ? (speciesOptions || []) : fieldOptions;
   const [text, setText] = useState('');
   const values = Array.isArray(row.values) ? row.values : [];
 
@@ -287,9 +254,7 @@ const ValueEditor = ({ row, onChange, tagContext }) => {
       {values.length > 0 && (
         <span style={{ fontSize: '0.7rem', color: '#6c757d', whiteSpace: 'nowrap' }}>or</span>
       )}
-      {row.field === 'species' ? (
-        <SpeciesValueAdder hasValues={values.length > 0} onAdd={addChip} />
-      ) : row.field === 'entity' ? (
+      {row.field === 'entity' ? (
         <EntityValueAdder
           hasValues={values.length > 0}
           entityTypeCurie={tagContext?.entityTypeCurie}
@@ -368,8 +333,22 @@ const FieldRow = ({ row, onChange, onRemove, canRemove, tagContext }) => (
 // DIFFERENT tag on the same paper.
 const TagCard = ({ leaf, index, onChange, onRemove, canRemove }) => {
   const dispatch = useDispatch();
-  const setField = (idx, newRow) =>
-    onChange({ ...leaf, fields: leaf.fields.map((f, i) => (i === idx ? newRow : f)) });
+  const setField = (idx, newRow) => {
+    let fields = leaf.fields.map((f, i) => (i === idx ? newRow : f));
+    // Picking "Entity" needs an entity type and a species to resolve the name
+    // against (a gene is species-specific), so surface those fields automatically
+    // if the Tag doesn't already have them — inserted just above the Entity row so
+    // the curator fills them top-down.
+    if (newRow.field === 'entity') {
+      const missing = ['entity_type', 'species']
+        .filter((k) => !fields.some((f) => f.field === k))
+        .map((k) => createFieldRow(k));
+      if (missing.length > 0) {
+        fields = [...fields.slice(0, idx), ...missing, ...fields.slice(idx)];
+      }
+    }
+    onChange({ ...leaf, fields });
+  };
   const addField = () => onChange({ ...leaf, fields: [...leaf.fields, createFieldRow()] });
   const removeField = (idx) => {
     onChange({ ...leaf, fields: leaf.fields.filter((_f, i) => i !== idx) });
@@ -460,6 +439,12 @@ const AdvancedTopicQueryBuilder = () => {
   useEffect(() => {
     dispatch(fetchAdvancedFacetsVocab());
   }, [corpusModsKey, dispatch]);
+
+  // Load the MOD species list once so the Species field's dropdown is populated
+  // (shared biblio taxon data; the thunk caches and de-dupes fetches).
+  useEffect(() => {
+    dispatch(fetchTaxonData());
+  }, [dispatch]);
 
   // Seed a default flat tree the first time the builder is shown; normalize a
   // legacy/nested saved tree into flat Tag cards so it renders without crashing.
@@ -562,9 +547,9 @@ const AdvancedTopicQueryBuilder = () => {
             </li>
             <li>
               <b>Entity</b> matches a specific entity (e.g. the gene <i>ACT1</i>) by
-              name and stores its curie. It needs an <b>Entity type</b> and a{' '}
-              <b>Species</b> field on the same Tag; type the exact name and press Enter
-              to validate it against that species and type.
+              name and stores its curie. Picking it adds <b>Entity type</b> and{' '}
+              <b>Species</b> fields for you (an entity is species-specific); choose
+              those, then type the exact name and press Enter to validate it.
             </li>
             <li>
               <b>Has data</b> distinguishes positive tags (has data) from negated tags

--- a/src/components/search/advanced/AdvancedTopicQueryBuilder.js
+++ b/src/components/search/advanced/AdvancedTopicQueryBuilder.js
@@ -634,7 +634,24 @@ const AdvancedTopicQueryBuilder = () => {
         padding: '10px 16px', borderBottom: '1px solid #cfe2ff', backgroundColor: '#eef5ff',
         borderTopLeftRadius: '9px', borderTopRightRadius: '9px', flexWrap: 'wrap',
       }}>
-        <span style={{ fontWeight: 600, letterSpacing: '0.01em' }}>Advanced Topic query</span>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+          <span style={{ fontWeight: 600, letterSpacing: '0.01em' }}>Advanced Topic query</span>
+          <OverlayTrigger trigger="click" placement="bottom-start" rootClose overlay={helpPopover}>
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label="How to use the advanced query builder"
+              title="How to use — AND/OR, tags, and examples"
+              style={{
+                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                width: '20px', height: '20px', borderRadius: '50%',
+                backgroundColor: '#0d6efd', color: '#fff',
+                fontSize: '0.75rem', fontWeight: 700, lineHeight: 1, cursor: 'pointer',
+                boxShadow: '0 1px 2px rgba(13, 110, 253, 0.35)',
+              }}
+            >?</span>
+          </OverlayTrigger>
+        </span>
         <div style={{ display: 'flex', alignItems: 'center', gap: '14px' }}>
           <Form.Check
             type="checkbox"
@@ -649,19 +666,6 @@ const AdvancedTopicQueryBuilder = () => {
             }
             style={{ marginBottom: 0 }}
           />
-          <OverlayTrigger trigger="click" placement="bottom-end" rootClose overlay={helpPopover}>
-            <span
-              role="button"
-              tabIndex={0}
-              aria-label="How to use the advanced query builder"
-              style={{
-                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-                width: '20px', height: '20px', borderRadius: '50%',
-                border: '1px solid #0d6efd', color: '#0d6efd',
-                fontSize: '0.72rem', fontWeight: 700, lineHeight: 1, cursor: 'pointer',
-              }}
-            >?</span>
-          </OverlayTrigger>
         </div>
       </div>
 
@@ -724,15 +728,16 @@ const AdvancedTopicQueryBuilder = () => {
         boxShadow: '0 -2px 6px rgba(15, 23, 42, 0.05)',
       }}>
         <div style={{
-          flex: 1, minWidth: '240px', backgroundColor: '#0d1b2a',
+          flex: 1, minWidth: '240px', backgroundColor: '#f1f5f9',
+          border: '1px solid #dbe4ee',
           borderRadius: '8px', padding: '8px 12px', overflowX: 'auto',
         }}>
           <div style={{
-            fontSize: '0.62rem', color: '#7c96b3', marginBottom: '3px',
+            fontSize: '0.62rem', color: '#64748b', marginBottom: '3px',
             textTransform: 'uppercase', letterSpacing: '0.06em',
           }}>Query preview</div>
           <code style={{
-            fontSize: '0.75rem', color: '#a9d5ff', wordBreak: 'break-word',
+            fontSize: '0.75rem', color: '#0b5394', wordBreak: 'break-word',
             whiteSpace: 'pre-wrap', fontFamily: 'monospace',
           }}>
             PAPER WHERE {tetPart}{corpusPart}

--- a/src/components/search/advanced/AdvancedTopicQueryBuilder.js
+++ b/src/components/search/advanced/AdvancedTopicQueryBuilder.js
@@ -345,11 +345,11 @@ const FieldRow = ({ row, onChange, onRemove, canRemove, tagContext, usedFieldKey
     <Button
       variant="link" size="sm"
       onClick={onRemove} disabled={!canRemove}
-      title="Remove field"
+      title={canRemove ? 'Remove field' : 'A tag needs at least one field'}
       aria-label="remove field"
       style={{
-        flex: '0 0 auto', color: '#adb5bd', textDecoration: 'none',
-        fontSize: '1.15rem', lineHeight: 1, padding: '0 4px',
+        flex: '0 0 auto', color: canRemove ? '#dc3545' : '#cbd5e1',
+        textDecoration: 'none', fontSize: '1.15rem', lineHeight: 1, padding: '0 4px',
       }}
     >×</Button>
   </div>
@@ -434,8 +434,11 @@ const TagCard = ({ leaf, index, onChange, onRemove, canRemove }) => {
           <Button
             variant="link" size="sm"
             onClick={onRemove} disabled={!canRemove}
-            title="Remove tag"
-            style={{ color: '#94a3b8', textDecoration: 'none', padding: 0, fontSize: '0.8rem' }}
+            title={canRemove ? 'Remove tag' : 'A query needs at least one tag'}
+            style={{
+              color: canRemove ? '#dc3545' : '#cbd5e1',
+              textDecoration: 'none', padding: 0, fontSize: '0.8rem',
+            }}
           ><FontAwesomeIcon icon={faTrashAlt} style={{ marginRight: '5px' }} />Remove tag</Button>
         </div>
       </div>

--- a/src/components/search/advanced/AdvancedTopicQueryBuilder.js
+++ b/src/components/search/advanced/AdvancedTopicQueryBuilder.js
@@ -20,6 +20,7 @@ import {
   createLeaf,
   createEmptyTree,
   normalizeToFlatTree,
+  needsFlatNormalization,
   isLeaf,
   isAdvancedQueryEmpty,
   compileAdvancedQuery,
@@ -54,12 +55,14 @@ const useSpeciesOptions = () => {
   const isFetching = useSelector((s) => s.biblio.isFetchingTaxonData);
   const fetchError = useSelector((s) => s.biblio.taxonDataError);
   return useMemo(() => {
-    if (isFetching || !modToTaxon || !curieToNameTaxon) {
-      return { status: 'loading', options: [] };
-    }
-    if (fetchError || Object.keys(modToTaxon).length === 0) {
-      return { status: 'error', options: [] };
-    }
+    if (isFetching) return { status: 'loading', options: [] };
+    // A dispatched fetch error (should getTaxonData ever start rejecting) takes
+    // precedence over the not-loaded-yet check below, which would otherwise pin the
+    // row to "loading" forever since FETCH_TAXON_DATA_ERROR leaves modToTaxon null.
+    if (fetchError) return { status: 'error', options: [] };
+    if (!modToTaxon || !curieToNameTaxon) return { status: 'loading', options: [] };
+    // Empty modToTaxon = the swallowed /mod/taxons/all failure (see note above).
+    if (Object.keys(modToTaxon).length === 0) return { status: 'error', options: [] };
     const curies = [...new Set(Object.values(modToTaxon).flat().concat('NCBITaxon:9606'))];
     const options = curies
       .filter((c) => c && curieToNameTaxon[c])
@@ -541,14 +544,13 @@ const AdvancedTopicQueryBuilder = () => {
     dispatch(fetchTaxonData());
   }, [dispatch]);
 
-  // Seed a default flat tree the first time the builder is shown; normalize a
-  // legacy/nested saved tree into flat Tag cards so it renders without crashing.
-  // Also normalize excludeNoData for a tree that predates the flag (e.g. persisted
-  // from an earlier session) so it reads as the current default (off) rather than
-  // an undefined flag (SCRUM-6228).
+  // Seed a default flat tree the first time the builder is shown; otherwise
+  // re-normalize a restored tree that the flat Tag builder can't safely display as-is
+  // — nested groups, a pre-excludeNoData flag, or duplicate field rows within a Tag
+  // (see needsFlatNormalization). Idempotent, so this one-shot effect can't loop.
   useEffect(() => {
     if (!tree) { dispatch(setAdvancedTopicQuery(createEmptyTree())); return; }
-    if ((tree.children || []).some((c) => !isLeaf(c)) || tree.excludeNoData === undefined) {
+    if (needsFlatNormalization(tree)) {
       dispatch(setAdvancedTopicQuery(normalizeToFlatTree(tree)));
     }
   }, [tree, dispatch]);

--- a/src/components/search/advanced/AdvancedTopicQueryBuilder.js
+++ b/src/components/search/advanced/AdvancedTopicQueryBuilder.js
@@ -314,7 +314,7 @@ const ValueEditor = ({ row, onChange, tagContext }) => {
   );
 };
 
-const FieldRow = ({ row, onChange, onRemove, canRemove, tagContext }) => (
+const FieldRow = ({ row, onChange, onRemove, canRemove, tagContext, usedFieldKeys }) => (
   <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '2px' }}>
     <Form.Control
       as="select"
@@ -324,8 +324,14 @@ const FieldRow = ({ row, onChange, onRemove, canRemove, tagContext }) => (
       value={row.field}
       onChange={(e) => onChange(createFieldRow(e.target.value))}
     >
+      {/* A Tag can carry each field at most once (a tag can't be topic=A AND topic=B),
+          so disable field types already used by other rows in this same Tag. */}
       {TET_FIELD_DEFS.map((def) => (
-        <option key={def.key} value={def.key}>{def.label}</option>
+        <option
+          key={def.key}
+          value={def.key}
+          disabled={def.key !== row.field && usedFieldKeys.includes(def.key)}
+        >{def.label}</option>
       ))}
     </Form.Control>
     <span style={{ color: '#94a3b8', fontWeight: 600, flex: '0 0 auto' }}>=</span>
@@ -370,7 +376,14 @@ const TagCard = ({ leaf, index, onChange, onRemove, canRemove }) => {
     }
     onChange({ ...leaf, fields });
   };
-  const addField = () => onChange({ ...leaf, fields: [...leaf.fields, createFieldRow()] });
+  const addField = () => {
+    // Default a new row to the first field type this Tag isn't already using, so we
+    // never open on a duplicate the curator would then have to change.
+    const usedKeys = leaf.fields.map((f) => f.field);
+    const nextDef = TET_FIELD_DEFS.find((def) => !usedKeys.includes(def.key));
+    if (!nextDef) return; // every field type already present in this Tag
+    onChange({ ...leaf, fields: [...leaf.fields, createFieldRow(nextDef.key)] });
+  };
   const removeField = (idx) => {
     onChange({ ...leaf, fields: leaf.fields.filter((_f, i) => i !== idx) });
     // Re-pull the vocabulary so the dropdowns are full and fresh when a replacement
@@ -441,12 +454,15 @@ const TagCard = ({ leaf, index, onChange, onRemove, canRemove }) => {
             onRemove={() => removeField(idx)}
             canRemove={leaf.fields.length > 1}
             tagContext={tagContext}
+            usedFieldKeys={leaf.fields.filter((_f, i) => i !== idx).map((f) => f.field)}
           />
         </React.Fragment>
       ))}
       <Button
         variant="outline-secondary" size="sm"
         onClick={addField}
+        disabled={leaf.fields.length >= TET_FIELD_DEFS.length}
+        title={leaf.fields.length >= TET_FIELD_DEFS.length ? 'Every field type is already used in this Tag' : undefined}
         style={{ marginTop: '10px', borderRadius: '16px', fontSize: '0.8rem' }}
       ><FontAwesomeIcon icon={faPlus} style={{ marginRight: '6px' }} />Add field to Tag {index + 1}</Button>
     </div>

--- a/src/components/search/advanced/AdvancedTopicQueryBuilder.js
+++ b/src/components/search/advanced/AdvancedTopicQueryBuilder.js
@@ -4,13 +4,14 @@ import { Button, Form, InputGroup, OverlayTrigger, Popover } from 'react-bootstr
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrashAlt, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { api } from '../../../api';
+import './AdvancedTopicQueryBuilder.css';
 import {
   setAdvancedTopicQuery,
   setSearchResultsPage,
   searchReferences,
   fetchAdvancedFacetsVocab,
 } from '../../../actions/searchActions';
-import { changeFieldEntityEntityList, fetchTaxonData } from '../../../actions/biblioActions';
+import { changeFieldEntityEntityList, fetchTaxonData, clearTaxonData } from '../../../actions/biblioActions';
 import {
   TET_FIELD_DEFS,
   FIELD_DEF_BY_KEY,
@@ -36,21 +37,36 @@ const ENTITY_WARN_CURIES = [
 ];
 
 // Species options for the Species field's dropdown: the Alliance MOD taxa (plus
-// human), matching the TET create form's species list. Read from the shared
-// biblio taxon data (loaded once by the builder via fetchTaxonData). Value is the
+// human), matching the TET create form's species list. Read from the shared biblio
+// taxon data (loaded once by the builder via fetchTaxonData). Value is the
 // NCBITaxon curie (what tags store, and what the entity lookup needs); label is the
-// species name. Returns null until the data has loaded.
+// species name. Returns { status, options }:
+//   'loading' — data not in yet (or a fetch is in flight)
+//   'error'   — the fetch failed. NOTE getModToTaxon swallows a /mod/taxons/all
+//               failure and returns {}, which fetchTaxonData then caches as a
+//               "successful" empty modToTaxon (no taxonDataError). That yields a
+//               bogus Homo-sapiens-only list, so an EMPTY modToTaxon is treated as
+//               an error here rather than a one-species result.
+//   'ready'   — options populated.
 const useSpeciesOptions = () => {
   const modToTaxon = useSelector((s) => s.biblio.modToTaxon);
   const curieToNameTaxon = useSelector((s) => s.biblio.curieToNameTaxon);
+  const isFetching = useSelector((s) => s.biblio.isFetchingTaxonData);
+  const fetchError = useSelector((s) => s.biblio.taxonDataError);
   return useMemo(() => {
-    if (!modToTaxon || !curieToNameTaxon) return null;
+    if (isFetching || !modToTaxon || !curieToNameTaxon) {
+      return { status: 'loading', options: [] };
+    }
+    if (fetchError || Object.keys(modToTaxon).length === 0) {
+      return { status: 'error', options: [] };
+    }
     const curies = [...new Set(Object.values(modToTaxon).flat().concat('NCBITaxon:9606'))];
-    return curies
+    const options = curies
       .filter((c) => c && curieToNameTaxon[c])
       .map((c) => ({ value: c, label: curieToNameTaxon[c] }))
       .sort((a, b) => (a.label > b.label ? 1 : -1));
-  }, [modToTaxon, curieToNameTaxon]);
+    return { status: 'ready', options };
+  }, [modToTaxon, curieToNameTaxon, isFetching, fetchError]);
 };
 
 // Process-wide cache of resolved ATP/ECO curie -> display name, so switching
@@ -201,10 +217,12 @@ const EntityValueAdder = ({ hasValues, entityTypeCurie, taxon, onAdd }) => {
 const ValueEditor = ({ row, onChange, tagContext }) => {
   const dispatch = useDispatch();
   const fieldOptions = useFieldOptions(row.field);
-  const speciesOptions = useSpeciesOptions();
-  // Species is a controlled dropdown of the MOD taxa; [] while the list loads so it
-  // still renders as a (temporarily empty) select rather than a free-text box.
-  const options = row.field === 'species' ? (speciesOptions || []) : fieldOptions;
+  const species = useSpeciesOptions();
+  const isSpecies = row.field === 'species';
+  // Species is a controlled dropdown of the MOD taxa. Its options are only used
+  // once loaded; while loading/errored the render below shows a status affordance
+  // instead of the select, so it never falls through to a free-text box.
+  const options = isSpecies ? species.options : fieldOptions;
   const [text, setText] = useState('');
   const values = Array.isArray(row.values) ? row.values : [];
 
@@ -264,6 +282,17 @@ const ValueEditor = ({ row, onChange, tagContext }) => {
           taxon={tagContext?.taxon}
           onAdd={addChip}
         />
+      ) : isSpecies && species.status === 'loading' ? (
+        <span style={{ fontSize: '0.75rem', color: '#6c757d' }}>loading species…</span>
+      ) : isSpecies && species.status === 'error' ? (
+        <span style={{ fontSize: '0.75rem', color: '#b02a37' }}>
+          Couldn’t load the species list.{' '}
+          <Button
+            variant="link" size="sm"
+            style={{ padding: 0, fontSize: '0.75rem', verticalAlign: 'baseline' }}
+            onClick={() => { dispatch(clearTaxonData()); dispatch(fetchTaxonData()); }}
+          >Retry</Button>
+        </span>
       ) : options ? (
         <Form.Control
           as="select"
@@ -344,12 +373,13 @@ const FieldRow = ({ row, onChange, onRemove, canRemove, tagContext, usedFieldKey
     </div>
     <Button
       variant="link" size="sm"
+      className="tetv-adv-remove-btn"
       onClick={onRemove} disabled={!canRemove}
       title={canRemove ? 'Remove field' : 'A tag needs at least one field'}
       aria-label="remove field"
       style={{
-        flex: '0 0 auto', color: canRemove ? '#dc3545' : '#cbd5e1',
-        textDecoration: 'none', fontSize: '1.15rem', lineHeight: 1, padding: '0 4px',
+        flex: '0 0 auto', textDecoration: 'none',
+        fontSize: '1.15rem', lineHeight: 1, padding: '0 4px',
       }}
     >×</Button>
   </div>
@@ -358,22 +388,29 @@ const FieldRow = ({ row, onChange, onRemove, canRemove, tagContext, usedFieldKey
 // One Tag card = one topic_entity_tag the paper must (or must not) have. All fields
 // inside AND on the SAME tag; multiple values on a field OR. A second Tag card is a
 // DIFFERENT tag on the same paper.
+// Picking "Entity" needs an entity type and a species to resolve the name against
+// (a gene is species-specific), so surface those fields automatically if the Tag
+// doesn't already have them — inserted just above the Entity row at entityIdx so
+// the curator fills them top-down. No-op when the row isn't Entity or the
+// companions are already present. Applies whether the Entity row was added or a
+// row was switched to Entity, so the Add-field path doesn't leave a bare Entity
+// row showing the "choose type and species first" prompt.
+const withEntityCompanions = (fields, entityIdx) => {
+  if (fields[entityIdx]?.field !== 'entity') return fields;
+  const missing = ['entity_type', 'species']
+    .filter((k) => !fields.some((f) => f.field === k))
+    .map((k) => createFieldRow(k));
+  if (missing.length === 0) return fields;
+  return [...fields.slice(0, entityIdx), ...missing, ...fields.slice(entityIdx)];
+};
+
 const TagCard = ({ leaf, index, onChange, onRemove, canRemove }) => {
   const dispatch = useDispatch();
   const setField = (idx, newRow) => {
-    let fields = leaf.fields.map((f, i) => (i === idx ? newRow : f));
-    // Picking "Entity" needs an entity type and a species to resolve the name
-    // against (a gene is species-specific), so surface those fields automatically
-    // if the Tag doesn't already have them — inserted just above the Entity row so
-    // the curator fills them top-down.
-    if (newRow.field === 'entity') {
-      const missing = ['entity_type', 'species']
-        .filter((k) => !fields.some((f) => f.field === k))
-        .map((k) => createFieldRow(k));
-      if (missing.length > 0) {
-        fields = [...fields.slice(0, idx), ...missing, ...fields.slice(idx)];
-      }
-    }
+    const fields = withEntityCompanions(
+      leaf.fields.map((f, i) => (i === idx ? newRow : f)),
+      idx
+    );
     onChange({ ...leaf, fields });
   };
   const addField = () => {
@@ -382,7 +419,8 @@ const TagCard = ({ leaf, index, onChange, onRemove, canRemove }) => {
     const usedKeys = leaf.fields.map((f) => f.field);
     const nextDef = TET_FIELD_DEFS.find((def) => !usedKeys.includes(def.key));
     if (!nextDef) return; // every field type already present in this Tag
-    onChange({ ...leaf, fields: [...leaf.fields, createFieldRow(nextDef.key)] });
+    const appended = [...leaf.fields, createFieldRow(nextDef.key)];
+    onChange({ ...leaf, fields: withEntityCompanions(appended, appended.length - 1) });
   };
   const removeField = (idx) => {
     onChange({ ...leaf, fields: leaf.fields.filter((_f, i) => i !== idx) });
@@ -433,12 +471,10 @@ const TagCard = ({ leaf, index, onChange, onRemove, canRemove }) => {
           />
           <Button
             variant="link" size="sm"
+            className="tetv-adv-remove-btn"
             onClick={onRemove} disabled={!canRemove}
             title={canRemove ? 'Remove tag' : 'A query needs at least one tag'}
-            style={{
-              color: canRemove ? '#dc3545' : '#cbd5e1',
-              textDecoration: 'none', padding: 0, fontSize: '0.8rem',
-            }}
+            style={{ textDecoration: 'none', padding: 0, fontSize: '0.8rem' }}
           ><FontAwesomeIcon icon={faTrashAlt} style={{ marginRight: '5px' }} />Remove tag</Button>
         </div>
       </div>
@@ -655,20 +691,23 @@ const AdvancedTopicQueryBuilder = () => {
       }}>
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
           <span style={{ fontWeight: 600, letterSpacing: '0.01em' }}>Advanced Topic query</span>
+          {/* A native <button> (not a role="button" span) so it's keyboard-
+              operable: react-bootstrap v1's OverlayTrigger only binds onClick, and
+              a button fires that on Enter/Space where a span would not. */}
           <OverlayTrigger trigger="click" placement="bottom-start" rootClose overlay={helpPopover}>
-            <span
-              role="button"
-              tabIndex={0}
+            <button
+              type="button"
               aria-label="How to use the advanced query builder"
+              aria-haspopup="dialog"
               title="How to use — AND/OR, tags, and examples"
               style={{
                 display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-                width: '20px', height: '20px', borderRadius: '50%',
+                width: '20px', height: '20px', borderRadius: '50%', border: 'none', padding: 0,
                 backgroundColor: '#0d6efd', color: '#fff',
                 fontSize: '0.75rem', fontWeight: 700, lineHeight: 1, cursor: 'pointer',
                 boxShadow: '0 1px 2px rgba(13, 110, 253, 0.35)',
               }}
-            >?</span>
+            >?</button>
           </OverlayTrigger>
         </span>
         <div style={{ display: 'flex', alignItems: 'center', gap: '14px' }}>

--- a/src/components/search/advanced/__tests__/advancedQueryModel.test.js
+++ b/src/components/search/advanced/__tests__/advancedQueryModel.test.js
@@ -11,7 +11,6 @@ import {
   ENTITY_TYPE_OPTIONS,
   VALIDATION_BY_PROFESSIONAL_BIOCURATOR_OPTIONS,
   FIELD_DEF_BY_KEY,
-  TET_FIELD_DEFS,
   entityTypeNameForCurie,
 } from '../advancedQueryModel';
 
@@ -192,12 +191,15 @@ describe('entity_type controlled vocabulary (SCRUM-6228)', () => {
 });
 
 describe('entity field (specific-entity lookup, SCRUM-6228)', () => {
-  test('entity is NOT a selectable field in the dropdown (removed per curator request)', () => {
-    expect(FIELD_DEF_BY_KEY.entity).toBeUndefined();
-    expect(TET_FIELD_DEFS.some((d) => d.key === 'entity')).toBe(false);
+  test('entity is a free-text field def (no static options/facet)', () => {
+    const def = FIELD_DEF_BY_KEY.entity;
+    expect(def).toBeTruthy();
+    expect(def.label).toBe('Entity');
+    expect(def.facetKey).toBeNull();
+    expect(def.options).toBeUndefined();
   });
 
-  test('the compiler still folds a persisted entity field into the entity match key', () => {
+  test('an entity curie compiles to the entity match key', () => {
     const leaf = {
       type: 'tet',
       negate: false,

--- a/src/components/search/advanced/__tests__/advancedQueryModel.test.js
+++ b/src/components/search/advanced/__tests__/advancedQueryModel.test.js
@@ -5,6 +5,7 @@ import {
   createFieldRow,
   flattenAdvancedForGrid,
   normalizeToFlatTree,
+  needsFlatNormalization,
   describeCompiledQuery,
   isLeaf,
   buildValueLabeler,
@@ -373,6 +374,54 @@ describe('normalizeToFlatTree (legacy/nested -> flat Tag cards, SCRUM-6228)', ()
     expect(rows[0].values.map((v) => v.value)).toEqual(['ATP:1', 'ATP:2']);
     // The merged leaf still compiles to the OR of both topic values.
     expect(compileAdvancedQuery(flat).match.topic).toEqual(['ATP:1', 'ATP:2']);
+  });
+});
+
+describe('needsFlatNormalization (restore-path gate, SCRUM-6333)', () => {
+  const leafWith = (fields) => ({ type: 'tet', negate: false, fields });
+
+  test('true for a nested tree', () => {
+    const nested = { operator: 'AND', excludeNoData: false, children: [
+      { operator: 'OR', children: [leafWith([{ field: 'topic', values: [] }])] },
+    ] };
+    expect(needsFlatNormalization(nested)).toBe(true);
+  });
+
+  test('true for a tree that predates the excludeNoData flag', () => {
+    const legacy = { operator: 'AND', children: [leafWith([{ field: 'topic', values: [] }])] };
+    expect(legacy.excludeNoData).toBeUndefined();
+    expect(needsFlatNormalization(legacy)).toBe(true);
+  });
+
+  test('true for a flat, excludeNoData-defined tree carrying a duplicate field row', () => {
+    // The case the dedupe targets: saved by the flat builder after excludeNoData
+    // landed but before the one-row-per-field invariant. Both other gate clauses
+    // are false here, so this duplicate check is what triggers re-normalization.
+    const dup = { operator: 'AND', excludeNoData: false, children: [leafWith([
+      { field: 'topic', values: [{ value: 'ATP:1' }] },
+      { field: 'topic', values: [{ value: 'ATP:2' }] },
+    ])] };
+    expect(needsFlatNormalization(dup)).toBe(true);
+  });
+
+  test('false for a clean flat tree, and idempotent after one normalize pass', () => {
+    const clean = { operator: 'AND', excludeNoData: false, children: [leafWith([
+      { field: 'topic', values: [{ value: 'ATP:1' }] },
+      { field: 'source_method', values: [{ value: 'sm' }] },
+    ])] };
+    expect(needsFlatNormalization(clean)).toBe(false);
+    // Normalizing the duplicate tree from the previous test must yield a tree the
+    // gate leaves alone, so the builder's seeding effect can't loop.
+    const normalized = normalizeToFlatTree({ operator: 'AND', excludeNoData: false, children: [leafWith([
+      { field: 'topic', values: [{ value: 'ATP:1' }] },
+      { field: 'topic', values: [{ value: 'ATP:2' }] },
+    ])] });
+    expect(needsFlatNormalization(normalized)).toBe(false);
+  });
+
+  test('false for null/undefined (seeding handles the empty case separately)', () => {
+    expect(needsFlatNormalization(null)).toBe(false);
+    expect(needsFlatNormalization(undefined)).toBe(false);
   });
 });
 

--- a/src/components/search/advanced/__tests__/advancedQueryModel.test.js
+++ b/src/components/search/advanced/__tests__/advancedQueryModel.test.js
@@ -350,6 +350,30 @@ describe('normalizeToFlatTree (legacy/nested -> flat Tag cards, SCRUM-6228)', ()
     const off = { operator: 'AND', excludeNoData: false, children: [] };
     expect(normalizeToFlatTree(off).excludeNoData).toBe(false);
   });
+
+  test('dedupes duplicate field rows within a leaf, merging their values (OR)', () => {
+    // A query saved before the one-row-per-field invariant can carry the same
+    // field twice; the flat builder must collapse them so Add-field/field-disable
+    // logic stays correct.
+    const dup = {
+      operator: 'AND',
+      children: [{
+        type: 'tet', negate: false,
+        fields: [
+          { field: 'topic', values: [{ value: 'ATP:1', label: 'a' }] },
+          { field: 'source_method', values: [{ value: 'sm', label: 'sm' }] },
+          { field: 'topic', values: [{ value: 'ATP:2', label: 'b' }, { value: 'ATP:1', label: 'a' }] },
+        ],
+      }],
+    };
+    const flat = normalizeToFlatTree(dup);
+    const rows = flat.children[0].fields;
+    // topic appears once, in first-occurrence position, with merged, de-duped values.
+    expect(rows.map((r) => r.field)).toEqual(['topic', 'source_method']);
+    expect(rows[0].values.map((v) => v.value)).toEqual(['ATP:1', 'ATP:2']);
+    // The merged leaf still compiles to the OR of both topic values.
+    expect(compileAdvancedQuery(flat).match.topic).toEqual(['ATP:1', 'ATP:2']);
+  });
 });
 
 describe('describeCompiledQuery (preview, SCRUM-6228)', () => {

--- a/src/components/search/advanced/advancedQueryModel.js
+++ b/src/components/search/advanced/advancedQueryModel.js
@@ -92,6 +92,7 @@ export const VALIDATION_BY_PROFESSIONAL_BIOCURATOR_OPTIONS = [
 export const TET_FIELD_DEFS = [
   { key: 'topic', label: 'Topic', facetKey: 'topics' },
   { key: 'entity_type', label: 'Entity type', facetKey: null, options: ENTITY_TYPE_OPTIONS },
+  { key: 'entity', label: 'Entity', facetKey: null },
   { key: 'source_method', label: 'Source method', facetKey: 'source_methods' },
   { key: 'source_evidence_assertion', label: 'Source evidence assertion', facetKey: 'source_evidence_assertions' },
   { key: 'confidence_level', label: 'Confidence level', facetKey: 'confidence_levels' },

--- a/src/components/search/advanced/advancedQueryModel.js
+++ b/src/components/search/advanced/advancedQueryModel.js
@@ -204,6 +204,28 @@ export const normalizeToFlatTree = (tree) => {
   };
 };
 
+// True when a (possibly restored) tree must be run through normalizeToFlatTree
+// before the flat Tag builder can safely display it. Three cases:
+//   - it still contains nested groups (the flat UI can't render them),
+//   - it predates the excludeNoData flag (undefined reads as an unset default),
+//   - it carries duplicate field rows within a Tag — a search saved by the flat
+//     builder AFTER excludeNoData landed but BEFORE the one-row-per-field
+//     invariant. Those trees are all-leaf with excludeNoData defined, so the first
+//     two checks miss them; without this the duplicates survive and Add-field can
+//     be disabled while field types remain unused (SCRUM-6333).
+// Idempotent with normalizeToFlatTree: a normalized tree returns false, so the
+// builder's one-shot seeding effect can't loop.
+export const needsFlatNormalization = (tree) => {
+  if (!tree) return false;
+  const children = tree.children || [];
+  if (children.some((c) => !isLeaf(c))) return true;
+  if (tree.excludeNoData === undefined) return true;
+  return children.some((c) => {
+    const fieldKeys = (c.fields || []).map((f) => f && f.field).filter(Boolean);
+    return new Set(fieldKeys).size !== fieldKeys.length;
+  });
+};
+
 // Split a free-text value into a trimmed, de-duplicated, non-empty list.
 const splitValues = (value) => {
   if (Array.isArray(value)) return value.map((v) => String(v).trim()).filter(Boolean);

--- a/src/components/search/advanced/advancedQueryModel.js
+++ b/src/components/search/advanced/advancedQueryModel.js
@@ -155,6 +155,35 @@ export const createEmptyTree = () => ({
 
 export const isLeaf = (node) => !!node && node.type === 'tet';
 
+// Collapse duplicate field rows within a leaf so the one-row-per-field invariant
+// the flat Tag builder relies on holds for restored queries too. A query saved
+// before that invariant (or a nested tree) can carry the same field twice; the
+// builder would then render two rows of the same type, and Add-field could be
+// disabled while types remain unused. Later duplicates merge their chip values
+// into the first row (values on one field are OR, so nothing is lost); range
+// fields keep the first row's min/max. First-occurrence order is preserved.
+const dedupeLeafFields = (leaf) => {
+  if (!leaf || !Array.isArray(leaf.fields)) return leaf;
+  const byField = new Map();
+  leaf.fields.forEach((row) => {
+    if (!row || !row.field) return;
+    const existing = byField.get(row.field);
+    if (!existing) {
+      byField.set(row.field, { ...row });
+      return;
+    }
+    const valueKey = (v) => (v && typeof v === 'object' ? v.value : v);
+    const seen = new Set((existing.values || []).map(valueKey));
+    const merged = [...(existing.values || [])];
+    (row.values || []).forEach((v) => {
+      const k = valueKey(v);
+      if (k && !seen.has(k)) { seen.add(k); merged.push(v); }
+    });
+    existing.values = merged;
+  });
+  return { ...leaf, fields: Array.from(byField.values()) };
+};
+
 // Collect every leaf in a (possibly nested) tree into a flat { operator, children:[leaf] }
 // so the Tag-card builder can display a legacy/nested saved query without crashing.
 // Best-effort: intermediate group operators are dropped (the flat UI can't show them).
@@ -171,7 +200,7 @@ export const normalizeToFlatTree = (tree) => {
     operator: String(tree.operator || 'AND').toUpperCase() === 'OR' ? 'OR' : 'AND',
     // Preserve an explicit excludeNoData; default it off for trees that predate the flag.
     excludeNoData: tree.excludeNoData === true,
-    children: leaves.length > 0 ? leaves : [createLeaf()],
+    children: leaves.length > 0 ? leaves.map(dedupeLeafFields) : [createLeaf()],
   };
 };
 


### PR DESCRIPTION
Fix code so a tag can carry each field at most once (a tag can't be topic=A AND topic=B), so disable already-used field types in each row's dropdown, default new rows to the first unused type, and disable "Add field" once every type is present. This keeps the interface and compiled query in agreement.