### PR TITLE
feat(scrum-6330): align topic grid column names and values with the rest of the UI

### DIFF
--- a/src/components/refs_tet_validation/TetValidationGrid.css
+++ b/src/components/refs_tet_validation/TetValidationGrid.css
@@ -353,6 +353,25 @@
   color: #475467;
   font-weight: 600;
 }
+/* Nested group inside a topic group: the "Data assessment by other sources"
+   band that spans the source label, its Y/N/{N}E tag and the optional
+   confidence / note columns. Toned between the topic-name band above it and
+   the leaf sub-headers below so the three levels stay distinguishable. */
+.ag-header-group-cell.tetv-topic-subgroup-header {
+  background: #eef3f7;
+  font-size: var(--tetv-secondary-font-size);
+  font-weight: 700;
+  color: #3d5566;
+  border-right: 1px solid #d0dce7;
+  border-bottom: 1px solid #dbe4ec;
+}
+/* The biocurator column has no nested group above it, so AgGrid renders an
+   empty group cell in that row. Keep it blank rather than showing a stray
+   band of the sub-group tone. */
+.tetv-grid-wrapper .ag-header-group-cell-no-group {
+  background: #f8fafc;
+  border-right: 1px solid #d0dce7;
+}
 /* Alternating row tones for readability. Each paper is separated by a
    prominent slate-grey divider so curators clearly see where one paper ends
    and the next begins. */
@@ -383,6 +402,9 @@
   font-size: 1rem;
   font-weight: 700;
   padding: 7px 14px;
+  /* Y and N are single characters — keep both pills the same size so a column
+     of assessments reads as one consistent shape. */
+  min-width: 2.75rem;
   border-radius: 999px;
   text-align: center;
   white-space: normal;

--- a/src/components/refs_tet_validation/TetValidationGrid.jsx
+++ b/src/components/refs_tet_validation/TetValidationGrid.jsx
@@ -17,6 +17,7 @@ import {
   groupTetsByTopicAndSource,
   sourceLabel,
   normalizeCurie,
+  VALIDATION_STATE_LABELS,
 } from './helpers/groupTets';
 import IdsCell from './cellRenderers/IdsCell';
 import TitleCell from './cellRenderers/TitleCell';
@@ -62,12 +63,18 @@ const EMPTY_CELL_FILTER_FLAGS = Object.freeze({
 });
 
 const INNER_COLUMN_FILTER_LABELS = {
-  [INNER_COLUMN_TYPES.VALIDATION]: 'Assessment status',
+  [INNER_COLUMN_TYPES.VALIDATION]: 'Data assessment by biocurator',
   [INNER_COLUMN_TYPES.TAG]: 'Data',
   [INNER_COLUMN_TYPES.SOURCES]: 'Sources',
   [INNER_COLUMN_TYPES.CONF_SCORE]: 'Confidence score',
   [INNER_COLUMN_TYPES.CONF_LEVEL]: 'Confidence level',
   [INNER_COLUMN_TYPES.NOTE]: 'Note',
+};
+
+// Display labels for filter checkboxes whose raw values are internal keys. The
+// filter model keeps the raw values so saved models stay valid (SCRUM-6330).
+const INNER_COLUMN_FILTER_VALUE_LABELS = {
+  [INNER_COLUMN_TYPES.VALIDATION]: VALIDATION_STATE_LABELS,
 };
 
 function modelsEqual(a, b) {
@@ -1372,11 +1379,17 @@ export default function TetValidationGrid({
           minWidth,
           maxWidth,
           autoHeight: true,
+          // Sub-header labels are full phrases ("Data assessment by
+          // biocurator"), so let them wrap over the column width instead of
+          // being clipped, and grow the sub-header row to fit the tallest one.
+          wrapHeaderText: true,
+          autoHeaderHeight: true,
           sortable: true,
           filter: InnerValueFilter,
           filterParams: {
             availableValues: innerFilterOptions[kind] || [],
             filterLabel: INNER_COLUMN_FILTER_LABELS[kind],
+            valueLabels: INNER_COLUMN_FILTER_VALUE_LABELS[kind],
             innerFieldType: kind,
             sourceFilterModel,
           },
@@ -1392,31 +1405,37 @@ export default function TetValidationGrid({
           headerClass: 'tetv-topic-subheader',
           cellRendererParams,
         });
-        const children = [
-          makeInnerColumn({
-            headerName: 'Assessment by Biocurator',
-            headerTooltip:
-              'Assessment by Biocurator. When at least one curator has submitted a topic-level tag, the cell shows the assessment status (positive / negative / assessment conflict). Otherwise, ✓ and ✗ buttons let the curator submit one.',
-            colId: `${t.curie}__val`,
-            kind: INNER_COLUMN_TYPES.VALIDATION,
-            width: 90,
-            minWidth: 80,
-            wrapHeaderText: true,
-            autoHeaderHeight: true,
-            cellRenderer: ValidationCell,
-            cellClass: leftmostClass,
-            cellRendererParams: {
-              topicCurie: t.curie,
-              topicName: t.name || t.curie,
-              onValidated: handleValidated,
-              curationStatusOptions,
-              curationTagOptions,
-            },
-          }),
+        // The biocurator assessment stands alone; every other sub-column is
+        // driven by `buildEntries`, which excludes curator-submitted tags, so
+        // they all describe the same thing — what the non-biocurator sources
+        // said — and sit under one sub-group header (SCRUM-6330).
+        const validationChild = makeInnerColumn({
+          headerName: 'Data assessment by biocurator',
+          headerTooltip:
+            'Data assessment by biocurator. When at least one curator has submitted a topic-level tag, the cell shows the assessment: Y (data present for this topic), N (no data), or "conflict" when curators disagree. Otherwise, ✓ and ✗ buttons let the curator submit one. Y / N here mean the same thing as under "Data assessment by other sources" and as the has_data facet in advanced search.',
+          colId: `${t.curie}__val`,
+          kind: INNER_COLUMN_TYPES.VALIDATION,
+          width: 90,
+          minWidth: 80,
+          // Cap the autosize: the Y / N / conflict pill and the wrapped
+          // curator names are narrow, so without this each topic group would
+          // widen just to fit the header phrase on one line.
+          maxWidth: 150,
+          cellRenderer: ValidationCell,
+          cellClass: leftmostClass,
+          cellRendererParams: {
+            topicCurie: t.curie,
+            topicName: t.name || t.curie,
+            onValidated: handleValidated,
+            curationStatusOptions,
+            curationTagOptions,
+          },
+        });
+        const otherSourceChildren = [
           makeInnerColumn({
             headerName: 'Sources',
             headerTooltip:
-              'Source pipelines that produced TET tags for this topic on this reference (e.g. textpresso, manual, abc_entity_extractor). The cell only lists the source labels — the actual Y / N / {N}E breakdown is shown in the adjacent Tag column.',
+              'Source pipelines that produced TET tags for this topic on this reference (e.g. textpresso, manual, abc_entity_extractor). The cell only lists the source labels — each one\'s Y / N / {N}E assessment is on the matching row of the adjacent Data column.',
             colId: t.curie,
             kind: INNER_COLUMN_TYPES.SOURCES,
             width: 180,
@@ -1429,7 +1448,7 @@ export default function TetValidationGrid({
           makeInnerColumn({
             headerName: 'Data',
             headerTooltip:
-              'Per-source TET data pills for this topic. Y (green) = topic-level positive tag; N (red) = topic-level negated tag; "{N}E" (violet) = an entity-level extraction with N entities (click the badge to see the full list of entities). Each row aligns with the matching source label in the Sources column to its left.',
+              'Per-source TET data pills for this topic. Y (green) = topic-level tag, data present; N (red) = topic-level negated tag, no data; "{N}E" (violet) = an entity-level extraction with N entities (click the badge to see the full list of entities). Each row aligns with the matching source label in the Sources column to its left.',
             colId: `${t.curie}__tag`,
             kind: INNER_COLUMN_TYPES.TAG,
             width: 58,
@@ -1442,7 +1461,7 @@ export default function TetValidationGrid({
           }),
         ];
         if (displayOptions.showScore) {
-          children.push(makeInnerColumn({
+          otherSourceChildren.push(makeInnerColumn({
             headerName: 'conf sc',
             headerTooltip:
               'Confidence score (0.00 – 1.00) of the TET tag, when reported by the source pipeline. For entity-level buckets, the cell shows the min – max range across that bucket.',
@@ -1455,7 +1474,7 @@ export default function TetValidationGrid({
           }));
         }
         if (displayOptions.showLevel) {
-          children.push(makeInnerColumn({
+          otherSourceChildren.push(makeInnerColumn({
             headerName: 'conf lvl',
             headerTooltip:
               'Confidence level label (e.g. high / medium / low) of the TET tag, when reported by the source pipeline. For entity-level buckets, the cell shows the count of distinct levels if they vary.',
@@ -1467,7 +1486,7 @@ export default function TetValidationGrid({
             cellRendererParams: { sourceFilterModel },
           }));
         }
-        children.push(makeInnerColumn({
+        otherSourceChildren.push(makeInnerColumn({
           headerName: 'note',
           headerTooltip:
             'Free-text notes attached to TET tags. Click the 📝 icon for the full note in a modal; toggle "Expand notes" in the toolbar to render note text inline.',
@@ -1481,12 +1500,27 @@ export default function TetValidationGrid({
             sourceFilterModel,
           },
         }));
+        const children = [
+          validationChild,
+          {
+            headerName: 'Data assessment by other sources',
+            headerGroupComponent: HeaderGroupWithHelp,
+            headerTooltip:
+              'Data assessment by the non-biocurator sources that produced TET tags for this topic on this reference (e.g. textpresso, abc_entity_extractor). Each sub-column iterates the same per-source rows in lockstep: the source label, its Y / N / {N}E assessment, and — when toggled on in the toolbar — its confidence and notes.',
+            groupId: `tg-${t.curie}-other`,
+            marryChildren: true,
+            wrapHeaderText: true,
+            autoHeaderHeight: true,
+            headerClass: 'tetv-topic-subgroup-header',
+            children: otherSourceChildren,
+          },
+        ];
         return {
           headerName: t.name || t.curie,
           headerGroupComponent: HeaderGroupWithHelp,
           headerTooltip:
             `Topic "${t.name || t.curie}" (${t.curie}) — a topic from the MOD's ATP subset. ` +
-            'Sub-columns show the assessment status, per-source TET data, a compact tag summary, and (optionally) confidence and notes for this topic on each reference.',
+            'Sub-columns split into the data assessment by biocurator and the data assessment by other sources (source label, Y / N / {N}E tag, and optionally confidence and notes) for this topic on each reference.',
           groupId: `tg-${t.curie}`,
           marryChildren: true,
           // Allow long topic names to wrap inside the group header instead of

--- a/src/components/refs_tet_validation/cellRenderers/ValidationCell.jsx
+++ b/src/components/refs_tet_validation/cellRenderers/ValidationCell.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import CellValidationStrip from './CellValidationStrip';
-import { isCuratorValidationTet } from '../helpers/groupTets';
+import {
+  VALIDATION_STATE_LABELS,
+  isCuratorValidationTet,
+} from '../helpers/groupTets';
 import { speciesBadgeLetter, speciesName } from '../helpers/speciesUtils';
 
 /** TETs from this cell that are *topic-level* and authored by a professional
@@ -148,10 +151,10 @@ export default function ValidationCell(params) {
 
     let label, cls, tooltip, attribution;
     if (positives > 0 && negatives > 0) {
-      label = 'assessment conflict';
+      label = VALIDATION_STATE_LABELS.conflict;
       cls = 'tetv-validation-status tetv-validated-conflict';
       tooltip =
-        `${positives} positive + ${negatives} negative professional ` +
+        `${positives} Y + ${negatives} N professional ` +
         `biocurator topic tag(s) on this cell`;
       attribution = (
         <div className="tetv-validation-by-list">
@@ -163,7 +166,11 @@ export default function ValidationCell(params) {
                     ? 'tetv-validation-by-neg'
                     : 'tetv-validation-by-pos'
                 }`}
-                title={p.negated ? 'voted negative' : 'voted positive'}
+                title={
+                  p.negated
+                    ? 'assessed N (no data for this topic)'
+                    : 'assessed Y (data present for this topic)'
+                }
               >
                 {p.negated ? 'N' : 'Y'}
               </span>{' '}
@@ -180,13 +187,15 @@ export default function ValidationCell(params) {
       );
     } else if (positives > 0 || negatives > 0) {
       const isPositive = positives > 0;
-      label = isPositive ? 'positive' : 'negative';
+      label = isPositive
+        ? VALIDATION_STATE_LABELS.positive
+        : VALIDATION_STATE_LABELS.negative;
       cls = isPositive
         ? 'tetv-validation-status tetv-validated-pos'
         : 'tetv-validation-status tetv-validated-neg';
       tooltip = isPositive
-        ? `${positives} positive professional biocurator topic tag(s)`
-        : `${negatives} negative professional biocurator topic tag(s)`;
+        ? `Y (data present) — ${positives} professional biocurator topic tag(s)`
+        : `N (no data) — ${negatives} professional biocurator topic tag(s)`;
       attribution =
         uniquePairs.length > 0 ? (
           <div className="tetv-validation-by-list">

--- a/src/components/refs_tet_validation/cellRenderers/__tests__/ValidationCell.test.js
+++ b/src/components/refs_tet_validation/cellRenderers/__tests__/ValidationCell.test.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ValidationCell from '../ValidationCell';
+import {
+  VALIDATION_FILTER_KEYS,
+  VALIDATION_STATE_LABELS,
+} from '../../helpers/groupTets';
+
+// The cell only needs the species lookup from the store.
+jest.mock('react-redux', () => ({
+  useSelector: (selector) => selector({ biblio: { curieToNameTaxon: {} } }),
+}));
+// Rendered only on the "no curator assessment yet" path; not under test here.
+jest.mock('../CellValidationStrip', () => () => <div data-testid="strip" />);
+
+const cellWith = (validation) => ({
+  value: { tets: [], validation },
+  colDef: { cellRendererParams: { topicCurie: 'ATP:0001' } },
+  data: { curie: 'AGRKB:101' },
+});
+
+// SCRUM-6330: the biocurator assessment is the same yes/no judgement as the
+// "Data" pills and the has_data advanced-search facet, so it must read Y / N
+// rather than positive / negative.
+describe('ValidationCell assessment labels (SCRUM-6330)', () => {
+  test('renders Y for a positive curator assessment', () => {
+    render(
+      <ValidationCell
+        {...cellWith({
+          state: 'positive',
+          positives: 1,
+          negatives: 0,
+          by_curator: [{ name: 'curator_a', negated: false }],
+        })}
+      />
+    );
+    expect(screen.getByText('Y')).toBeInTheDocument();
+    expect(screen.queryByText('positive')).not.toBeInTheDocument();
+  });
+
+  test('renders N for a negative curator assessment', () => {
+    render(
+      <ValidationCell
+        {...cellWith({
+          state: 'negative',
+          positives: 0,
+          negatives: 2,
+          by_curator: [{ name: 'curator_b', negated: true }],
+        })}
+      />
+    );
+    expect(screen.getByText('N')).toBeInTheDocument();
+    expect(screen.queryByText('negative')).not.toBeInTheDocument();
+  });
+
+  test('renders "conflict" when curators disagree, with a Y/N mark per curator', () => {
+    render(
+      <ValidationCell
+        {...cellWith({
+          state: 'conflict',
+          positives: 1,
+          negatives: 1,
+          by_curator: [
+            { name: 'curator_a', negated: false },
+            { name: 'curator_b', negated: true },
+          ],
+        })}
+      />
+    );
+    expect(screen.getByText('conflict')).toBeInTheDocument();
+    expect(screen.queryByText('assessment conflict')).not.toBeInTheDocument();
+    expect(screen.getByText('Y')).toBeInTheDocument();
+    expect(screen.getByText('N')).toBeInTheDocument();
+  });
+
+  test('falls back to the validation strip when no curator has assessed', () => {
+    render(<ValidationCell {...cellWith(null)} />);
+    expect(screen.getByTestId('strip')).toBeInTheDocument();
+  });
+});
+
+// The labels are display-only: the underlying keys are the server's
+// `validation.state` values and are persisted in saved AgGrid filter models,
+// so renaming them would silently invalidate both.
+describe('validation state keys are unchanged by the relabel (SCRUM-6330)', () => {
+  test('filter keys keep their raw server values', () => {
+    expect(VALIDATION_FILTER_KEYS).toEqual([
+      'unvalidated',
+      'positive',
+      'negative',
+      'conflict',
+    ]);
+  });
+
+  test('every filter key has a display label', () => {
+    VALIDATION_FILTER_KEYS.forEach((key) => {
+      expect(VALIDATION_STATE_LABELS[key]).toBeTruthy();
+    });
+    expect(VALIDATION_STATE_LABELS.positive).toBe('Y');
+    expect(VALIDATION_STATE_LABELS.negative).toBe('N');
+  });
+});

--- a/src/components/refs_tet_validation/filters/InnerValueFilter.jsx
+++ b/src/components/refs_tet_validation/filters/InnerValueFilter.jsx
@@ -7,6 +7,9 @@ const InnerValueFilter = ({
   onModelChange,
   availableValues = [],
   filterLabel = 'Filter',
+  // Display-only map raw filter value -> label. The checkbox values (and hence
+  // the persisted filter model) stay the raw values.
+  valueLabels,
   innerFieldType,
   sourceFilterModel,
   colDef,
@@ -98,7 +101,10 @@ const InnerValueFilter = ({
               checked={effectiveSelected.has(value)}
               onChange={(e) => onChange(value, e.target.checked)}
             />
-            <label htmlFor={`ivf-${innerFieldType}-${value}`}> {value}</label>
+            <label htmlFor={`ivf-${innerFieldType}-${value}`}>
+              {' '}
+              {valueLabels?.[value] || value}
+            </label>
           </div>
         ))}
       </div>

--- a/src/components/refs_tet_validation/filters/ValidationFilter.jsx
+++ b/src/components/refs_tet_validation/filters/ValidationFilter.jsx
@@ -3,13 +3,8 @@ import { useGridFilter } from 'ag-grid-react';
 import {
   VALIDATION_FILTER_KEYS,
   validationState,
+  validationStateLabel,
 } from '../helpers/groupTets';
-
-// Display labels for the (persisted) filter-model keys — the keys themselves
-// stay unchanged so saved filter models keep working (SCRUM-6291).
-const FILTER_KEY_LABELS = {
-  unvalidated: 'unassessed',
-};
 
 const ValidationFilter = ({ model: rawModel, onModelChange }) => {
   const model = Array.isArray(rawModel) ? rawModel : null;
@@ -47,7 +42,7 @@ const ValidationFilter = ({ model: rawModel, onModelChange }) => {
 
   return (
     <div className="custom-filter">
-      <div>Assessment status</div>
+      <div>Data assessment by biocurator</div>
       <hr />
       {VALIDATION_FILTER_KEYS.map((k) => (
         <div key={k}>
@@ -57,7 +52,7 @@ const ValidationFilter = ({ model: rawModel, onModelChange }) => {
             checked={!!(unappliedModel && unappliedModel.includes(k))}
             onChange={(e) => onChange(k, e.target.checked)}
           />
-          <label htmlFor={`vf-${k}`}> {FILTER_KEY_LABELS[k] || k}</label>
+          <label htmlFor={`vf-${k}`}> {validationStateLabel(k)}</label>
         </div>
       ))}
       <hr />

--- a/src/components/refs_tet_validation/helpers/groupTets.js
+++ b/src/components/refs_tet_validation/helpers/groupTets.js
@@ -101,6 +101,24 @@ export const VALIDATION_FILTER_KEYS = [
   'conflict',
 ];
 
+/** Display labels for the validation states above. The keys are the server's
+ *  aggregate `validation.state` values and are also what gets persisted in
+ *  saved AgGrid filter models, so they must not change — only the UI wording
+ *  does. Y / N mirror the "Data" column pills and the `has_data` advanced-search
+ *  facet, so a biocurator assessment reads the same way everywhere (SCRUM-6330). */
+export const VALIDATION_STATE_LABELS = Object.freeze({
+  unvalidated: 'unassessed',
+  positive: 'Y',
+  negative: 'N',
+  conflict: 'conflict',
+});
+
+/** Human label for a validation state, falling back to the raw key so an
+ *  unrecognized server state still renders something. */
+export function validationStateLabel(state) {
+  return VALIDATION_STATE_LABELS[state] || state;
+}
+
 /** Stable numeric ordering for AgGrid sort: unvalidated < conflict <
  *  negative < positive. Curators can flip via shift-click for descending. */
 export function validationSortRank(tets) {


### PR DESCRIPTION
## Summary

Closes [SCRUM-6330](https://agr-jira.atlassian.net/browse/SCRUM-6330).

The Topic grid's "Assessment by Biocurator" column is derived from the same manual-assessment ECO code as the "data" / `has_data` column, but rendered its values as `positive` / `negative` while that column — and the advanced topic & entity search facets now built on it — uses Y/N. Nothing in the UI told curators the two were the same thing.

Per the ticket's decisions:

| Where | Before | After |
|---|---|---|
| Column header | `Assessment by Biocurator` | `Data assessment by biocurator` |
| Cell badge | `positive` / `negative` | `Y` / `N` |
| Cell badge | `assessment conflict` | `conflict` |
| Filter checkboxes | `unvalidated` / `positive` / `negative` | `unassessed` / `Y` / `N` |
| Filter popup title | `Assessment status` | `Data assessment by biocurator` |

The source-side columns are now collected under one nested group header rather than renaming a single column:

```
┌──────────────────────────────────────────────────────────────────┐
│                        Topic name (ATP:…)                        │
├──────────────┬───────────────────────────────────────────────────┤
│              │        Data assessment by other sources           │
│              ├─────────┬──────┬─────────┬──────────┬─────────────┤
│ Data         │ Sources │ Data │ conf sc │ conf lvl │ note        │
│ assessment   ├─────────┼──────┼─────────┼──────────┼─────────────┤
│ by biocurator│textpresso│  Y  │  0.91   │   high   │     📝      │
│    [ Y ]     │ abc_ent… │ {3}E │ .40–.88 │    2     │             │
└──────────────┴─────────┴──────┴─────────┴──────────┴─────────────┘
```

All five entry-driven columns went under the group, not just Sources and Data: `buildEntries` skips curator-submitted tags outright (`helpers/buildEntries.js:112`), so every one of them describes exclusively non-biocurator sources and they iterate the same per-source rows in lockstep. Only the biocurator column sits outside. `Sources` and its tooltip therefore revert to their original wording — the group header carries the phrase now.

Header tooltips were rewritten to state that Y/N here mean the same as the `has_data` facet in advanced search.

## Labels are display-only

`positive` / `negative` / `conflict` are the server's `validation.state` aggregate values **and** what gets persisted in saved AgGrid filter models. Renaming them would silently invalidate both, so the keys are untouched and the wording comes from a `VALIDATION_STATE_LABELS` map in `helpers/groupTets.js`, threaded into the filter through a new display-only `valueLabels` param. A test pins that invariant.

Side effect worth flagging: `unvalidated` now displays as `unassessed` in the live filter. That wording already existed in the unused `ValidationFilter.jsx`, which now reads from the shared map so the two filters can't drift.

## Layout fixes the longer headers forced

- `makeInnerColumn` was silently dropping the `wrapHeaderText` / `autoHeaderHeight` flags the validation column already passed — harmless with short labels, but a 32-character header would have been clipped. Now forwarded for all inner columns.
- AgGrid's autosize measures headers unwrapped on a single line, so the validation column is capped at `maxWidth: 150`; without it every topic group would widen ~35px just to fit the header phrase.
- New `.tetv-topic-subgroup-header` tone for the nested band, plus a rule for `ag-header-group-cell-no-group` (AgGrid's filler cell above the biocurator column) so it stays blank instead of showing a stray band.

Leaf `colId`s are all unchanged, so `allowedInnerColumnIds`, the filter/sort pruning on topic visibility changes, the autosize `__`-suffix heuristic, and the sticky scrollbar's header-height `ResizeObserver` are unaffected by the regrouping.

## Test plan

- `npx eslint` clean on all changed files.
- `CI=true npx react-app-rewired test` — 176 tests pass across 16 suites, including 6 new `ValidationCell` tests covering Y, N, conflict, the unassessed-strip fallback, and the filter-key invariant.
- `src/App.test.js` still fails on a pre-existing d3 import error in `WorkflowDiagram`, confirmed identical on unmodified `main`.
- **Not verified:** no suite renders the grid's column definitions, and the rendered three-row header has not been looked at in a browser. The header height, the wrapped `Data assessment by biocurator` label at its 150px cap, and the blank filler cell above it are worth a visual check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SCRUM-6330]: https://agr-jira.atlassian.net/browse/SCRUM-6330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
